### PR TITLE
feat: The “llmTip” field has been added to the endpoints to provide hints to the LLM

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -31,6 +31,7 @@ interface EndpointConfig {
   toolName: string;
   scopes?: string[];
   workScopes?: string[];
+  llmTip?: string;
 }
 
 const __filename = fileURLToPath(import.meta.url);

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -3,7 +3,8 @@
     "pathPattern": "/me/messages",
     "method": "get",
     "toolName": "list-mail-messages",
-    "scopes": ["Mail.Read"]
+    "scopes": ["Mail.Read"],
+    "llmTip": "CRITICAL: When searching emails, the $search parameter value MUST be wrapped in double quotes. Format: $search=\"your search query here\". Use KQL (Keyword Query Language) syntax to search specific properties: 'from:', 'subject:', 'body:', 'to:', 'cc:', 'bcc:', 'attachment:', 'hasAttachments:', 'importance:', 'received:', 'sent:'. Examples: $search=\"from:john@example.com\" | $search=\"subject:meeting AND hasAttachments:true\" | $search=\"body:urgent AND received>=2024-01-01\" | $search=\"from:john AND importance:high\". Remember: ALWAYS wrap the entire search expression in double quotes! Reference: https://learn.microsoft.com/en-us/graph/search-query-parameter"
   },
   {
     "pathPattern": "/me/mailFolders",
@@ -15,7 +16,8 @@
     "pathPattern": "/me/mailFolders/{mailFolder-id}/messages",
     "method": "get",
     "toolName": "list-mail-folder-messages",
-    "scopes": ["Mail.Read"]
+    "scopes": ["Mail.Read"],
+    "llmTip": "CRITICAL: When searching emails, the $search parameter value MUST be wrapped in double quotes. Format: $search=\"your search query here\". Use KQL (Keyword Query Language) syntax to search specific properties: 'from:', 'subject:', 'body:', 'to:', 'cc:', 'bcc:', 'attachment:', 'hasAttachments:', 'importance:', 'received:', 'sent:'. Examples: $search=\"from:john@example.com\" | $search=\"subject:meeting AND hasAttachments:true\" | $search=\"body:urgent AND received>=2024-01-01\" | $search=\"from:alice AND importance:high\". Remember: ALWAYS wrap the entire search expression in double quotes! Reference: https://learn.microsoft.com/en-us/graph/search-query-parameter"
   },
   {
     "pathPattern": "/me/messages/{message-id}",
@@ -27,19 +29,22 @@
     "pathPattern": "/me/sendMail",
     "method": "post",
     "toolName": "send-mail",
-    "scopes": ["Mail.Send"]
+    "scopes": ["Mail.Send"],
+    "llmTip": "CRITICAL: Do not try to guess the email address of the recipients. Use the list-users tool to find the email address of the recipients."
   },
   {
     "pathPattern": "/users/{user-id}/messages",
     "method": "get",
     "toolName": "list-shared-mailbox-messages",
-    "workScopes": ["Mail.Read.Shared"]
+    "workScopes": ["Mail.Read.Shared"],
+    "llmTip": "CRITICAL: When searching emails, the $search parameter value MUST be wrapped in double quotes. Format: $search=\"your search query here\". Use KQL (Keyword Query Language) syntax to search specific properties: 'from:', 'subject:', 'body:', 'to:', 'cc:', 'bcc:', 'attachment:', 'hasAttachments:', 'importance:', 'received:', 'sent:'. Examples: $search=\"from:john@example.com\" | $search=\"subject:meeting AND hasAttachments:true\" | $search=\"body:urgent AND received>=2024-01-01\" | $search=\"from:alice AND importance:high\". Remember: ALWAYS wrap the entire search expression in double quotes! Reference: https://learn.microsoft.com/en-us/graph/search-query-parameter"
   },
   {
     "pathPattern": "/users/{user-id}/mailFolders/{mailFolder-id}/messages",
     "method": "get",
     "toolName": "list-shared-mailbox-folder-messages",
-    "workScopes": ["Mail.Read.Shared"]
+    "workScopes": ["Mail.Read.Shared"],
+    "llmTip": "CRITICAL: When searching emails, the $search parameter value MUST be wrapped in double quotes. Format: $search=\"your search query here\". Use KQL (Keyword Query Language) syntax to search specific properties: 'from:', 'subject:', 'body:', 'to:', 'cc:', 'bcc:', 'attachment:', 'hasAttachments:', 'importance:', 'received:', 'sent:'. Examples: $search=\"from:john@example.com\" | $search=\"subject:meeting AND hasAttachments:true\" | $search=\"body:urgent AND received>=2024-01-01\" | $search=\"from:alice AND importance:high\". Remember: ALWAYS wrap the entire search expression in double quotes! Reference: https://learn.microsoft.com/en-us/graph/search-query-parameter"
   },
   {
     "pathPattern": "/users/{user-id}/messages/{message-id}",
@@ -51,13 +56,15 @@
     "pathPattern": "/users/{user-id}/sendMail",
     "method": "post",
     "toolName": "send-shared-mailbox-mail",
-    "workScopes": ["Mail.Send.Shared"]
+    "workScopes": ["Mail.Send.Shared"],
+    "llmTip": "CRITICAL: Do not try to guess the email address of the recipients. Use the list-users tool to find the email address of the recipients."
   },
   {
     "pathPattern": "/users",
     "method": "get",
     "toolName": "list-users",
-    "workScopes": ["User.Read.All"]
+    "workScopes": ["User.Read.All"],
+    "llmTip": "CRITICAL: This request requires the ConsistencyLevel header set to eventual. When searching users, the $search parameter value MUST be wrapped in double quotes. Format: $search=\"your search query here\". Use KQL (Keyword Query Language) syntax to search specific properties: 'displayName:'. Examples: $search=\"displayName:john\" | $search=\"displayName:john\" OR \"displayName:jane\". Remember: ALWAYS wrap the entire search expression in double quotes and set the ConsistencyLevel header to eventual! Reference: https://learn.microsoft.com/en-us/graph/search-query-parameter"
   },
   {
     "pathPattern": "/me/messages",
@@ -117,13 +124,15 @@
     "pathPattern": "/me/events",
     "method": "post",
     "toolName": "create-calendar-event",
-    "scopes": ["Calendars.ReadWrite"]
+    "scopes": ["Calendars.ReadWrite"],
+    "llmTip": "CRITICAL: Do not try to guess the email address of the recipients. Use the list-users tool to find the email address of the recipients."
   },
   {
     "pathPattern": "/me/events/{event-id}",
     "method": "patch",
     "toolName": "update-calendar-event",
-    "scopes": ["Calendars.ReadWrite"]
+    "scopes": ["Calendars.ReadWrite"],
+    "llmTip": "CRITICAL: Do not try to guess the email address of the recipients. Use the list-users tool to find the email address of the recipients."
   },
   {
     "pathPattern": "/me/events/{event-id}",
@@ -147,13 +156,15 @@
     "pathPattern": "/me/calendars/{calendar-id}/events",
     "method": "post",
     "toolName": "create-specific-calendar-event",
-    "scopes": ["Calendars.ReadWrite"]
+    "scopes": ["Calendars.ReadWrite"],
+    "llmTip": "CRITICAL: Do not try to guess the email address of the recipients. Use the list-users tool to find the email address of the recipients."
   },
   {
     "pathPattern": "/me/calendars/{calendar-id}/events/{event-id}",
     "method": "patch",
     "toolName": "update-specific-calendar-event",
-    "scopes": ["Calendars.ReadWrite"]
+    "scopes": ["Calendars.ReadWrite"],
+    "llmTip": "CRITICAL: Do not try to guess the email address of the recipients. Use the list-users tool to find the email address of the recipients."
   },
   {
     "pathPattern": "/me/calendars/{calendar-id}/events/{event-id}",

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -17,6 +17,7 @@ interface EndpointConfig {
   scopes?: string[];
   workScopes?: string[];
   returnDownloadUrl?: boolean;
+  llmTip?: string;
 }
 
 const endpointsData = JSON.parse(
@@ -137,9 +138,16 @@ export function registerGraphTools(
       .describe('Exclude the full response body and only return success or failure indication')
       .optional();
 
+    // Build the tool description, optionally appending LLM tips
+    let toolDescription =
+      tool.description || `Execute ${tool.method.toUpperCase()} request to ${tool.path}`;
+    if (endpointConfig?.llmTip) {
+      toolDescription += `\n\n💡 TIP: ${endpointConfig.llmTip}`;
+    }
+
     server.tool(
       tool.alias,
-      tool.description || `Execute ${tool.method.toUpperCase()} request to ${tool.path}`,
+      toolDescription,
       paramSchema,
       {
         title: tool.alias,


### PR DESCRIPTION
# Add LLM Tips to Tool Descriptions

## Summary
Adds contextual tips to tool descriptions to help LLM assistants use the Microsoft Graph API correctly. Tips are automatically appended to tool descriptions with a 💡 prefix.

## Changes

### Core Implementation
- Added `llmTip` field to `EndpointConfig` interface in `src/graph-tools.ts` and `src/auth.ts`
- Modified `registerGraphTools()` to append tips to tool descriptions
- Added tips to 11 tools in `src/endpoints.json`

### Tips Added

**Mail Search (4 tools)**: Emphasizes wrapping `$search` parameter in double quotes and provides KQL syntax examples
- `list-mail-messages`, `list-mail-folder-messages`, `list-shared-mailbox-messages`, `list-shared-mailbox-folder-messages`

**Email/Calendar (6 tools)**: Reminds to use `list-users` instead of guessing email addresses
- `send-mail`, `send-shared-mailbox-mail`, `create-calendar-event`, `update-calendar-event`, `create-specific-calendar-event`, `update-specific-calendar-event`

**User Search (1 tool)**: Highlights `ConsistencyLevel: eventual` header requirement and `$search` syntax
- `list-users`

## Benefits
- ✅ Prevents common API errors (missing quotes, wrong headers)
- ✅ Reduces failed requests and improves UX
- ✅ Backward compatible and extensible
- ✅ Based on [official Microsoft documentation](https://learn.microsoft.com/en-us/graph/search-query-parameter)