### PR TITLE
feat: add Teams meeting search hints to calendarView llmTips

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -273,7 +273,7 @@
     "scopes": ["Calendars.Read"],
     "supportsTimezone": true,
     "supportsExpandExtendedProperties": true,
-    "llmTip": "Returns expanded recurring event instances (not just seriesMaster) within a date range for the default calendar. Requires startDateTime and endDateTime query parameters in ISO 8601 format (e.g., 2024-01-01T00:00:00Z). Use get-specific-calendar-view if you need a non-default calendar."
+    "llmTip": "Returns expanded recurring event instances (not just seriesMaster) within a date range for the default calendar. Requires startDateTime and endDateTime query parameters in ISO 8601 format (e.g., 2024-01-01T00:00:00Z). Use get-specific-calendar-view if you need a non-default calendar. To find Teams meetings, use $filter=isOnlineMeeting eq true. To search by subject, use $filter=contains(subject,'keyword'). Teams meetings include a joinWebUrl property needed for transcript access via list-online-meetings."
   },
   {
     "pathPattern": "/me/calendars/{calendar-id}/calendarView",
@@ -282,7 +282,7 @@
     "scopes": ["Calendars.Read"],
     "supportsTimezone": true,
     "supportsExpandExtendedProperties": true,
-    "llmTip": "Returns expanded recurring event instances (not just seriesMaster) within a date range for a specific calendar. Requires startDateTime and endDateTime query parameters in ISO 8601 format (e.g., 2024-01-01T00:00:00Z). Each instance includes seriesMasterId and type (occurrence/exception) fields for recurring event linkage. Use fetchAllPages=true to retrieve all results when there are many events."
+    "llmTip": "Returns expanded recurring event instances (not just seriesMaster) within a date range for a specific calendar. Requires startDateTime and endDateTime query parameters in ISO 8601 format (e.g., 2024-01-01T00:00:00Z). Each instance includes seriesMasterId and type (occurrence/exception) fields for recurring event linkage. Use fetchAllPages=true to retrieve all results when there are many events. To find Teams meetings, use $filter=isOnlineMeeting eq true. Teams meetings include a joinWebUrl property needed for transcript access via list-online-meetings."
   },
   {
     "pathPattern": "/me/calendars/{calendar-id}/events/{event-id}/instances",


### PR DESCRIPTION
## Summary

- Enhance `get-calendar-view` llmTip with `$filter=isOnlineMeeting eq true` guidance for finding Teams meetings
- Add `joinWebUrl` reference for transcript access workflow via `list-online-meetings`
- Same enhancement on `get-specific-calendar-view` for non-default calendars

No new endpoints, no new scopes — just better LLM discoverability for existing calendarView tools.

## Test plan

- [x] `npm run verify` passes (lint + build + 74 tests)
- [ ] Verify LLM can discover Teams meetings via `get-calendar-view` with the new filter hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)