### PR TITLE
feat: Hello discovery tools and categories - bye bye error arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,19 @@ This method:
 > **Authentication Tools**: In HTTP mode, login/logout tools are disabled by default since OAuth handles authentication.
 > Use `--enable-auth-tools` if you need them available.
 
+## Tool Presets
+
+To reduce initial connection overhead, use preset tool categories instead of loading all 90+ tools:
+
+```bash
+npx @softeria/ms-365-mcp-server --preset mail
+npx @softeria/ms-365-mcp-server --list-presets  # See all available presets
+```
+
+Available presets: `mail`, `calendar`, `files`, `personal`, `work`, `excel`, `contacts`, `tasks`, `onenote`, `search`, `users`, `all`
+
+**Experimental:** `--discovery` starts with only 2 tools (`search-tools`, `execute-tool`) for minimal token usage.
+
 ## CLI Options
 
 The following options can be used when running ms-365-mcp-server directly from the command line:
@@ -364,7 +377,10 @@ When running as an MCP server, the following options can be used:
                   Starts Express.js server with MCP endpoint at /mcp
 --enable-auth-tools Enable login/logout tools when using HTTP mode (disabled by default in HTTP mode)
 --enabled-tools <pattern> Filter tools using regex pattern (e.g., "excel|contact" to enable Excel and Contact tools)
+--preset <names>  Use preset tool categories (comma-separated). See "Tool Presets" section above
+--list-presets    List all available presets and exit
 --toon            (experimental) Enable TOON output format for 30-60% token reduction
+--discovery       (experimental) Start with search-tools + execute-tool only
 ```
 
 Environment variables:

--- a/bin/modules/generate-mcp-tools.mjs
+++ b/bin/modules/generate-mcp-tools.mjs
@@ -33,6 +33,10 @@ export function generateMcpTools(openApiSpec, outputDir) {
       (match) => match.replace(/\.strict\(\);/, '.passthrough();')
     );
 
+    console.log('Stripping unused errors arrays from endpoint definitions...');
+    // I didn't make up this crazy regex myself; you know who did. It seems works though.
+    clientCode = clientCode.replace(/,?\s*errors:\s*\[[\s\S]*?],?(?=\s*})/g, '');
+
     fs.writeFileSync(clientFilePath, clientCode);
 
     return true;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { getCombinedPresetPattern, listPresets, presetRequiresOrgMode } from './tool-categories.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageJsonPath = path.join(__dirname, '..', 'package.json');
@@ -35,12 +36,18 @@ program
     'Filter tools using regex pattern (e.g., "excel|contact" to enable Excel and Contact tools)'
   )
   .option(
+    '--preset <names>',
+    'Use preset tool categories (comma-separated). Available: mail, calendar, files, personal, work, excel, contacts, tasks, onenote, search, users, all'
+  )
+  .option('--list-presets', 'List all available presets and exit')
+  .option(
     '--org-mode',
     'Enable organization/work mode from start (includes Teams, SharePoint, etc.)'
   )
   .option('--work-mode', 'Alias for --org-mode')
   .option('--force-work-scopes', 'Backwards compatibility alias for --org-mode (deprecated)')
-  .option('--toon', '(experimental) Enable TOON output format for 30-60% token reduction');
+  .option('--toon', '(experimental) Enable TOON output format for 30-60% token reduction')
+  .option('--discovery', 'Enable runtime tool discovery and loading (experimental feature)');
 
 export interface CommandOptions {
   v?: boolean;
@@ -54,10 +61,13 @@ export interface CommandOptions {
   http?: string | boolean;
   enableAuthTools?: boolean;
   enabledTools?: string;
+  preset?: string;
+  listPresets?: boolean;
   orgMode?: boolean;
   workMode?: boolean;
   forceWorkScopes?: boolean;
   toon?: boolean;
+  discovery?: boolean;
 
   [key: string]: unknown;
 }
@@ -65,6 +75,29 @@ export interface CommandOptions {
 export function parseArgs(): CommandOptions {
   program.parse();
   const options = program.opts();
+
+  if (options.listPresets) {
+    const presets = listPresets();
+    console.log(JSON.stringify({ presets }, null, 2));
+    process.exit(0);
+  }
+
+  if (options.preset) {
+    const presetNames = options.preset.split(',').map((p: string) => p.trim());
+    try {
+      options.enabledTools = getCombinedPresetPattern(presetNames);
+
+      const requiresOrgMode = presetNames.some((preset: string) => presetRequiresOrgMode(preset));
+      if (requiresOrgMode && !options.orgMode) {
+        console.warn(
+          `Warning: Preset(s) [${presetNames.filter((p: string) => presetRequiresOrgMode(p)).join(', ')}] require --org-mode to function properly`
+        );
+      }
+    } catch (error) {
+      console.error(`Error: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  }
 
   if (process.env.READ_ONLY === 'true' || process.env.READ_ONLY === '1') {
     options.readOnly = true;

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { TOOL_CATEGORIES } from './tool-categories.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -79,13 +80,254 @@ interface CallToolResult {
   [key: string]: unknown;
 }
 
+async function executeGraphTool(
+  tool: (typeof api.endpoints)[0],
+  config: EndpointConfig | undefined,
+  graphClient: GraphClient,
+  params: Record<string, unknown>
+): Promise<CallToolResult> {
+  logger.info(`Tool ${tool.alias} called with params: ${JSON.stringify(params)}`);
+  try {
+    const parameterDefinitions = tool.parameters || [];
+
+    let path = tool.path;
+    const queryParams: Record<string, string> = {};
+    const headers: Record<string, string> = {};
+    let body: unknown = null;
+
+    for (const [paramName, paramValue] of Object.entries(params)) {
+      // Skip control parameters - not part of the Microsoft Graph API
+      if (['fetchAllPages', 'includeHeaders', 'excludeResponse', 'timezone'].includes(paramName)) {
+        continue;
+      }
+
+      // Ok, so, MCP clients (such as claude code) doesn't support $ in parameter names,
+      // and others might not support __, so we strip them in hack.ts and restore them here
+      const odataParams = [
+        'filter',
+        'select',
+        'expand',
+        'orderby',
+        'skip',
+        'top',
+        'count',
+        'search',
+        'format',
+      ];
+      // Handle both "top" and "$top" formats - strip $ if present, then re-add it
+      const normalizedParamName = paramName.startsWith('$') ? paramName.slice(1) : paramName;
+      const isOdataParam = odataParams.includes(normalizedParamName.toLowerCase());
+      const fixedParamName = isOdataParam ? `$${normalizedParamName.toLowerCase()}` : paramName;
+      // Look up param definition using normalized name (without $) for OData params
+      const paramDef = parameterDefinitions.find(
+        (p) => p.name === paramName || (isOdataParam && p.name === normalizedParamName)
+      );
+
+      if (paramDef) {
+        switch (paramDef.type) {
+          case 'Path':
+            path = path
+              .replace(`{${paramName}}`, encodeURIComponent(paramValue as string))
+              .replace(`:${paramName}`, encodeURIComponent(paramValue as string));
+            break;
+
+          case 'Query':
+            queryParams[fixedParamName] = `${paramValue}`;
+            break;
+
+          case 'Body':
+            if (paramDef.schema) {
+              const parseResult = paramDef.schema.safeParse(paramValue);
+              if (!parseResult.success) {
+                const wrapped = { [paramName]: paramValue };
+                const wrappedResult = paramDef.schema.safeParse(wrapped);
+                if (wrappedResult.success) {
+                  logger.info(
+                    `Auto-corrected parameter '${paramName}': AI passed nested field directly, wrapped it as {${paramName}: ...}`
+                  );
+                  body = wrapped;
+                } else {
+                  body = paramValue;
+                }
+              } else {
+                body = paramValue;
+              }
+            } else {
+              body = paramValue;
+            }
+            break;
+
+          case 'Header':
+            headers[fixedParamName] = `${paramValue}`;
+            break;
+        }
+      } else if (paramName === 'body') {
+        body = paramValue;
+        logger.info(`Set body param: ${JSON.stringify(body)}`);
+      }
+    }
+
+    // Handle timezone parameter for calendar endpoints
+    if (config?.supportsTimezone && params.timezone) {
+      headers['Prefer'] = `outlook.timezone="${params.timezone}"`;
+      logger.info(`Setting timezone header: Prefer: outlook.timezone="${params.timezone}"`);
+    }
+
+    if (Object.keys(queryParams).length > 0) {
+      const queryString = Object.entries(queryParams)
+        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+        .join('&');
+      path = `${path}${path.includes('?') ? '&' : '?'}${queryString}`;
+    }
+
+    const options: {
+      method: string;
+      headers: Record<string, string>;
+      body?: string;
+      rawResponse?: boolean;
+      includeHeaders?: boolean;
+      excludeResponse?: boolean;
+      queryParams?: Record<string, string>;
+    } = {
+      method: tool.method.toUpperCase(),
+      headers,
+    };
+
+    if (options.method !== 'GET' && body) {
+      options.body = typeof body === 'string' ? body : JSON.stringify(body);
+    }
+
+    const isProbablyMediaContent =
+      tool.errors?.some((error) => error.description === 'Retrieved media content') ||
+      path.endsWith('/content');
+
+    if (config?.returnDownloadUrl && path.endsWith('/content')) {
+      path = path.replace(/\/content$/, '');
+      logger.info(
+        `Auto-returning download URL for ${tool.alias} (returnDownloadUrl=true in endpoints.json)`
+      );
+    } else if (isProbablyMediaContent) {
+      options.rawResponse = true;
+    }
+
+    // Set includeHeaders if requested
+    if (params.includeHeaders === true) {
+      options.includeHeaders = true;
+    }
+
+    // Set excludeResponse if requested
+    if (params.excludeResponse === true) {
+      options.excludeResponse = true;
+    }
+
+    logger.info(`Making graph request to ${path} with options: ${JSON.stringify(options)}`);
+    let response = await graphClient.graphRequest(path, options);
+
+    const fetchAllPages = params.fetchAllPages === true;
+    if (fetchAllPages && response?.content?.[0]?.text) {
+      try {
+        let combinedResponse = JSON.parse(response.content[0].text);
+        let allItems = combinedResponse.value || [];
+        let nextLink = combinedResponse['@odata.nextLink'];
+        let pageCount = 1;
+
+        while (nextLink && pageCount < 100) {
+          logger.info(`Fetching page ${pageCount + 1} from: ${nextLink}`);
+
+          const url = new URL(nextLink);
+          const nextPath = url.pathname.replace('/v1.0', '');
+          const nextOptions = { ...options };
+
+          const nextQueryParams: Record<string, string> = {};
+          for (const [key, value] of url.searchParams.entries()) {
+            nextQueryParams[key] = value;
+          }
+          nextOptions.queryParams = nextQueryParams;
+
+          const nextResponse = await graphClient.graphRequest(nextPath, nextOptions);
+          if (nextResponse?.content?.[0]?.text) {
+            const nextJsonResponse = JSON.parse(nextResponse.content[0].text);
+            if (nextJsonResponse.value && Array.isArray(nextJsonResponse.value)) {
+              allItems = allItems.concat(nextJsonResponse.value);
+            }
+            nextLink = nextJsonResponse['@odata.nextLink'];
+            pageCount++;
+          } else {
+            break;
+          }
+        }
+
+        if (pageCount >= 100) {
+          logger.warn(`Reached maximum page limit (100) for pagination`);
+        }
+
+        combinedResponse.value = allItems;
+        if (combinedResponse['@odata.count']) {
+          combinedResponse['@odata.count'] = allItems.length;
+        }
+        delete combinedResponse['@odata.nextLink'];
+
+        response.content[0].text = JSON.stringify(combinedResponse);
+
+        logger.info(
+          `Pagination complete: collected ${allItems.length} items across ${pageCount} pages`
+        );
+      } catch (e) {
+        logger.error(`Error during pagination: ${e}`);
+      }
+    }
+
+    if (response?.content?.[0]?.text) {
+      const responseText = response.content[0].text;
+      logger.info(`Response size: ${responseText.length} characters`);
+
+      try {
+        const jsonResponse = JSON.parse(responseText);
+        if (jsonResponse.value && Array.isArray(jsonResponse.value)) {
+          logger.info(`Response contains ${jsonResponse.value.length} items`);
+        }
+        if (jsonResponse['@odata.nextLink']) {
+          logger.info(`Response has pagination nextLink: ${jsonResponse['@odata.nextLink']}`);
+        }
+      } catch {
+        // Non-JSON response
+      }
+    }
+
+    // Convert McpResponse to CallToolResult with the correct structure
+    const content: ContentItem[] = response.content.map((item) => ({
+      type: 'text' as const,
+      text: item.text,
+    }));
+
+    return {
+      content,
+      _meta: response._meta,
+      isError: response.isError,
+    };
+  } catch (error) {
+    logger.error(`Error in tool ${tool.alias}: ${(error as Error).message}`);
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            error: `Error in tool ${tool.alias}: ${(error as Error).message}`,
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
 export function registerGraphTools(
   server: McpServer,
   graphClient: GraphClient,
   readOnly: boolean = false,
   enabledToolsPattern?: string,
   orgMode: boolean = false
-): void {
+): number {
   let enabledToolsRegex: RegExp | undefined;
   if (enabledToolsPattern) {
     try {
@@ -96,24 +338,31 @@ export function registerGraphTools(
     }
   }
 
+  let registeredCount = 0;
+  let skippedCount = 0;
+  let failedCount = 0;
+
   for (const tool of api.endpoints) {
     const endpointConfig = endpointsData.find((e) => e.toolName === tool.alias);
     if (!orgMode && endpointConfig && !endpointConfig.scopes && endpointConfig.workScopes) {
       logger.info(`Skipping work account tool ${tool.alias} - not in org mode`);
+      skippedCount++;
       continue;
     }
 
     if (readOnly && tool.method.toUpperCase() !== 'GET') {
       logger.info(`Skipping write operation ${tool.alias} in read-only mode`);
+      skippedCount++;
       continue;
     }
 
     if (enabledToolsRegex && !enabledToolsRegex.test(tool.alias)) {
       logger.info(`Skipping tool ${tool.alias} - doesn't match filter pattern`);
+      skippedCount++;
       continue;
     }
 
-    const paramSchema: Record<string, unknown> = {};
+    const paramSchema: Record<string, z.ZodTypeAny> = {};
     if (tool.parameters && tool.parameters.length > 0) {
       for (const param of tool.parameters) {
         paramSchema[param.name] = param.schema || z.any();
@@ -156,274 +405,172 @@ export function registerGraphTools(
       toolDescription += `\n\n💡 TIP: ${endpointConfig.llmTip}`;
     }
 
-    server.tool(
-      tool.alias,
-      toolDescription,
-      paramSchema,
-      {
-        title: tool.alias,
-        readOnlyHint: tool.method.toUpperCase() === 'GET',
-      },
-      async (params) => {
-        logger.info(`Tool ${tool.alias} called with params: ${JSON.stringify(params)}`);
-        try {
-          logger.info(`params: ${JSON.stringify(params)}`);
-
-          const parameterDefinitions = tool.parameters || [];
-
-          let path = tool.path;
-          const queryParams: Record<string, string> = {};
-          const headers: Record<string, string> = {};
-          let body: unknown = null;
-
-          for (let [paramName, paramValue] of Object.entries(params)) {
-            // Skip pagination control parameter - it's not part of the Microsoft Graph API - I think 🤷
-            if (paramName === 'fetchAllPages') {
-              continue;
-            }
-
-            // Skip headers control parameter - it's not part of the Microsoft Graph API
-            if (paramName === 'includeHeaders') {
-              continue;
-            }
-
-            // Skip excludeResponse control parameter - it's not part of the Microsoft Graph API
-            if (paramName === 'excludeResponse') {
-              continue;
-            }
-
-            // Ok, so, MCP clients (such as claude code) doesn't support $ in parameter names,
-            // and others might not support __, so we strip them in hack.ts and restore them here
-            const odataParams = [
-              'filter',
-              'select',
-              'expand',
-              'orderby',
-              'skip',
-              'top',
-              'count',
-              'search',
-              'format',
-            ];
-            const fixedParamName = odataParams.includes(paramName.toLowerCase())
-              ? `$${paramName.toLowerCase()}`
-              : paramName;
-            const paramDef = parameterDefinitions.find((p) => p.name === paramName);
-
-            if (paramDef) {
-              switch (paramDef.type) {
-                case 'Path':
-                  path = path
-                    .replace(`{${paramName}}`, encodeURIComponent(paramValue as string))
-                    .replace(`:${paramName}`, encodeURIComponent(paramValue as string));
-                  break;
-
-                case 'Query':
-                  queryParams[fixedParamName] = `${paramValue}`;
-                  break;
-
-                case 'Body':
-                  if (paramDef.schema) {
-                    const parseResult = paramDef.schema.safeParse(paramValue);
-                    if (!parseResult.success) {
-                      const wrapped = { [paramName]: paramValue };
-                      const wrappedResult = paramDef.schema.safeParse(wrapped);
-                      if (wrappedResult.success) {
-                        logger.info(
-                          `Auto-corrected parameter '${paramName}': AI passed nested field directly, wrapped it as {${paramName}: ...}`
-                        );
-                        body = wrapped;
-                      } else {
-                        body = paramValue;
-                      }
-                    } else {
-                      body = paramValue;
-                    }
-                  } else {
-                    body = paramValue;
-                  }
-                  break;
-
-                case 'Header':
-                  headers[fixedParamName] = `${paramValue}`;
-                  break;
-              }
-            } else if (paramName === 'body') {
-              body = paramValue;
-              logger.info(`Set body param: ${JSON.stringify(body)}`);
-            }
-          }
-
-          // Handle timezone parameter for calendar endpoints
-          if (endpointConfig?.supportsTimezone && params.timezone) {
-            headers['Prefer'] = `outlook.timezone="${params.timezone}"`;
-            logger.info(`Setting timezone header: Prefer: outlook.timezone="${params.timezone}"`);
-          }
-
-          if (Object.keys(queryParams).length > 0) {
-            const queryString = Object.entries(queryParams)
-              .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
-              .join('&');
-            path = `${path}${path.includes('?') ? '&' : '?'}${queryString}`;
-          }
-
-          const options: {
-            method: string;
-            headers: Record<string, string>;
-            body?: string;
-            rawResponse?: boolean;
-            includeHeaders?: boolean;
-            excludeResponse?: boolean;
-          } = {
-            method: tool.method.toUpperCase(),
-            headers,
-          };
-
-          if (options.method !== 'GET' && body) {
-            options.body = typeof body === 'string' ? body : JSON.stringify(body);
-          }
-
-          const isProbablyMediaContent =
-            tool.errors?.some((error) => error.description === 'Retrieved media content') ||
-            path.endsWith('/content');
-
-          if (endpointConfig?.returnDownloadUrl && path.endsWith('/content')) {
-            path = path.replace(/\/content$/, '');
-            logger.info(
-              `Auto-returning download URL for ${tool.alias} (returnDownloadUrl=true in endpoints.json)`
-            );
-          } else if (isProbablyMediaContent) {
-            options.rawResponse = true;
-          }
-
-          // Set includeHeaders if requested
-          if (params.includeHeaders === true) {
-            options.includeHeaders = true;
-          }
-
-          // Set excludeResponse if requested
-          if (params.excludeResponse === true) {
-            options.excludeResponse = true;
-          }
-
-          logger.info(`Making graph request to ${path} with options: ${JSON.stringify(options)}`);
-          let response = await graphClient.graphRequest(path, options);
-
-          const fetchAllPages = params.fetchAllPages === true;
-          if (fetchAllPages && response && response.content && response.content.length > 0) {
-            try {
-              let combinedResponse = JSON.parse(response.content[0].text);
-              let allItems = combinedResponse.value || [];
-              let nextLink = combinedResponse['@odata.nextLink'];
-              let pageCount = 1;
-
-              while (nextLink) {
-                logger.info(`Fetching page ${pageCount + 1} from: ${nextLink}`);
-
-                const url = new URL(nextLink);
-                const nextPath = url.pathname.replace('/v1.0', '');
-                const nextOptions = { ...options };
-
-                const nextQueryParams: Record<string, string> = {};
-                for (const [key, value] of url.searchParams.entries()) {
-                  nextQueryParams[key] = value;
-                }
-                nextOptions.queryParams = nextQueryParams;
-
-                const nextResponse = await graphClient.graphRequest(nextPath, nextOptions);
-                if (nextResponse && nextResponse.content && nextResponse.content.length > 0) {
-                  const nextJsonResponse = JSON.parse(nextResponse.content[0].text);
-                  if (nextJsonResponse.value && Array.isArray(nextJsonResponse.value)) {
-                    allItems = allItems.concat(nextJsonResponse.value);
-                  }
-                  nextLink = nextJsonResponse['@odata.nextLink'];
-                  pageCount++;
-
-                  if (pageCount > 100) {
-                    logger.warn(`Reached maximum page limit (100) for pagination`);
-                    break;
-                  }
-                } else {
-                  break;
-                }
-              }
-
-              combinedResponse.value = allItems;
-              if (combinedResponse['@odata.count']) {
-                combinedResponse['@odata.count'] = allItems.length;
-              }
-              delete combinedResponse['@odata.nextLink'];
-
-              response.content[0].text = JSON.stringify(combinedResponse);
-
-              logger.info(
-                `Pagination complete: collected ${allItems.length} items across ${pageCount} pages`
-              );
-            } catch (e) {
-              logger.error(`Error during pagination: ${e}`);
-            }
-          }
-
-          if (response && response.content && response.content.length > 0) {
-            const responseText = response.content[0].text;
-            const responseSize = responseText.length;
-            logger.info(`Response size: ${responseSize} characters`);
-
-            try {
-              const jsonResponse = JSON.parse(responseText);
-              if (jsonResponse.value && Array.isArray(jsonResponse.value)) {
-                logger.info(`Response contains ${jsonResponse.value.length} items`);
-                if (jsonResponse.value.length > 0 && jsonResponse.value[0].body) {
-                  logger.info(
-                    `First item has body field with size: ${JSON.stringify(jsonResponse.value[0].body).length} characters`
-                  );
-                }
-              }
-              if (jsonResponse['@odata.nextLink']) {
-                logger.info(`Response has pagination nextLink: ${jsonResponse['@odata.nextLink']}`);
-              }
-              const preview = responseText.substring(0, 500);
-              logger.info(`Response preview: ${preview}${responseText.length > 500 ? '...' : ''}`);
-            } catch {
-              const preview = responseText.substring(0, 500);
-              logger.info(
-                `Response preview (non-JSON): ${preview}${responseText.length > 500 ? '...' : ''}`
-              );
-            }
-          }
-
-          // Convert McpResponse to CallToolResult with the correct structure
-          const content: ContentItem[] = response.content.map((item) => {
-            // GraphClient only returns text content items, so create proper TextContent items
-            const textContent: TextContent = {
-              type: 'text',
-              text: item.text,
-            };
-            return textContent;
-          });
-
-          const result: CallToolResult = {
-            content,
-            _meta: response._meta,
-            isError: response.isError,
-          };
-
-          return result;
-        } catch (error) {
-          logger.error(`Error in tool ${tool.alias}: ${(error as Error).message}`);
-          const errorContent: TextContent = {
-            type: 'text',
-            text: JSON.stringify({
-              error: `Error in tool ${tool.alias}: ${(error as Error).message}`,
-            }),
-          };
-
-          return {
-            content: [errorContent],
-            isError: true,
-          };
-        }
-      }
-    );
+    try {
+      server.tool(
+        tool.alias,
+        toolDescription,
+        paramSchema,
+        {
+          title: tool.alias,
+          readOnlyHint: tool.method.toUpperCase() === 'GET',
+        },
+        async (params) => executeGraphTool(tool, endpointConfig, graphClient, params)
+      );
+      registeredCount++;
+    } catch (error) {
+      logger.error(`Failed to register tool ${tool.alias}: ${(error as Error).message}`);
+      failedCount++;
+    }
   }
+
+  logger.info(
+    `Tool registration complete: ${registeredCount} registered, ${skippedCount} skipped, ${failedCount} failed`
+  );
+  return registeredCount;
+}
+
+function buildToolsRegistry(
+  readOnly: boolean,
+  orgMode: boolean
+): Map<string, { tool: (typeof api.endpoints)[0]; config: EndpointConfig | undefined }> {
+  const toolsMap = new Map<
+    string,
+    { tool: (typeof api.endpoints)[0]; config: EndpointConfig | undefined }
+  >();
+
+  for (const tool of api.endpoints) {
+    const endpointConfig = endpointsData.find((e) => e.toolName === tool.alias);
+
+    if (!orgMode && endpointConfig && !endpointConfig.scopes && endpointConfig.workScopes) {
+      continue;
+    }
+
+    if (readOnly && tool.method.toUpperCase() !== 'GET') {
+      continue;
+    }
+
+    toolsMap.set(tool.alias, { tool, config: endpointConfig });
+  }
+
+  return toolsMap;
+}
+
+export function registerDiscoveryTools(
+  server: McpServer,
+  graphClient: GraphClient,
+  readOnly: boolean = false,
+  orgMode: boolean = false
+): void {
+  const toolsRegistry = buildToolsRegistry(readOnly, orgMode);
+  logger.info(`Discovery mode: ${toolsRegistry.size} tools available in registry`);
+
+  server.tool(
+    'search-tools',
+    `Search through ${toolsRegistry.size} available Microsoft Graph API tools. Use this to find tools by name, path, or description before executing them.`,
+    {
+      query: z
+        .string()
+        .describe('Search query to filter tools (searches name, path, and description)')
+        .optional(),
+      category: z
+        .string()
+        .describe(
+          'Filter by category: mail, calendar, files, contacts, tasks, onenote, search, users, excel'
+        )
+        .optional(),
+      limit: z.number().describe('Maximum results to return (default: 20, max: 50)').optional(),
+    },
+    {
+      title: 'search-tools',
+      readOnlyHint: true,
+    },
+    async ({ query, category, limit = 20 }) => {
+      const maxLimit = Math.min(limit, 50);
+      const results: Array<{
+        name: string;
+        method: string;
+        path: string;
+        description: string;
+      }> = [];
+
+      const queryLower = query?.toLowerCase();
+      const categoryDef = category ? TOOL_CATEGORIES[category] : undefined;
+
+      for (const [name, { tool, config }] of toolsRegistry) {
+        if (categoryDef && !categoryDef.pattern.test(name)) {
+          continue;
+        }
+
+        if (queryLower) {
+          const searchText =
+            `${name} ${tool.path} ${tool.description || ''} ${config?.llmTip || ''}`.toLowerCase();
+          if (!searchText.includes(queryLower)) {
+            continue;
+          }
+        }
+
+        results.push({
+          name,
+          method: tool.method.toUpperCase(),
+          path: tool.path,
+          description: tool.description || `${tool.method.toUpperCase()} ${tool.path}`,
+        });
+
+        if (results.length >= maxLimit) break;
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                found: results.length,
+                total: toolsRegistry.size,
+                tools: results,
+                tip: 'Use execute-tool with the tool name and required parameters to call any of these tools.',
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+  );
+
+  server.tool(
+    'execute-tool',
+    'Execute a Microsoft Graph API tool by name. Use search-tools first to find available tools and their parameters.',
+    {
+      tool_name: z.string().describe('Name of the tool to execute (e.g., "list-mail-messages")'),
+      parameters: z
+        .record(z.any())
+        .describe('Parameters to pass to the tool as key-value pairs')
+        .optional(),
+    },
+    {
+      title: 'execute-tool',
+      readOnlyHint: false,
+    },
+    async ({ tool_name, parameters = {} }) => {
+      const toolData = toolsRegistry.get(tool_name);
+      if (!toolData) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                error: `Tool not found: ${tool_name}`,
+                tip: 'Use search-tools to find available tools.',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return executeGraphTool(toolData.tool, toolData.config, graphClient, parameters);
+    }
+  );
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@ import express, { Request, Response } from 'express';
 import crypto from 'crypto';
 import logger, { enableConsoleLogging } from './logger.js';
 import { registerAuthTools } from './auth-tools.js';
-import { registerGraphTools } from './graph-tools.js';
+import { registerGraphTools, registerDiscoveryTools } from './graph-tools.js';
 import GraphClient from './graph-client.js';
 import AuthManager, { buildScopesFromEndpoints } from './auth.js';
 import { MicrosoftOAuthProvider } from './oauth-provider.js';
@@ -55,13 +55,24 @@ class MicrosoftGraphServer {
     if (shouldRegisterAuthTools) {
       registerAuthTools(this.server, this.authManager);
     }
-    registerGraphTools(
-      this.server,
-      this.graphClient,
-      this.options.readOnly,
-      this.options.enabledTools,
-      this.options.orgMode
-    );
+
+    if (this.options.discovery) {
+      logger.info('Discovery mode enabled (experimental) - registering discovery tool only');
+      registerDiscoveryTools(
+        this.server,
+        this.graphClient,
+        this.options.readOnly,
+        this.options.orgMode
+      );
+    } else {
+      registerGraphTools(
+        this.server,
+        this.graphClient,
+        this.options.readOnly,
+        this.options.enabledTools,
+        this.options.orgMode
+      );
+    }
   }
 
   async start(): Promise<void> {

--- a/src/tool-categories.ts
+++ b/src/tool-categories.ts
@@ -1,0 +1,101 @@
+export interface ToolCategory {
+  name: string;
+  pattern: RegExp;
+  description: string;
+  requiresOrgMode?: boolean;
+}
+
+export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
+  mail: {
+    name: 'mail',
+    pattern: /mail|attachment|draft/i,
+    description: 'Email operations (read, send, manage folders, attachments)',
+  },
+  calendar: {
+    name: 'calendar',
+    pattern: /calendar|event/i,
+    description: 'Calendar and event management',
+  },
+  files: {
+    name: 'files',
+    pattern: /drive|file|upload|download|folder|item/i,
+    description: 'OneDrive file and folder operations',
+  },
+  personal: {
+    name: 'personal',
+    pattern: /mail|calendar|drive|contact|todo|onenote|attachment|draft|event|file|folder/i,
+    description: 'Personal productivity tools (mail, calendar, files, contacts, tasks, notes)',
+  },
+  work: {
+    name: 'work',
+    pattern: /team|channel|chat|sharepoint|planner|site|list|shared/i,
+    description: 'Organization/work tools (Teams, SharePoint, shared mailboxes)',
+    requiresOrgMode: true,
+  },
+  excel: {
+    name: 'excel',
+    pattern: /excel|worksheet|workbook|range|chart/i,
+    description: 'Excel spreadsheet operations',
+  },
+  contacts: {
+    name: 'contacts',
+    pattern: /contact/i,
+    description: 'Outlook contacts management',
+  },
+  tasks: {
+    name: 'tasks',
+    pattern: /todo|planner|task/i,
+    description: 'Task and planning tools (To Do, Planner)',
+  },
+  onenote: {
+    name: 'onenote',
+    pattern: /onenote|notebook|section|page/i,
+    description: 'OneNote notebook operations',
+  },
+  search: {
+    name: 'search',
+    pattern: /search|query/i,
+    description: 'Microsoft Search capabilities',
+  },
+  users: {
+    name: 'users',
+    pattern: /user|list-users/i,
+    description: 'User directory access',
+    requiresOrgMode: true,
+  },
+  all: {
+    name: 'all',
+    pattern: /.*/,
+    description: 'All available tools',
+  },
+};
+
+export function getCombinedPresetPattern(presets: string[]): string {
+  const patterns = presets.map((preset) => {
+    const category = TOOL_CATEGORIES[preset];
+    if (!category) {
+      throw new Error(
+        `Unknown preset: ${preset}. Available presets: ${Object.keys(TOOL_CATEGORIES).join(', ')}`
+      );
+    }
+    return category.pattern.source;
+  });
+  return patterns.join('|');
+}
+
+export function listPresets(): Array<{
+  name: string;
+  description: string;
+  requiresOrgMode?: boolean;
+}> {
+  return Object.values(TOOL_CATEGORIES).map((category) => ({
+    name: category.name,
+    description: category.description,
+    requiresOrgMode: category.requiresOrgMode,
+  }));
+}
+
+export function presetRequiresOrgMode(preset: string): boolean {
+  const category = TOOL_CATEGORIES[preset];
+  return category?.requiresOrgMode || false;
+}


### PR DESCRIPTION
Ok so the idea here is:

  * Introduce _discovery_ as experimental flag (--discovery
  * Remove error arrays - returns - these take up a lot of space and the LLM simply won't care about them
  * Add categories which are basically just more friendly collections of tools to enable (instead of regex which non-dev users probably never have even heard of) - added mostly because these are used in the tool discovery.