### PR TITLE
feat: add meeting attendance report endpoints

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -767,6 +767,27 @@
     "llmTip": "Returns a temporary download URL for the meeting recording in MP4 format. Use the download URL to access the video file. The recording may be large — do not attempt to stream it inline."
   },
   {
+    "pathPattern": "/me/onlineMeetings/{onlineMeeting-id}/attendanceReports",
+    "method": "get",
+    "toolName": "list-meeting-attendance-reports",
+    "workScopes": ["OnlineMeetingArtifact.Read.All"],
+    "llmTip": "Lists attendance reports for a meeting. Each report has meetingStartDateTime, meetingEndDateTime, totalParticipantCount. For recurring meetings, there is one report per occurrence. Get the meeting ID first via list-online-meetings."
+  },
+  {
+    "pathPattern": "/me/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}",
+    "method": "get",
+    "toolName": "get-meeting-attendance-report",
+    "workScopes": ["OnlineMeetingArtifact.Read.All"],
+    "llmTip": "Gets a specific attendance report with totalParticipantCount, meetingStartDateTime, meetingEndDateTime."
+  },
+  {
+    "pathPattern": "/me/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords",
+    "method": "get",
+    "toolName": "list-meeting-attendance-records",
+    "workScopes": ["OnlineMeetingArtifact.Read.All"],
+    "llmTip": "Lists individual attendance records for a meeting report. Each record has: identity (displayName), emailAddress, role (Organizer/Presenter/Attendee), totalAttendanceInSeconds, and attendanceIntervals with joinDateTime/leaveDateTime. Use to determine who attended, how long, and when they joined/left."
+  },
+  {
     "pathPattern": "/groups/{group-id}/conversations",
     "method": "get",
     "toolName": "list-group-conversations",


### PR DESCRIPTION
## Summary

- Add `list-meeting-attendance-reports`: lists attendance reports per meeting occurrence with participant counts and timing
- Add `get-meeting-attendance-report`: gets a specific report summary
- Add `list-meeting-attendance-records`: individual attendee details with join/leave times, duration, and role (Organizer/Presenter/Attendee)

All three are endpoint-driven (JSON config only, no TypeScript changes). Useful for compliance, training verification, and meeting analytics.

**New permission**: `OnlineMeetingArtifact.Read.All` (delegated)

## Test plan

- [x] `npm run verify` passes (lint + build + 74 tests)
- [ ] Verify the three tools appear in tool list and accept path parameters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)