### PR TITLE
fix: update the parameter handling by adding auto-correction for nest…

### DIFF
--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -192,7 +192,25 @@ export function registerGraphTools(
                   break;
 
                 case 'Body':
-                  body = paramValue;
+                  if (paramDef.schema) {
+                    const parseResult = paramDef.schema.safeParse(paramValue);
+                    if (!parseResult.success) {
+                      const wrapped = { [paramName]: paramValue };
+                      const wrappedResult = paramDef.schema.safeParse(wrapped);
+                      if (wrappedResult.success) {
+                        logger.info(
+                          `Auto-corrected parameter '${paramName}': AI passed nested field directly, wrapped it as {${paramName}: ...}`
+                        );
+                        body = wrapped;
+                      } else {
+                        body = paramValue;
+                      }
+                    } else {
+                      body = paramValue;
+                    }
+                  } else {
+                    body = paramValue;
+                  }
                   break;
 
                 case 'Header':


### PR DESCRIPTION
…ed fields in request body

This is kind of a hack, as it doesn't actually fix the generated schema - BUT it _should_ work. My theory is that some agents might get confused with body in body, and this solves that problem.