### PR TITLE
feat: Implement client credential authentication flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "generate": "node bin/generate-graph-client.mjs",
     "postinstall": "npm run generate",
     "build": "tsup",
+    "start": "node dist/index.js --http ${PORT-3000}",
     "test": "vitest run",
     "test:watch": "vitest",
     "dev": "tsx src/index.ts",

--- a/src/server.ts
+++ b/src/server.ts
@@ -177,7 +177,10 @@ class MicrosoftGraphServer {
       app.get('/authorize', async (req, res) => {
         const url = new URL(req.url!, `${req.protocol}://${req.get('host')}`);
         const tenantId = process.env.MS365_MCP_TENANT_ID || 'common';
-        const clientId = process.env.MS365_MCP_CLIENT_ID || '084a3e9f-a9f4-43f7-89f9-d229cf97853e';
+        const clientId = process.env.MS365_MCP_CLIENT_ID;
+        if (!clientId) {
+          throw new Error('MS365_MCP_CLIENT_ID environment variable is not set.');
+        }
         const microsoftAuthUrl = new URL(
           `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/authorize`
         );
@@ -252,11 +255,10 @@ class MicrosoftGraphServer {
 
           if (body.grant_type === 'authorization_code') {
             const tenantId = process.env.MS365_MCP_TENANT_ID || 'common';
-            const clientId =
-              process.env.MS365_MCP_CLIENT_ID || '084a3e9f-a9f4-43f7-89f9-d229cf97853e';
+            const clientId = process.env.MS365_MCP_CLIENT_ID;
             const clientSecret = process.env.MS365_MCP_CLIENT_SECRET;
 
-            if (!clientSecret) {
+            if (!clientId || !clientSecret) {
               logger.error('Token endpoint: MS365_MCP_CLIENT_SECRET is not configured');
               res.status(500).json({
                 error: 'server_error',
@@ -276,11 +278,10 @@ class MicrosoftGraphServer {
             res.json(result);
           } else if (body.grant_type === 'refresh_token') {
             const tenantId = process.env.MS365_MCP_TENANT_ID || 'common';
-            const clientId =
-              process.env.MS365_MCP_CLIENT_ID || '084a3e9f-a9f4-43f7-89f9-d229cf97853e';
+            const clientId = process.env.MS365_MCP_CLIENT_ID;
             const clientSecret = process.env.MS365_MCP_CLIENT_SECRET;
 
-            if (!clientSecret) {
+            if (!clientId || !clientSecret) {
               logger.error('Token endpoint: MS365_MCP_CLIENT_SECRET is not configured');
               res.status(500).json({
                 error: 'server_error',


### PR DESCRIPTION
This commit implements the client credential authentication flow to allow the server to authenticate non-interactively using a client ID and client secret.

Key changes:
- The `AuthManager` in `src/auth.ts` now detects the presence of the `MS365_MCP_CLIENT_SECRET` environment variable.
- When the secret is present, it uses `ConfidentialClientApplication` to acquire a token via the client credential flow. This bypasses the interactive device code flow.
- When the secret is not present, it retains the existing `PublicClientApplication` for interactive logins.
- Hardcoded fallback Client IDs have been removed from `src/server.ts` and `src/auth.ts` to ensure that only user-provided credentials are used.
- A `start` script has been added to `package.json` to standardize the production startup command for deployment platforms.