### PR TITLE
fix: prevent calendar event properties from being silently dropped

### DIFF
--- a/bin/modules/generate-mcp-tools.mjs
+++ b/bin/modules/generate-mcp-tools.mjs
@@ -28,10 +28,7 @@ export function generateMcpTools(openApiSpec, outputDir) {
     let clientCode = fs.readFileSync(clientFilePath, 'utf-8');
     clientCode = clientCode.replace(/'@zodios\/core';/, "'./hack.js';");
 
-    clientCode = clientCode.replace(
-      /const microsoft_graph_attachment = z\s+\.object\({[\s\S]*?}\)\s+\.strict\(\);/,
-      (match) => match.replace(/\.strict\(\);/, '.passthrough();')
-    );
+    clientCode = clientCode.replace(/\.strict\(\)/g, '.passthrough()');
 
     console.log('Stripping unused errors arrays from endpoint definitions...');
     // I didn't make up this crazy regex myself; you know who did. It seems works though.

--- a/bin/modules/simplified-openapi.mjs
+++ b/bin/modules/simplified-openapi.mjs
@@ -255,6 +255,22 @@ function reduceProperties(schema, schemaName) {
       'enabled',
       'singleValueExtendedProperties',
       'multiValueExtendedProperties',
+      'start',
+      'end',
+      'location',
+      'showAs',
+      'sensitivity',
+      'isAllDay',
+      'importance',
+      'isOnlineMeeting',
+      'isReminderOn',
+      'attendees',
+      'recurrence',
+      'reminderMinutesBeforeStart',
+      'allowNewTimeProposals',
+      'responseRequested',
+      'from',
+      'toRecipients',
     ];
 
     const keptProperties = {};


### PR DESCRIPTION
Ok so the .strict() on ALL nested Zod schemas was too strict. Unstricting