### PR TITLE
Add Multi-Account Support with Device Flow and Account Switching Tools

### DIFF
--- a/src/auth-tools.ts
+++ b/src/auth-tools.ts
@@ -86,4 +86,115 @@ export function registerAuthTools(server: McpServer, authManager: AuthManager): 
       ],
     };
   });
+
+  server.tool('list-accounts', {}, async () => {
+    try {
+      const accounts = await authManager.listAccounts();
+      const selectedAccountId = authManager.getSelectedAccountId();
+      const result = accounts.map(account => ({
+        id: account.homeAccountId,
+        username: account.username,
+        name: account.name,
+        selected: account.homeAccountId === selectedAccountId
+      }));
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ accounts: result }),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ error: `Failed to list accounts: ${(error as Error).message}` }),
+          },
+        ],
+      };
+    }
+  });
+
+  server.tool(
+    'select-account',
+    {
+      accountId: z.string().describe('The account ID to select'),
+    },
+    async ({ accountId }) => {
+      try {
+        const success = await authManager.selectAccount(accountId);
+        if (success) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({ message: `Selected account: ${accountId}` }),
+              },
+            ],
+          };
+        } else {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({ error: `Account not found: ${accountId}` }),
+              },
+            ],
+          };
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ error: `Failed to select account: ${(error as Error).message}` }),
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.tool(
+    'remove-account',
+    {
+      accountId: z.string().describe('The account ID to remove'),
+    },
+    async ({ accountId }) => {
+      try {
+        const success = await authManager.removeAccount(accountId);
+        if (success) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({ message: `Removed account: ${accountId}` }),
+              },
+            ],
+          };
+        } else {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({ error: `Account not found: ${accountId}` }),
+              },
+            ],
+          };
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ error: `Failed to remove account: ${(error as Error).message}` }),
+            },
+          ],
+        };
+      }
+    }
+  );
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,9 @@ program
   .option('--login', 'Login using device code flow')
   .option('--logout', 'Log out and clear saved credentials')
   .option('--verify-login', 'Verify login without starting the server')
+  .option('--list-accounts', 'List all cached accounts')
+  .option('--select-account <accountId>', 'Select a specific account by ID')
+  .option('--remove-account <accountId>', 'Remove a specific account by ID')
   .option('--read-only', 'Start server in read-only mode, disabling write operations')
   .option(
     '--http [port]',
@@ -41,6 +44,9 @@ export interface CommandOptions {
   login?: boolean;
   logout?: boolean;
   verifyLogin?: boolean;
+  listAccounts?: boolean;
+  selectAccount?: string;
+  removeAccount?: string;
   readOnly?: boolean;
   http?: string | boolean;
   enableAuthTools?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,41 @@ async function main(): Promise<void> {
       process.exit(0);
     }
 
+    if (args.listAccounts) {
+      const accounts = await authManager.listAccounts();
+      const selectedAccountId = authManager.getSelectedAccountId();
+      const result = accounts.map(account => ({
+        id: account.homeAccountId,
+        username: account.username,
+        name: account.name,
+        selected: account.homeAccountId === selectedAccountId
+      }));
+      console.log(JSON.stringify({ accounts: result }));
+      process.exit(0);
+    }
+
+    if (args.selectAccount) {
+      const success = await authManager.selectAccount(args.selectAccount);
+      if (success) {
+        console.log(JSON.stringify({ message: `Selected account: ${args.selectAccount}` }));
+      } else {
+        console.log(JSON.stringify({ error: `Account not found: ${args.selectAccount}` }));
+        process.exit(1);
+      }
+      process.exit(0);
+    }
+
+    if (args.removeAccount) {
+      const success = await authManager.removeAccount(args.removeAccount);
+      if (success) {
+        console.log(JSON.stringify({ message: `Removed account: ${args.removeAccount}` }));
+      } else {
+        console.log(JSON.stringify({ error: `Account not found: ${args.removeAccount}` }));
+        process.exit(1);
+      }
+      process.exit(0);
+    }
+
     const server = new MicrosoftGraphServer(authManager, args);
     await server.initialize(version);
     await server.start();


### PR DESCRIPTION
This PR introduces support for multiple Microsoft 365 accounts, addressing #78 . Users frequently work across multiple tenants—personal, work, or partner organizations—and this update enables seamless switching and isolation between accounts while maintaining backward compatibility with single-account workflows.s

**Features:**
- **Device Flow Authentication for Multiple Accounts**
Enables secure authentication and session persistence for multiple tenants.

- New commands:
   - `list-accounts`: View all configured accounts
   - `select-account`: Set the active account context
   - `remove-account`: Remove a stored account

- **Session Isolation**
Each account operates in a separate context with token/session separation.

- **MCP Integration**
Account context is preserved across MCP commands for reliable multitenant workflows.
