### PR TITLE
fix: apply MCP guideline compliance improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,7 @@ COPY --from=builder /app/package*.json ./
 ENV NODE_ENV=production
 RUN npm i --ignore-scripts --omit=dev
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+  CMD node -e "fetch('http://localhost:3000/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
+
 ENTRYPOINT ["node", "dist/index.js"]

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -91,6 +91,9 @@ async function executeGraphTool(
   params: Record<string, unknown>,
   authManager?: AuthManager
 ): Promise<CallToolResult> {
+  const startMs = Date.now();
+  // Derive a stable user identifier from the account param or the auth context.
+  const userId = (params.account as string | undefined) ?? 'default';
   logger.info(`Tool ${tool.alias} called with params: ${JSON.stringify(params)}`);
   try {
     // Resolve account-specific token if `account` parameter is provided (or auto-resolve for single account).
@@ -395,6 +398,15 @@ async function executeGraphTool(
       text: item.text,
     }));
 
+    const resultSize = content.reduce((sum, item) => sum + (item as TextContent).text.length, 0);
+    logger.info('tool_audit', {
+      userId,
+      tool: tool.alias,
+      durationMs: Date.now() - startMs,
+      resultSize,
+      isError: response.isError ?? false,
+    });
+
     return {
       content,
       _meta: response._meta,
@@ -402,6 +414,13 @@ async function executeGraphTool(
     };
   } catch (error) {
     logger.error(`Error in tool ${tool.alias}: ${(error as Error).message}`);
+    logger.info('tool_audit', {
+      userId,
+      tool: tool.alias,
+      durationMs: Date.now() - startMs,
+      resultSize: 0,
+      isError: true,
+    });
     return {
       content: [
         {

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -1,0 +1,28 @@
+/**
+ * In-memory per-user rate limiter.
+ * Limits each userId to `limit` requests per `windowMs` milliseconds.
+ */
+
+interface RateLimitEntry {
+  count: number;
+  windowStart: number;
+}
+
+const store = new Map<string, RateLimitEntry>();
+
+export function checkRateLimit(userId: string, limit = 30, windowMs = 60_000): boolean {
+  const now = Date.now();
+  const entry = store.get(userId);
+
+  if (!entry || now - entry.windowStart >= windowMs) {
+    store.set(userId, { count: 1, windowStart: now });
+    return true;
+  }
+
+  if (entry.count >= limit) {
+    return false;
+  }
+
+  entry.count++;
+  return true;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import type { CommandOptions } from './cli.ts';
 import { getSecrets, type AppSecrets } from './secrets.js';
 import { getCloudEndpoints } from './cloud-config.js';
 import { requestContext } from './request-context.js';
+import { checkRateLimit } from './rate-limiter.js';
 
 /**
  * Parse HTTP option into host and port components.
@@ -388,6 +389,12 @@ class MicrosoftGraphServer {
           req: Request & { microsoftAuth?: { accessToken: string; refreshToken: string } },
           res: Response
         ) => {
+          const userId = req.microsoftAuth?.accessToken.slice(-16) ?? 'anonymous';
+          if (!checkRateLimit(userId)) {
+            res.status(429).json({ error: 'Too many requests. Please slow down.' });
+            return;
+          }
+
           const handler = async () => {
             const server = this.createMcpServer();
             const transport = new StreamableHTTPServerTransport({
@@ -437,6 +444,12 @@ class MicrosoftGraphServer {
           req: Request & { microsoftAuth?: { accessToken: string; refreshToken: string } },
           res: Response
         ) => {
+          const userId = req.microsoftAuth?.accessToken.slice(-16) ?? 'anonymous';
+          if (!checkRateLimit(userId)) {
+            res.status(429).json({ error: 'Too many requests. Please slow down.' });
+            return;
+          }
+
           const handler = async () => {
             const server = this.createMcpServer();
             const transport = new StreamableHTTPServerTransport({
@@ -480,7 +493,29 @@ class MicrosoftGraphServer {
       );
 
       // Health check endpoint
-      app.get('/', (req, res) => {
+      app.get('/health', async (_req, res) => {
+        const graphApiUrl = 'https://graph.microsoft.com/v1.0/$metadata';
+        try {
+          const controller = new AbortController();
+          const timeout = setTimeout(() => controller.abort(), 5000);
+          const graphResponse = await fetch(graphApiUrl, {
+            method: 'HEAD',
+            signal: controller.signal,
+          });
+          clearTimeout(timeout);
+
+          if (graphResponse.ok || graphResponse.status === 401) {
+            // 401 means the endpoint is reachable (auth required but service is up)
+            res.status(200).json({ status: 'healthy', version: this.version, timestamp: new Date().toISOString() });
+          } else {
+            res.status(503).json({ status: 'degraded', reason: `Graph API returned ${graphResponse.status}`, timestamp: new Date().toISOString() });
+          }
+        } catch (err) {
+          res.status(503).json({ status: 'degraded', reason: 'Graph API unreachable', timestamp: new Date().toISOString() });
+        }
+      });
+
+      app.get('/', (_req, res) => {
         res.send('Microsoft 365 MCP Server is running');
       });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
- Add per-user rate limiting (30 req/min) to HTTP /mcp endpoints via new src/rate-limiter.ts module; returns HTTP 429 when exceeded
- Add structured audit logging per tool call (userId, tool, durationMs, resultSize, isError) emitted as 'tool_audit' log entries
- Replace plain-text GET / health check with proper GET /health endpoint returning JSON 200 (healthy) or 503 (degraded) with Graph API reachability probe
- Add Dockerfile HEALTHCHECK instruction using /health endpoint
- Bump tsconfig target from ES2020 to ES2022 per guideline recommendation

https://claude.ai/code/session_01Bgi2mtTgeg1zyBhzQquA9Z