### PR TITLE
feat: configurable token cache paths for headless deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,25 @@ Environment variables:
 - `MS365_MCP_TENANT_ID`: Custom tenant ID (defaults to 'common' for multi-tenant)
 - `MS365_MCP_OAUTH_TOKEN`: Pre-existing OAuth token for Microsoft Graph API (BYOT method)
 - `MS365_MCP_KEYVAULT_URL`: Azure Key Vault URL for secrets management (see Azure Key Vault section)
+- `MS365_MCP_TOKEN_CACHE_PATH`: Custom file path for MSAL token cache (see Token Storage below)
+- `MS365_MCP_SELECTED_ACCOUNT_PATH`: Custom file path for selected account metadata (see Token Storage below)
+
+## Token Storage
+
+Authentication tokens are stored using the OS credential store (via keytar) when available. If keytar is not installed or fails (common on headless Linux), the server falls back to file-based storage.
+
+**Default fallback paths** are relative to the installed package directory. This means tokens can be lost when the package is reinstalled or updated via npm.
+
+To persist tokens across updates, set custom paths outside the package directory:
+
+```bash
+export MS365_MCP_TOKEN_CACHE_PATH="$HOME/.config/ms365-mcp/.token-cache.json"
+export MS365_MCP_SELECTED_ACCOUNT_PATH="$HOME/.config/ms365-mcp/.selected-account.json"
+```
+
+Parent directories are created automatically. Files are written with `0600` permissions.
+
+> **Security note**: File-based token storage writes sensitive credentials to disk. Ensure the chosen directory has appropriate access controls. The OS credential store (keytar) is preferred when available.
 
 ## Azure Key Vault Integration
 

--- a/test/auth-paths.test.ts
+++ b/test/auth-paths.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
+
+describe('token cache path configuration', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  async function importHelpers() {
+    const mod = await import('../src/auth.js');
+    return {
+      getTokenCachePath: mod.getTokenCachePath,
+      getSelectedAccountPath: mod.getSelectedAccountPath,
+    };
+  }
+
+  describe('getTokenCachePath', () => {
+    it('should return default path when env var is not set', async () => {
+      vi.stubEnv('MS365_MCP_TOKEN_CACHE_PATH', '');
+      const { getTokenCachePath } = await importHelpers();
+      const result = getTokenCachePath();
+      expect(result).toContain('.token-cache.json');
+      expect(path.isAbsolute(result)).toBe(true);
+    });
+
+    it('should return env var path when set', async () => {
+      vi.stubEnv('MS365_MCP_TOKEN_CACHE_PATH', '/tmp/test-cache/.token-cache.json');
+      const { getTokenCachePath } = await importHelpers();
+      const result = getTokenCachePath();
+      expect(result).toBe('/tmp/test-cache/.token-cache.json');
+    });
+
+    it('should trim whitespace from env var', async () => {
+      vi.stubEnv('MS365_MCP_TOKEN_CACHE_PATH', '  /tmp/test-cache/.token-cache.json  ');
+      const { getTokenCachePath } = await importHelpers();
+      const result = getTokenCachePath();
+      expect(result).toBe('/tmp/test-cache/.token-cache.json');
+    });
+
+    it('should return default path when env var is undefined', async () => {
+      delete process.env.MS365_MCP_TOKEN_CACHE_PATH;
+      const { getTokenCachePath } = await importHelpers();
+      const result = getTokenCachePath();
+      expect(result).toContain('.token-cache.json');
+      expect(path.isAbsolute(result)).toBe(true);
+    });
+  });
+
+  describe('getSelectedAccountPath', () => {
+    it('should return default path when env var is not set', async () => {
+      vi.stubEnv('MS365_MCP_SELECTED_ACCOUNT_PATH', '');
+      const { getSelectedAccountPath } = await importHelpers();
+      const result = getSelectedAccountPath();
+      expect(result).toContain('.selected-account.json');
+      expect(path.isAbsolute(result)).toBe(true);
+    });
+
+    it('should return env var path when set', async () => {
+      vi.stubEnv('MS365_MCP_SELECTED_ACCOUNT_PATH', '/tmp/test-cache/.selected-account.json');
+      const { getSelectedAccountPath } = await importHelpers();
+      const result = getSelectedAccountPath();
+      expect(result).toBe('/tmp/test-cache/.selected-account.json');
+    });
+
+    it('should trim whitespace from env var', async () => {
+      vi.stubEnv('MS365_MCP_SELECTED_ACCOUNT_PATH', '  /tmp/test-cache/.selected-account.json  ');
+      const { getSelectedAccountPath } = await importHelpers();
+      const result = getSelectedAccountPath();
+      expect(result).toBe('/tmp/test-cache/.selected-account.json');
+    });
+
+    it('should return default path when env var is undefined', async () => {
+      delete process.env.MS365_MCP_SELECTED_ACCOUNT_PATH;
+      const { getSelectedAccountPath } = await importHelpers();
+      const result = getSelectedAccountPath();
+      expect(result).toContain('.selected-account.json');
+      expect(path.isAbsolute(result)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add optional, backwards-compatible environment variable overrides that let operators control where the MSAL token cache and selected-account metadata are stored on disk when keytar is unavailable.

**Problem:** On headless Linux servers where keytar is unavailable, the file-based fallback stores tokens relative to the installed package directory. When the package is reinstalled/updated via npm, the directory is replaced and auth tokens are lost.

**Solution:** Two new env vars (`MS365_MCP_TOKEN_CACHE_PATH`, `MS365_MCP_SELECTED_ACCOUNT_PATH`) let operators point token storage to a stable location outside the package directory.

## Changes

### `src/auth.ts`
- Replaced hard-coded `FALLBACK_PATH` / `SELECTED_ACCOUNT_PATH` constants with `getTokenCachePath()` / `getSelectedAccountPath()` helper functions
- Helpers check env vars first, fall back to original default paths
- Added `ensureParentDir()` to create parent directories recursively with `0o700` permissions before writes
- Preserved `0o600` file permissions on all write paths
- Updated all 8 usage sites (read, write, delete) consistently
- Exported helpers for testability

### `README.md`
- Added Token Storage section explaining keytar vs file fallback
- Documented new env vars with headless Linux examples
- Added security note about file-based token storage
- Listed new env vars in the environment variables reference

### `test/auth-paths.test.ts` (new)
- 8 tests covering: default paths, env var overrides, whitespace trimming, undefined env var handling

## Design Decisions

- **Env var override** chosen as the smallest compatible fix — no new dependencies, no config files, no CLI flags
- **No behaviour change** without env vars set — fully backwards-compatible
- **Directory permissions `0o700`** to match the `0o600` file security posture
- **`recursive: true` on mkdir** — no separate `existsSync` check needed

## Usage

```bash
export MS365_MCP_TOKEN_CACHE_PATH="$HOME/.config/ms365-mcp/.token-cache.json"
export MS365_MCP_SELECTED_ACCOUNT_PATH="$HOME/.config/ms365-mcp/.selected-account.json"
ms-365-mcp-server --enable-auth-tools
```

## Test Plan

- [x] All 36 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Lint passes with 0 errors (`npm run lint`)
- [x] Prettier formatting valid
- [x] Unit tests verify env var override, default fallback, whitespace trimming, and undefined env var