### PR TITLE
fix: correct SharePoint file download endpoint path

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -198,7 +198,7 @@
     "scopes": ["Files.Read"]
   },
   {
-    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/children/{driveItem-id1}/content",
+    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/content",
     "method": "get",
     "toolName": "download-onedrive-file-content",
     "scopes": ["Files.Read"]


### PR DESCRIPTION
## Summary
Fixes #137 - `download-onedrive-file-content` was returning 404 errors for SharePoint files

## Root Cause
The endpoint path pattern in `src/endpoints.json` included an incorrect `/children/{driveItem-id1}` segment that doesn't match the Microsoft Graph API specification for downloading file content.

## Changes
Updated the path pattern in `src/endpoints.json` (line 201):
- **Before:** `/drives/{drive-id}/items/{driveItem-id}/children/{driveItem-id1}/content`
- **After:** `/drives/{drive-id}/items/{driveItem-id}/content`

## Test Plan
✅ Tested with SharePoint Internal site
✅ File downloads now succeed (previously returned 404)
✅ Built and verified with local MCP server

## Note
During testing, discovered that large file responses may exceed MCP token limits due to base64 encoding overhead. This is a separate issue from the 404 error and should be tracked separately if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)