### PR TITLE
Add forward, reply, reply-all endpoints to endpoints.json

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -121,6 +121,34 @@
     "scopes": ["Mail.ReadWrite"]
   },
   {
+    "pathPattern": "/me/messages/{message-id}/forward",
+    "method": "post",
+    "toolName": "forward-mail-message",
+    "scopes": ["Mail.Send"],
+    "llmTip": "Forward an email preserving full HTML formatting and attachments. The 'comment' field adds text above the forwarded content. toRecipients is required. Do NOT reconstruct the email manually - this endpoint handles everything server-side."
+  },
+  {
+    "pathPattern": "/me/messages/{message-id}/reply",
+    "method": "post",
+    "toolName": "reply-mail-message",
+    "scopes": ["Mail.Send"],
+    "llmTip": "Reply to an email preserving full HTML formatting. The 'comment' field is your reply text. Do NOT reconstruct the email manually."
+  },
+  {
+    "pathPattern": "/me/messages/{message-id}/replyAll",
+    "method": "post",
+    "toolName": "reply-all-mail-message",
+    "scopes": ["Mail.Send"],
+    "llmTip": "Reply-all preserving full HTML formatting. The 'comment' field is your reply text."
+  },
+  {
+    "pathPattern": "/me/messages/{message-id}/createForward",
+    "method": "post",
+    "toolName": "create-forward-draft",
+    "scopes": ["Mail.ReadWrite"],
+    "llmTip": "Create a forward draft (does not send). Useful when user wants to review before sending."
+  },
+  {
     "pathPattern": "/me/events",
     "method": "get",
     "toolName": "list-calendar-events",


### PR DESCRIPTION
## Summary

- Adds 4 new endpoint entries to `src/endpoints.json` for native email forward/reply actions
- Uses Microsoft Graph API's server-side message actions which preserve full HTML formatting and attachments
- No code changes needed beyond the declarative JSON entries

### New endpoints

| Tool Name | Graph API Path | Scope |
|-----------|---------------|-------|
| `forward-mail-message` | `POST /me/messages/{id}/forward` | Mail.Send |
| `reply-mail-message` | `POST /me/messages/{id}/reply` | Mail.Send |
| `reply-all-mail-message` | `POST /me/messages/{id}/replyAll` | Mail.Send |
| `create-forward-draft` | `POST /me/messages/{id}/createForward` | Mail.ReadWrite |

## Motivation

Currently, forwarding or replying to an email requires manually reading the message, reconstructing the body HTML, and sending via `send-mail`. This strips HTML formatting, loses inline images, and requires manual attachment handling.

The Graph API provides native `/forward`, `/reply`, and `/replyAll` actions that handle all of this server-side, preserving the original message formatting perfectly.

## Test plan

- [ ] Verify the server starts and registers the new tools
- [ ] Forward an HTML email and confirm formatting is preserved
- [ ] Reply to an email and confirm threading works correctly
- [ ] Test reply-all sends to all original recipients

🤖 Generated with [Claude Code](https://claude.com/claude-code)