### PR TITLE
feat: add list-channel-message-replies endpoint

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -587,6 +587,12 @@
     "workScopes": ["ChannelMessage.Send"]
   },
   {
+    "pathPattern": "/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies",
+    "method": "get",
+    "toolName": "list-channel-message-replies",
+    "workScopes": ["ChannelMessage.Read.All"]
+  },
+  {
     "pathPattern": "/teams/{team-id}/members",
     "method": "get",
     "toolName": "list-team-members",


### PR DESCRIPTION
## Summary

- Adds missing `list-channel-message-replies` endpoint (`GET /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies`)
- Uses `ChannelMessage.Read.All` scope, matching the existing write-side endpoint

## What was missing

The server had an **asymmetric threading gap** for Teams channels:

| Capability | Chats | Channels |
|-----------|-------|----------|
| **Send threaded reply** | `reply-to-chat-message` | `reply-to-channel-message` |
| **List threaded replies** | `list-chat-message-replies` | **MISSING** |

Chat threading was fully supported (read + write), but channel threading was write-only — you could reply to a channel message in a thread, but couldn't read the replies in that thread.

`list-channel-messages` only returns root/top-level messages. Without the replies endpoint, thread conversations in channels were invisible to MCP consumers.

## Fix

One entry added to `endpoints.json`. The existing generic tool execution engine (`graph-tools.ts`) handles it automatically — no code changes needed. The Graph API endpoint already exists in Microsoft's OpenAPI spec, so `npm run generate` picks it up and generates the correct client code.

## Test plan

- [x] `npm run generate` succeeds — new endpoint appears in generated client
- [x] `npm run build` compiles cleanly
- [x] `npm test` — all 47 tests pass
- [ ] Manual test: list replies in a channel thread with `--org-mode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)