### PR TITLE
feat: add parse-teams-url utility tool

### DIFF
--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -9,6 +9,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { TOOL_CATEGORIES } from './tool-categories.js';
 import { getRequestTokens } from './request-context.js';
+import { parseTeamsUrl } from './lib/teams-url-parser.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -560,6 +561,41 @@ export function registerGraphTools(
 
   if (multiAccount) {
     logger.info('Multi-account mode: "account" parameter injected into all tool schemas');
+  }
+
+  // Register parse-teams-url utility tool (no Graph API call)
+  if (!enabledToolsRegex || enabledToolsRegex.test('parse-teams-url')) {
+    try {
+      server.tool(
+        'parse-teams-url',
+        'Converts any Teams meeting URL format (short /meet/, full /meetup-join/, or recap ?threadId=) into a standard joinWebUrl. Use this before list-online-meetings when the user provides a recap or short URL.',
+        {
+          url: z.string().describe('Teams meeting URL in any format'),
+        },
+        {
+          title: 'parse-teams-url',
+          readOnlyHint: true,
+          openWorldHint: false,
+        },
+        async ({ url }) => {
+          try {
+            const joinWebUrl = parseTeamsUrl(url);
+            return { content: [{ type: 'text', text: joinWebUrl }] };
+          } catch (error) {
+            return {
+              content: [
+                { type: 'text', text: JSON.stringify({ error: (error as Error).message }) },
+              ],
+              isError: true,
+            };
+          }
+        }
+      );
+      registeredCount++;
+    } catch (error) {
+      logger.error(`Failed to register tool parse-teams-url: ${(error as Error).message}`);
+      failedCount++;
+    }
   }
 
   // Layer 3 (list-accounts tool) is registered by registerAuthTools in auth-tools.ts.

--- a/src/lib/teams-url-parser.ts
+++ b/src/lib/teams-url-parser.ts
@@ -1,0 +1,38 @@
+/**
+ * Converts any Teams meeting URL format into a standard joinWebUrl
+ * usable with the list-online-meetings $filter=joinWebUrl eq '...' query.
+ *
+ * Supported formats:
+ * - Short URL: https://teams.microsoft.com/meet/29752586464443?p=...
+ * - Full joinWebUrl: https://teams.microsoft.com/l/meetup-join/19%3ameeting_.../0?context=...
+ * - Recap URL: https://teams.microsoft.com/v2/#/meetingrecap?threadId=...&tenantId=...&organizerId=...
+ */
+export function parseTeamsUrl(url: string): string {
+  // Format 1 & 2: Already a joinWebUrl or short /meet/ URL — pass through
+  if (url.includes('/meet/') || url.includes('/meetup-join/')) {
+    return url;
+  }
+
+  // Format 3: Recap URL — extract params and reconstruct joinWebUrl
+  if (url.toLowerCase().includes('meetingrecap')) {
+    const params = Object.fromEntries(
+      [...url.matchAll(/([a-zA-Z]+)=([^&#]+)/g)].map((m) => [m[1], m[2]])
+    );
+    const threadId = decodeURIComponent(params.threadId || '');
+    const tenantId = params.tenantId || '';
+    const organizerId = params.organizerId || '';
+
+    if (!threadId || !tenantId || !organizerId) {
+      throw new Error('Invalid recap URL: missing threadId, tenantId, or organizerId parameter');
+    }
+
+    const threadEnc = encodeURIComponent(threadId).replace(/%3A/gi, '%3a').replace(/%40/gi, '%40');
+    const ctx = JSON.stringify({ Tid: tenantId, Oid: organizerId });
+    const ctxEnc = encodeURIComponent(ctx);
+
+    return `https://teams.microsoft.com/l/meetup-join/${threadEnc}/0?context=${ctxEnc}`;
+  }
+
+  // Unknown format — return as-is
+  return url;
+}

--- a/test/calendar-view.test.ts
+++ b/test/calendar-view.test.ts
@@ -136,6 +136,9 @@ describe('Calendar View Tools', () => {
       registerGraphTools(mockServer, mockGraphClient, false);
 
       for (const call of mockServer.tool.mock.calls) {
+        const toolName = call[0] as string;
+        // Skip utility tools that are not Graph API endpoints
+        if (toolName === 'parse-teams-url') continue;
         const paramSchema = call[2] as Record<string, z.ZodTypeAny>;
         expect(paramSchema).toHaveProperty('fetchAllPages');
       }

--- a/test/read-only.test.ts
+++ b/test/read-only.test.ts
@@ -71,7 +71,8 @@ describe('Read-Only Mode', () => {
 
     registerGraphTools(mockServer, {} as GraphClient, options.readOnly);
 
-    expect(mockServer.tool).toHaveBeenCalledTimes(1);
+    // 1 GET endpoint + 1 parse-teams-url utility tool
+    expect(mockServer.tool).toHaveBeenCalledTimes(2);
 
     const toolCalls = mockServer.tool.mock.calls.map((call: unknown[]) => call[0]);
     expect(toolCalls).toContain('list-mail-messages');
@@ -87,7 +88,8 @@ describe('Read-Only Mode', () => {
 
     registerGraphTools(mockServer, {} as GraphClient, options.readOnly);
 
-    expect(mockServer.tool).toHaveBeenCalledTimes(3);
+    // 3 mocked endpoints + 1 parse-teams-url utility tool
+    expect(mockServer.tool).toHaveBeenCalledTimes(4);
 
     const toolCalls = mockServer.tool.mock.calls.map((call: unknown[]) => call[0]);
     expect(toolCalls).toContain('list-mail-messages');

--- a/test/teams-url-parser.test.ts
+++ b/test/teams-url-parser.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { parseTeamsUrl } from '../src/lib/teams-url-parser.js';
+
+describe('parseTeamsUrl', () => {
+  it('should pass through a full joinWebUrl unchanged', () => {
+    const url =
+      'https://teams.microsoft.com/l/meetup-join/19%3ameeting_abc123%40thread.v2/0?context=%7b%22Tid%22%3a%22tenant-id%22%7d';
+    expect(parseTeamsUrl(url)).toBe(url);
+  });
+
+  it('should pass through a short /meet/ URL unchanged', () => {
+    const url = 'https://teams.microsoft.com/meet/29752586464443?p=abc123';
+    expect(parseTeamsUrl(url)).toBe(url);
+  });
+
+  it('should convert a recap URL to a joinWebUrl', () => {
+    const recapUrl =
+      'https://teams.microsoft.com/v2/#/meetingrecap?threadId=19%3ameeting_abc123%40thread.v2&tenantId=tenant-123&organizerId=organizer-456';
+
+    const result = parseTeamsUrl(recapUrl);
+
+    expect(result).toContain('/l/meetup-join/');
+    expect(result).toContain('19%3ameeting_abc123%40thread.v2');
+    expect(result).toContain('context=');
+    expect(result).toContain('tenant-123');
+    expect(result).toContain('organizer-456');
+  });
+
+  it('should include Tid and Oid in the context JSON', () => {
+    const recapUrl =
+      'https://teams.microsoft.com/v2/#/meetingrecap?threadId=19%3ameeting_test%40thread.v2&tenantId=tid-abc&organizerId=oid-def';
+
+    const result = parseTeamsUrl(recapUrl);
+
+    // Extract and decode the context parameter
+    const contextMatch = result.match(/context=(.+)$/);
+    expect(contextMatch).toBeTruthy();
+    const ctx = JSON.parse(decodeURIComponent(contextMatch![1]));
+    expect(ctx.Tid).toBe('tid-abc');
+    expect(ctx.Oid).toBe('oid-def');
+  });
+
+  it('should throw on recap URL missing required params', () => {
+    const badUrl = 'https://teams.microsoft.com/v2/#/meetingrecap?threadId=19%3ameeting_abc';
+    expect(() => parseTeamsUrl(badUrl)).toThrow('missing threadId, tenantId, or organizerId');
+  });
+
+  it('should return unknown URL formats as-is', () => {
+    const unknownUrl = 'https://example.com/some-meeting';
+    expect(parseTeamsUrl(unknownUrl)).toBe(unknownUrl);
+  });
+
+  it('should handle recap URL with mixed case meetingRecap', () => {
+    const recapUrl =
+      'https://teams.microsoft.com/v2/#/meetingRecap?threadId=19%3ameeting_x%40thread.v2&tenantId=t1&organizerId=o1';
+    const result = parseTeamsUrl(recapUrl);
+    expect(result).toContain('/l/meetup-join/');
+  });
+});

--- a/test/tool-filtering.test.ts
+++ b/test/tool-filtering.test.ts
@@ -51,7 +51,8 @@ describe('Tool Filtering', () => {
   it('should register all tools when no filter is provided', () => {
     registerGraphTools(server, graphClient, false);
 
-    expect(toolSpy).toHaveBeenCalledTimes(5);
+    // 5 mocked endpoints + 1 parse-teams-url utility tool
+    expect(toolSpy).toHaveBeenCalledTimes(6);
     expect(toolSpy).toHaveBeenCalledWith(
       'list-mail-messages',
       expect.any(String),
@@ -132,7 +133,8 @@ describe('Tool Filtering', () => {
   it('should handle invalid regex patterns gracefully', () => {
     registerGraphTools(server, graphClient, false, '[invalid regex');
 
-    expect(toolSpy).toHaveBeenCalledTimes(5);
+    // 5 mocked endpoints + 1 parse-teams-url utility tool (no filter applied on invalid regex)
+    expect(toolSpy).toHaveBeenCalledTimes(6);
   });
 
   it('should combine read-only and filtering correctly', () => {


### PR DESCRIPTION
## Summary

- Add `parse-teams-url` tool that converts any Teams meeting URL format into a standard `joinWebUrl`
- Supports 3 formats: short `/meet/` URLs, full `/meetup-join/` URLs, and recap `?threadId=` URLs
- Pure utility (no Graph API call) — helps LLMs normalize URLs before calling `list-online-meetings`
- New module: `src/lib/teams-url-parser.ts`
- 7 unit tests in `test/teams-url-parser.test.ts`

No new permissions required.

## Test plan

- [x] `npm run verify` passes (lint + build + 81 tests)
- [ ] Test with all 3 URL formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)