### PR TITLE
Fix: Add quotes to file paths in execSync command

### DIFF
--- a/bin/modules/generate-mcp-tools.mjs
+++ b/bin/modules/generate-mcp-tools.mjs
@@ -17,7 +17,7 @@ export function generateMcpTools(openApiSpec, outputDir) {
 
     const clientFilePath = path.join(outputDir, 'client.ts');
     execSync(
-      `npx -y openapi-zod-client ${openapiTrimmedFile} -o ${clientFilePath} --with-description --strict-objects --additional-props-default-value=false`,
+      `npx -y openapi-zod-client "${openapiTrimmedFile}" -o "${clientFilePath}" --with-description --strict-objects --additional-props-default-value=false`,
       {
         stdio: 'inherit',
       }


### PR DESCRIPTION
This change adds quotes around file paths in the execSync command to handle paths containing spaces properly. Without quotes, paths with spaces would cause the command to fail as arguments would be split incorrectly.