### PR TITLE
Fixes and optimizations for server with oauth flow

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,7 @@ import logger, { enableConsoleLogging } from './logger.js';
 import { registerAuthTools } from './auth-tools.js';
 import { registerGraphTools } from './graph-tools.js';
 import GraphClient from './graph-client.js';
-import AuthManager from './auth.js';
+import AuthManager, { buildScopesFromEndpoints } from './auth.js';
 import { MicrosoftOAuthProvider } from './oauth-provider.js';
 import {
   exchangeCodeForToken,
@@ -118,6 +118,9 @@ class MicrosoftGraphServer {
       app.get('/.well-known/oauth-authorization-server', async (req, res) => {
         const protocol = req.secure ? 'https' : 'http';
         const url = new URL(`${protocol}://${req.get('host')}`);
+
+        const scopes = buildScopesFromEndpoints(this.options.orgMode);
+
         res.json({
           issuer: url.origin,
           authorization_endpoint: `${url.origin}/authorize`,
@@ -128,7 +131,7 @@ class MicrosoftGraphServer {
           grant_types_supported: ['authorization_code', 'refresh_token'],
           token_endpoint_auth_methods_supported: ['none'],
           code_challenge_methods_supported: ['S256'],
-          scopes_supported: ['Mail.Send', 'Mail.ReadWrite', 'Calendars.ReadWrite', 'Files.ReadWrite', 'Notes.Read', 'Notes.Create', 'Tasks.ReadWrite', 'Contacts.ReadWrite', 'User.Read', 'Files.Read.All', 'People.Read'],
+          scopes_supported: scopes,
         });
       });
 
@@ -136,10 +139,13 @@ class MicrosoftGraphServer {
       app.get('/.well-known/oauth-protected-resource', async (req, res) => {
         const protocol = req.secure ? 'https' : 'http';
         const url = new URL(`${protocol}://${req.get('host')}`);
+
+        const scopes = buildScopesFromEndpoints(this.options.orgMode);
+
         res.json({
           resource: `${url.origin}/mcp`,
           authorization_servers: [url.origin],
-          scopes_supported: ['Mail.Send', 'Mail.ReadWrite', 'Calendars.ReadWrite', 'Files.ReadWrite', 'Notes.Read', 'Notes.Create', 'Tasks.ReadWrite', 'Contacts.ReadWrite', 'User.Read', 'Files.Read.All', 'People.Read'],
+          scopes_supported: scopes,
           bearer_methods_supported: ['header'],
           resource_documentation: `${url.origin}`,
         });


### PR DESCRIPTION
I've added all available (and for some features needed) scopes for oauth discovery, so clients know what to be able to select, and therefore support e.g. writing to resources.

Also added support for running this mcp server behind a reverse proxy with https support, regarding the advertisement of the auto discovery urls.