### PR TITLE
feat: make calendar tools timezone aware

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -112,13 +112,15 @@
     "pathPattern": "/me/events",
     "method": "get",
     "toolName": "list-calendar-events",
-    "scopes": ["Calendars.Read"]
+    "scopes": ["Calendars.Read"],
+    "supportsTimezone": true
   },
   {
     "pathPattern": "/me/events/{event-id}",
     "method": "get",
     "toolName": "get-calendar-event",
-    "scopes": ["Calendars.Read"]
+    "scopes": ["Calendars.Read"],
+    "supportsTimezone": true
   },
   {
     "pathPattern": "/me/events",
@@ -144,13 +146,15 @@
     "pathPattern": "/me/calendars/{calendar-id}/events",
     "method": "get",
     "toolName": "list-specific-calendar-events",
-    "scopes": ["Calendars.Read"]
+    "scopes": ["Calendars.Read"],
+    "supportsTimezone": true
   },
   {
     "pathPattern": "/me/calendars/{calendar-id}/events/{event-id}",
     "method": "get",
     "toolName": "get-specific-calendar-event",
-    "scopes": ["Calendars.Read"]
+    "scopes": ["Calendars.Read"],
+    "supportsTimezone": true
   },
   {
     "pathPattern": "/me/calendars/{calendar-id}/events",
@@ -176,7 +180,8 @@
     "pathPattern": "/me/calendarView",
     "method": "get",
     "toolName": "get-calendar-view",
-    "scopes": ["Calendars.Read"]
+    "scopes": ["Calendars.Read"],
+    "supportsTimezone": true
   },
   {
     "pathPattern": "/me/calendars",


### PR DESCRIPTION
# Add Timezone Support for Calendar Events

## Summary

Implements timezone support for calendar event retrieval endpoints, allowing users to receive event times in their preferred timezone instead of UTC. This feature uses the Microsoft Graph API's `Prefer: outlook.timezone` header as documented in the [official API documentation](https://learn.microsoft.com/en-us/graph/api/calendar-list-calendarview?view=graph-rest-1.0&tabs=http).

## Changes

### 1. Configuration (`src/endpoints.json`)
- Added `supportsTimezone: true` flag to 5 calendar endpoints:
  - `list-calendar-events`
  - `get-calendar-event`
  - `list-specific-calendar-events`
  - `get-specific-calendar-event`
  - `get-calendar-view`

### 2. Implementation (`src/graph-tools.ts`)
- Extended `EndpointConfig` interface with `supportsTimezone` property
- Added optional `timezone` parameter to supported calendar tools
- Implemented automatic injection of `Prefer: outlook.timezone="{timezone}"` header when timezone parameter is provided
- Added logging for timezone header usage

## Usage

```typescript
// Get calendar events in New York timezone
{
  "name": "list-calendar-events",
  "arguments": {
    "timezone": "America/New_York",
    "$top": "10"
  }
}

// Get calendar view in Tokyo timezone
{
  "name": "get-calendar-view",
  "arguments": {
    "startDateTime": "2024-01-01T00:00:00",
    "endDateTime": "2024-01-31T23:59:59",
    "timezone": "Asia/Tokyo"
  }
}
```

## Features

- ✅ Accepts any valid IANA timezone name (e.g., `America/New_York`, `Europe/London`, `Asia/Tokyo`)
- ✅ Optional parameter - defaults to UTC if not specified
- ✅ Fully backward compatible - existing code continues to work unchanged
- ✅ Automatic header injection - no manual configuration needed
- ✅ Logging support for debugging

## Testing

The implementation can be tested by:
1. Building the project: `npm run build`
2. Calling any supported calendar tool with the `timezone` parameter
3. Verifying event times are returned in the specified timezone
4. Checking logs for: `Setting timezone header: Prefer: outlook.timezone="..."`

## Backward Compatibility

No breaking changes. The `timezone` parameter is optional and only affects behavior when explicitly provided. All existing functionality remains unchanged.