### PR TITLE
fix(auth): Handle MSAL device code flow timeout

### DIFF
--- a/src/auth-tools.ts
+++ b/src/auth-tools.ts
@@ -27,8 +27,8 @@ export function registerAuthTools(server: McpServer, authManager: AuthManager): 
           }
         }
 
-        const text = await new Promise<string>((r) => {
-          authManager.acquireTokenByDeviceCode(r);
+        const text = await new Promise<string>((resolve, reject) => {
+          authManager.acquireTokenByDeviceCode(resolve).catch(reject);
         });
         return {
           content: [


### PR DESCRIPTION
Hi,

If a user failed to complete the sign-in process within the Microsoft timeout, MSAL would correctly throw an error. However, this leads to an unhandled promise rejection, which terminates the entire server process (impacting UX and availability):
```js
file:///tools/microsoft365/ms-365-mcp-server/node_modules/@azure/msal-common/dist/error/ClientAuthError.mjs:255
    return new ClientAuthError(errorCode, additionalMessage);
           ^

ClientAuthError: device_code_expired: Device code is expired.
    at createClientAuthError (file:///tools/microsoft365/ms-365-mcp-server/node_modules/@azure/msal-common/dist/error/ClientAuthError.mjs:255:12)
    at DeviceCodeClient.continuePolling (file:///tools/microsoft365/ms-365-mcp-server/node_modules/@azure/msal-node/dist/client/DeviceCodeClient.mjs:127:19)
    at DeviceCodeClient.acquireTokenWithDeviceCode (file:///tools/microsoft365/ms-365-mcp-server/node_modules/@azure/msal-node/dist/client/DeviceCodeClient.mjs:150:21)
    at async DeviceCodeClient.acquireToken (file:///tools/microsoft365/ms-365-mcp-server/node_modules/@azure/msal-node/dist/client/DeviceCodeClient.mjs:26:26)
    at async PublicClientApplication.acquireTokenByDeviceCode (file:///tools/microsoft365/ms-365-mcp-server/node_modules/@azure/msal-node/dist/client/PublicClientApplication.mjs:71:20)
    at async AuthManager.acquireTokenByDeviceCode (file:///tools/microsoft365/ms-365-mcp-server/dist/auth.js:234:30) {
  errorCode: 'device_code_expired',
  errorMessage: 'Device code is expired.',
  subError: '',
  correlationId: '<uuid>'
}
```

We solve by explicitly handling the promise rejection.

Cheers, Oscar