### PR TITLE
fix: ensure retried requests go through full error handling and parsing

### DIFF
--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -54,7 +54,7 @@ class GraphClient {
     }
 
     try {
-      const response = await this.performRequest(endpoint, accessToken, options);
+      let response = await this.performRequest(endpoint, accessToken, options);
 
       if (response.status === 401 && refreshToken) {
         // Token expired, try to refresh
@@ -67,7 +67,7 @@ class GraphClient {
         }
 
         // Retry the request with new token
-        return this.performRequest(endpoint, accessToken, options);
+        response = await this.performRequest(endpoint, accessToken, options);
       }
 
       if (response.status === 403) {


### PR DESCRIPTION
When a 401 error occurs and the token is refreshed, the retry request was bypassing all error handling (403, 404, etc.) and JSON parsing by returning early. This fix ensures the retried response flows through the same error checking and parsing logic as the initial request.

Changes:
- Changed `response` from const to let to allow reassignment
- Changed retry logic to reassign response instead of returning early