### PR TITLE
feat: Add create-draft-email endpoint

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -30,6 +30,12 @@
     "scopes": ["Mail.Send"]
   },
   {
+    "pathPattern": "/me/messages",
+    "method": "post",
+    "toolName": "create-draft-email",
+    "scopes": ["Mail.ReadWrite"]
+  },
+  {
     "pathPattern": "/me/messages/{message-id}",
     "method": "delete",
     "toolName": "delete-mail-message",


### PR DESCRIPTION
## Summary
- Adds support for creating draft emails using the Microsoft Graph API
- Implements the `create-draft-email` tool that uses POST /me/messages endpoint
- Enables users to create draft emails that are saved to the Drafts folder without sending immediately

## Changes
- Added new endpoint configuration in `src/endpoints.json`:
  - Path: `/me/messages`
  - Method: `post`
  - Tool name: `create-draft-email`
  - Required scope: `Mail.ReadWrite`

## Testing
The endpoint follows the same pattern as other mail endpoints in the project and will be dynamically registered by the graph-tools.ts module.

## Use Case
This feature addresses the need to create draft emails programmatically, which is useful for:
- Preparing emails for later review and sending
- Batch email preparation
- Email templates that need manual review before sending

Fixes the limitation where only `send-mail` was available, forcing immediate email sending.