### PR TITLE
feat: add meeting recording endpoints

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -746,7 +746,6 @@
     "pathPattern": "/me/onlineMeetings/{onlineMeeting-id}/recordings",
     "method": "get",
     "toolName": "list-meeting-recordings",
-    "scopes": ["OnlineMeetingRecording.Read.All"],
     "workScopes": ["OnlineMeetingRecording.Read.All"],
     "llmTip": "Lists recordings for a meeting. Each recording has createdDateTime, endDateTime, meetingOrganizer, contentCorrelationId (links to corresponding transcript). For recurring meetings, there is one recording per occurrence."
   },
@@ -754,7 +753,6 @@
     "pathPattern": "/me/onlineMeetings/{onlineMeeting-id}/recordings/{callRecording-id}/content",
     "method": "get",
     "toolName": "get-meeting-recording-content",
-    "scopes": ["OnlineMeetingRecording.Read.All"],
     "workScopes": ["OnlineMeetingRecording.Read.All"],
     "returnDownloadUrl": true,
     "llmTip": "Returns a temporary download URL for the meeting recording in MP4 format. Use the download URL to access the video file. The recording may be large — do not attempt to stream it inline."


### PR DESCRIPTION
## Summary

- Add `list-meeting-recordings`: lists recordings with metadata and `contentCorrelationId` linking to corresponding transcripts
- Add `get-meeting-recording-content`: returns a temporary download URL for the MP4 recording file (uses `returnDownloadUrl: true` since video files are too large for inline MCP responses)

Both are endpoint-driven (JSON config only, no TypeScript changes). Complements the existing transcript endpoints from #260.

**New permission**: `OnlineMeetingRecording.Read.All` (delegated)

## Test plan

- [x] `npm run verify` passes (lint + build + 74 tests)
- [ ] Verify both tools appear in tool list and accept path parameters correctly
- [ ] Verify `get-meeting-recording-content` returns a download URL rather than streaming content

🤖 Generated with [Claude Code](https://claude.com/claude-code)