### PR TITLE
feat: Add destructiveHint and openWorldHint annotations to all tools

### DIFF
--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -413,6 +413,8 @@ export function registerGraphTools(
         {
           title: tool.alias,
           readOnlyHint: tool.method.toUpperCase() === 'GET',
+          destructiveHint: ['POST', 'PATCH', 'DELETE'].includes(tool.method.toUpperCase()),
+          openWorldHint: true, // All tools call Microsoft Graph API
         },
         async (params) => executeGraphTool(tool, endpointConfig, graphClient, params)
       );
@@ -483,6 +485,7 @@ export function registerDiscoveryTools(
     {
       title: 'search-tools',
       readOnlyHint: true,
+      openWorldHint: true, // Searches Microsoft Graph API tools
     },
     async ({ query, category, limit = 20 }) => {
       const maxLimit = Math.min(limit, 50);
@@ -552,6 +555,8 @@ export function registerDiscoveryTools(
     {
       title: 'execute-tool',
       readOnlyHint: false,
+      destructiveHint: true, // Can execute any tool, including write operations
+      openWorldHint: true, // Executes against Microsoft Graph API
     },
     async ({ tool_name, parameters = {} }) => {
       const toolData = toolsRegistry.get(tool_name);


### PR DESCRIPTION
## Summary

Completes the tool annotations by adding the missing `destructiveHint` and `openWorldHint` properties to all 101 tools in the MCP server.

## Changes

The existing implementation already had `title` and `readOnlyHint` annotations. This PR adds:

- **`destructiveHint: true`** for POST/PATCH/DELETE operations (37 tools)
- **`openWorldHint: true`** to all tools (since all call Microsoft Graph API)
- Updated `search-tools` discovery tool with `openWorldHint`
- Updated `execute-tool` discovery tool with `destructiveHint` and `openWorldHint`

## Why This Matters

Tool annotations help MCP clients understand tool behavior:
- Clients can auto-approve read-only operations
- Destructive operations trigger appropriate confirmation prompts
- `openWorldHint` indicates external API dependencies

## Tool Breakdown

| HTTP Method | Count | Annotations |
|-------------|-------|-------------|
| GET | 62 | `readOnlyHint: true`, `openWorldHint: true` |
| POST | 23 | `destructiveHint: true`, `openWorldHint: true` |
| PATCH | 10 | `destructiveHint: true`, `openWorldHint: true` |
| DELETE | 4 | `destructiveHint: true`, `openWorldHint: true` |
| Discovery | 2 | Appropriately annotated |

## Testing

- [x] All 22 tests pass
- [x] Build succeeds
- [x] Annotations verified in compiled output

🤖 Generated with [Claude Code](https://claude.com/claude-code)