### PR TITLE
fix: prevent Read scopes from upgrading to ReadWrite

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -120,10 +120,13 @@ function buildScopesFromEndpoints(
     }
   });
 
+  // Scope hierarchy: if we have BOTH a higher scope (ReadWrite) AND lower scopes (Read),
+  // keep only the higher scope since it includes the permissions of the lower scopes.
+  // Do NOT upgrade Read to ReadWrite if we only have Read scopes.
   Object.entries(SCOPE_HIERARCHY).forEach(([higherScope, lowerScopes]) => {
-    if (lowerScopes.every((scope) => scopesSet.has(scope))) {
+    if (scopesSet.has(higherScope) && lowerScopes.every((scope) => scopesSet.has(scope))) {
+      // We have both ReadWrite and Read, so remove the redundant Read scope
       lowerScopes.forEach((scope) => scopesSet.delete(scope));
-      scopesSet.add(higherScope);
     }
   });
 


### PR DESCRIPTION
  ## Problem                                                                                                                                                                                                           
  The SCOPE_HIERARCHY optimization was incorrectly upgrading Read scopes to ReadWrite scopes, even when only read-only tools were enabled via `--enabled-tools` filter. This prevented users from requesting minimal read-only permissions.                                                                                                                                                                                               
                                                                                                                                                                                                                       
  ## Solution                                                                                                                                                                                                          
  Modified the scope hierarchy logic to only consolidate when BOTH the higher scope (ReadWrite) AND lower scopes (Read) are present. Now it correctly:                                                                                                                                             
  - Keeps Mail.Read when only read tools are enabled                                                                                                                                                                   
  - Removes redundant Mail.Read when Mail.ReadWrite is also present                                                                                                                                                    
                                                                                                                                                                                                                       
  ## Impact                                                                                                                                                                                                            
  Users can now use `ENABLED_TOOLS="^(list-|get-)"` to request only read-only  OAuth scopes, enabling principle of least privilege for read-only use cases.   