### PR TITLE
feat: add GET method support for MCP Streamable HTTP endpoint

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -320,75 +320,89 @@ class MicrosoftGraphServer {
 
       // Microsoft Graph MCP endpoints with bearer token auth
       // Handle both GET and POST methods as required by MCP Streamable HTTP specification
-      app.get('/mcp', microsoftBearerTokenAuthMiddleware, async (req: Request & { microsoftAuth?: { accessToken: string; refreshToken: string } }, res: Response) => {
-        try {
-          // Set OAuth tokens in the GraphClient if available
-          if (req.microsoftAuth) {
-            this.graphClient.setOAuthTokens(
-              req.microsoftAuth.accessToken,
-              req.microsoftAuth.refreshToken
-            );
-          }
+      app.get(
+        '/mcp',
+        microsoftBearerTokenAuthMiddleware,
+        async (
+          req: Request & { microsoftAuth?: { accessToken: string; refreshToken: string } },
+          res: Response
+        ) => {
+          try {
+            // Set OAuth tokens in the GraphClient if available
+            if (req.microsoftAuth) {
+              this.graphClient.setOAuthTokens(
+                req.microsoftAuth.accessToken,
+                req.microsoftAuth.refreshToken
+              );
+            }
 
-          const transport = new StreamableHTTPServerTransport({
-            sessionIdGenerator: undefined, // Stateless mode
-          });
-
-          res.on('close', () => {
-            transport.close();
-          });
-
-          await this.server!.connect(transport);
-          await transport.handleRequest(req as any, res as any, undefined);
-        } catch (error) {
-          logger.error('Error handling MCP GET request:', error);
-          if (!res.headersSent) {
-            res.status(500).json({
-              jsonrpc: '2.0',
-              error: {
-                code: -32603,
-                message: 'Internal server error',
-              },
-              id: null,
+            const transport = new StreamableHTTPServerTransport({
+              sessionIdGenerator: undefined, // Stateless mode
             });
+
+            res.on('close', () => {
+              transport.close();
+            });
+
+            await this.server!.connect(transport);
+            await transport.handleRequest(req as any, res as any, undefined);
+          } catch (error) {
+            logger.error('Error handling MCP GET request:', error);
+            if (!res.headersSent) {
+              res.status(500).json({
+                jsonrpc: '2.0',
+                error: {
+                  code: -32603,
+                  message: 'Internal server error',
+                },
+                id: null,
+              });
+            }
           }
         }
-      });
+      );
 
-      app.post('/mcp', microsoftBearerTokenAuthMiddleware, async (req: Request & { microsoftAuth?: { accessToken: string; refreshToken: string } }, res: Response) => {
-        try {
-          // Set OAuth tokens in the GraphClient if available
-          if (req.microsoftAuth) {
-            this.graphClient.setOAuthTokens(
-              req.microsoftAuth.accessToken,
-              req.microsoftAuth.refreshToken
-            );
-          }
+      app.post(
+        '/mcp',
+        microsoftBearerTokenAuthMiddleware,
+        async (
+          req: Request & { microsoftAuth?: { accessToken: string; refreshToken: string } },
+          res: Response
+        ) => {
+          try {
+            // Set OAuth tokens in the GraphClient if available
+            if (req.microsoftAuth) {
+              this.graphClient.setOAuthTokens(
+                req.microsoftAuth.accessToken,
+                req.microsoftAuth.refreshToken
+              );
+            }
 
-          const transport = new StreamableHTTPServerTransport({
-            sessionIdGenerator: undefined, // Stateless mode
-          });
-
-          res.on('close', () => {
-            transport.close();
-          });
-
-          await this.server!.connect(transport);
-          await transport.handleRequest(req as any, res as any, req.body);
-        } catch (error) {
-          logger.error('Error handling MCP POST request:', error);
-          if (!res.headersSent) {
-            res.status(500).json({
-              jsonrpc: '2.0',
-              error: {
-                code: -32603,
-                message: 'Internal server error',
-              },
-              id: null,
+            const transport = new StreamableHTTPServerTransport({
+              sessionIdGenerator: undefined, // Stateless mode
             });
+
+            res.on('close', () => {
+              transport.close();
+            });
+
+            await this.server!.connect(transport);
+            await transport.handleRequest(req as any, res as any, req.body);
+          } catch (error) {
+            logger.error('Error handling MCP POST request:', error);
+            if (!res.headersSent) {
+              res.status(500).json({
+                jsonrpc: '2.0',
+                error: {
+                  code: -32603,
+                  message: 'Internal server error',
+                },
+                id: null,
+              });
+            }
           }
         }
-      });
+      );
 
       // Health check endpoint
       app.get('/', (req, res) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js';
-import express from 'express';
+import express, { Request, Response } from 'express';
 import crypto from 'crypto';
 import logger, { enableConsoleLogging } from './logger.js';
 import { registerAuthTools } from './auth-tools.js';
@@ -319,7 +319,8 @@ class MicrosoftGraphServer {
       );
 
       // Microsoft Graph MCP endpoints with bearer token auth
-      app.post('/mcp', microsoftBearerTokenAuthMiddleware, async (req: Request, res) => {
+      // Handle both GET and POST methods as required by MCP Streamable HTTP specification
+      app.get('/mcp', microsoftBearerTokenAuthMiddleware, async (req: Request & { microsoftAuth?: { accessToken: string; refreshToken: string } }, res: Response) => {
         try {
           // Set OAuth tokens in the GraphClient if available
           if (req.microsoftAuth) {
@@ -338,9 +339,44 @@ class MicrosoftGraphServer {
           });
 
           await this.server!.connect(transport);
-          await transport.handleRequest(req, res, req.body);
+          await transport.handleRequest(req as any, res as any, undefined);
         } catch (error) {
-          logger.error('Error handling MCP request:', error);
+          logger.error('Error handling MCP GET request:', error);
+          if (!res.headersSent) {
+            res.status(500).json({
+              jsonrpc: '2.0',
+              error: {
+                code: -32603,
+                message: 'Internal server error',
+              },
+              id: null,
+            });
+          }
+        }
+      });
+
+      app.post('/mcp', microsoftBearerTokenAuthMiddleware, async (req: Request & { microsoftAuth?: { accessToken: string; refreshToken: string } }, res: Response) => {
+        try {
+          // Set OAuth tokens in the GraphClient if available
+          if (req.microsoftAuth) {
+            this.graphClient.setOAuthTokens(
+              req.microsoftAuth.accessToken,
+              req.microsoftAuth.refreshToken
+            );
+          }
+
+          const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: undefined, // Stateless mode
+          });
+
+          res.on('close', () => {
+            transport.close();
+          });
+
+          await this.server!.connect(transport);
+          await transport.handleRequest(req as any, res as any, req.body);
+        } catch (error) {
+          logger.error('Error handling MCP POST request:', error);
           if (!res.headersSent) {
             res.status(500).json({
               jsonrpc: '2.0',


### PR DESCRIPTION
## Feature: MCP Streamable HTTP GET Support

### Summary
Implements GET method support for the /mcp endpoint to comply with the MCP Streamable HTTP specification (2025-03-26).

### Changes Made
- Added GET method handler for /mcp endpoint
- Both GET and POST methods now supported on single endpoint as required by MCP spec
- Maintained backward compatibility with existing POST functionality
- Used same authentication middleware
- GET requests handled with undefined body, POST requests with req.body
- All existing tests pass successfully (15/15)

### Technical Details
- Transport: Uses StreamableHTTPServerTransport in stateless mode
- Authentication: Same Bearer token authentication for both methods
- Error Handling: Consistent error responses for both GET and POST
- Session Management: Stateless mode

### Specification Compliance
According to the MCP Streamable HTTP specification, the server MUST provide a single HTTP endpoint path that supports both POST and GET methods. This implementation ensures full compliance.

### Testing
- All existing tests pass (5 test files, 15 tests)
- No breaking changes to existing functionality
- Server starts successfully and accepts both GET and POST requests

### Files Changed
- src/server.ts - Added GET method handler (+40 lines, -4 lines)

### References
- MCP Streamable HTTP Transport Specification (2025-03-26)
- Model Context Protocol Documentation