### PR TITLE
feat: add save-meeting-recap orchestration tool

### DIFF
--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'url';
 import { TOOL_CATEGORIES } from './tool-categories.js';
 import { getRequestTokens } from './request-context.js';
 import { parseTeamsUrl } from './lib/teams-url-parser.js';
+import { parseVtt, transcriptToMarkdown } from './lib/vtt-parser.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -684,6 +685,204 @@ export function registerGraphTools(
       registeredCount++;
     } catch (error) {
       logger.error(`Failed to register tool parse-teams-url: ${(error as Error).message}`);
+      failedCount++;
+    }
+  }
+
+  // Register get-meeting-transcript-markdown tool (Graph + VTT parsing)
+  if (!enabledToolsRegex || enabledToolsRegex.test('get-meeting-transcript-markdown')) {
+    try {
+      server.tool(
+        'get-meeting-transcript-markdown',
+        'Retrieves a meeting transcript and converts it from WebVTT to readable Markdown with speaker names, timestamps, and participant list. Requires onlineMeeting-id and callTranscript-id. For recurring meetings, use list-meeting-transcripts first to pick the right transcript by createdDateTime.',
+        {
+          'onlineMeeting-id': z.string().describe('Meeting ID from list-online-meetings'),
+          'callTranscript-id': z.string().describe('Transcript ID from list-meeting-transcripts'),
+        },
+        {
+          title: 'get-meeting-transcript-markdown',
+          readOnlyHint: true,
+          openWorldHint: true,
+        },
+        async (params) => {
+          try {
+            const meetingId = params['onlineMeeting-id'];
+            const transcriptId = params['callTranscript-id'];
+            const endpoint = `/me/onlineMeetings/${encodeURIComponent(meetingId)}/transcripts/${encodeURIComponent(transcriptId)}/content`;
+
+            const response = await graphClient.graphRequest(endpoint, {
+              method: 'GET',
+              headers: { Accept: 'text/vtt' },
+              rawResponse: true,
+            });
+
+            const responseText = response?.content?.[0]?.text ?? '';
+            let vttContent: string;
+            try {
+              const parsed = JSON.parse(responseText);
+              vttContent = parsed.rawResponse ?? responseText;
+            } catch {
+              vttContent = responseText;
+            }
+
+            const entries = parseVtt(vttContent);
+            const markdown = transcriptToMarkdown(entries);
+            return { content: [{ type: 'text' as const, text: markdown }] };
+          } catch (error) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: JSON.stringify({ error: (error as Error).message }),
+                },
+              ],
+              isError: true,
+            };
+          }
+        }
+      );
+      registeredCount++;
+    } catch (error) {
+      logger.error(
+        `Failed to register tool get-meeting-transcript-markdown: ${(error as Error).message}`
+      );
+      failedCount++;
+    }
+  }
+
+  // Register save-meeting-recap orchestration tool
+  if (!enabledToolsRegex || enabledToolsRegex.test('save-meeting-recap')) {
+    try {
+      server.tool(
+        'save-meeting-recap',
+        'End-to-end meeting recap: takes any Teams meeting URL, finds the meeting, fetches the transcript, converts to Markdown, and optionally saves to OneDrive. Combines parse-teams-url + list-online-meetings + list-meeting-transcripts + get-meeting-transcript-markdown into a single call.',
+        {
+          url: z
+            .string()
+            .describe('Teams meeting URL (any format: /meet/, /meetup-join/, or recap)'),
+          transcriptIndex: z
+            .number()
+            .optional()
+            .default(0)
+            .describe(
+              'Which transcript to use (0=most recent). For recurring meetings with multiple transcripts.'
+            ),
+          savePath: z
+            .string()
+            .optional()
+            .describe(
+              'OneDrive path to save the recap, e.g. "Meeting Recaps/weekly-2026-03-20.md". If omitted, returns Markdown without saving.'
+            ),
+        },
+        {
+          title: 'save-meeting-recap',
+          readOnlyHint: false,
+          openWorldHint: true,
+        },
+        async (params) => {
+          try {
+            // Step 1: Parse the Teams URL into a joinWebUrl
+            const joinWebUrl = parseTeamsUrl(params.url);
+
+            // Step 2: Find the meeting by joinWebUrl
+            const meetingsResponse = await graphClient.graphRequest(
+              `/me/onlineMeetings?$filter=joinWebUrl eq '${joinWebUrl}'`,
+              { method: 'GET' }
+            );
+            const meetingsText = meetingsResponse?.content?.[0]?.text ?? '{}';
+            const meetingsData = JSON.parse(meetingsText);
+            const meetings = meetingsData.value ?? [];
+            if (meetings.length === 0) {
+              return {
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: JSON.stringify({
+                      error:
+                        'No meeting found for this URL. Verify the URL is correct and you are the organizer or a participant.',
+                    }),
+                  },
+                ],
+                isError: true,
+              };
+            }
+            const meetingId = meetings[0].id;
+
+            // Step 3: List transcripts for the meeting
+            const transcriptsResponse = await graphClient.graphRequest(
+              `/me/onlineMeetings/${encodeURIComponent(meetingId)}/transcripts?$orderby=createdDateTime desc`,
+              { method: 'GET' }
+            );
+            const transcriptsText = transcriptsResponse?.content?.[0]?.text ?? '{}';
+            const transcriptsData = JSON.parse(transcriptsText);
+            const transcripts = transcriptsData.value ?? [];
+            if (transcripts.length === 0) {
+              return {
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: JSON.stringify({
+                      error:
+                        'No transcripts found for this meeting. Ensure transcription was enabled during the meeting.',
+                    }),
+                  },
+                ],
+                isError: true,
+              };
+            }
+            const transcriptIndex = Math.min(params.transcriptIndex ?? 0, transcripts.length - 1);
+            const transcriptId = transcripts[transcriptIndex].id;
+
+            // Step 4: Fetch VTT content and convert to Markdown
+            const vttResponse = await graphClient.graphRequest(
+              `/me/onlineMeetings/${encodeURIComponent(meetingId)}/transcripts/${encodeURIComponent(transcriptId)}/content`,
+              { method: 'GET', headers: { Accept: 'text/vtt' }, rawResponse: true }
+            );
+            const vttText = vttResponse?.content?.[0]?.text ?? '';
+            let vttContent: string;
+            try {
+              const parsed = JSON.parse(vttText);
+              vttContent = parsed.rawResponse ?? vttText;
+            } catch {
+              vttContent = vttText;
+            }
+            const entries = parseVtt(vttContent);
+            const markdown = transcriptToMarkdown(entries);
+
+            // Step 5: Optionally save to OneDrive
+            if (params.savePath) {
+              await graphClient.graphRequest(`/me/drive/root:/${params.savePath}:/content`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'text/plain' },
+                body: markdown,
+              });
+              return {
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: `Recap saved to OneDrive: ${params.savePath}\n\n${markdown}`,
+                  },
+                ],
+              };
+            }
+
+            return { content: [{ type: 'text' as const, text: markdown }] };
+          } catch (error) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: JSON.stringify({ error: (error as Error).message }),
+                },
+              ],
+              isError: true,
+            };
+          }
+        }
+      );
+      registeredCount++;
+    } catch (error) {
+      logger.error(`Failed to register tool save-meeting-recap: ${(error as Error).message}`);
       failedCount++;
     }
   }

--- a/src/lib/vtt-parser.ts
+++ b/src/lib/vtt-parser.ts
@@ -1,0 +1,50 @@
+/**
+ * Parses WebVTT transcript content from Microsoft Teams into structured entries
+ * and converts them to readable Markdown.
+ */
+
+export interface TranscriptEntry {
+  startTime: string;
+  endTime: string;
+  speaker: string;
+  text: string;
+}
+
+export function parseVtt(vttContent: string): TranscriptEntry[] {
+  const entries: TranscriptEntry[] = [];
+  const blocks = vttContent.split(/\n\n+/);
+
+  for (const block of blocks) {
+    const timeMatch = block.match(/(\d+:\d+:\d+[\d.]*)\s*-->\s*(\d+:\d+:\d+[\d.]*)/);
+    const speakerMatch = block.match(/<v\s+([^>]+)>([^<]*)<\/v>/);
+    if (timeMatch && speakerMatch) {
+      entries.push({
+        startTime: timeMatch[1],
+        endTime: timeMatch[2],
+        speaker: speakerMatch[1].trim(),
+        text: speakerMatch[2].trim(),
+      });
+    }
+  }
+  return entries;
+}
+
+export function transcriptToMarkdown(entries: TranscriptEntry[]): string {
+  if (entries.length === 0) {
+    return '_No transcript entries found._';
+  }
+
+  const participants = [...new Set(entries.map((e) => e.speaker))];
+  let md = `## Participants\n\n${participants.map((p) => `- ${p}`).join('\n')}\n\n`;
+  md += `## Transcription\n\n`;
+
+  let lastSpeaker = '';
+  for (const entry of entries) {
+    if (entry.speaker !== lastSpeaker) {
+      md += `\n**${entry.speaker}** _(${entry.startTime})_\n\n`;
+      lastSpeaker = entry.speaker;
+    }
+    md += `${entry.text} `;
+  }
+  return md.trim();
+}

--- a/test/calendar-view.test.ts
+++ b/test/calendar-view.test.ts
@@ -138,7 +138,12 @@ describe('Calendar View Tools', () => {
       for (const call of mockServer.tool.mock.calls) {
         const toolName = call[0] as string;
         // Skip utility tools that are not Graph API endpoints
-        if (toolName === 'parse-teams-url') continue;
+        if (
+          ['parse-teams-url', 'get-meeting-transcript-markdown', 'save-meeting-recap'].includes(
+            toolName
+          )
+        )
+          continue;
         const paramSchema = call[2] as Record<string, z.ZodTypeAny>;
         expect(paramSchema).toHaveProperty('fetchAllPages');
       }

--- a/test/read-only.test.ts
+++ b/test/read-only.test.ts
@@ -71,8 +71,8 @@ describe('Read-Only Mode', () => {
 
     registerGraphTools(mockServer, {} as GraphClient, options.readOnly);
 
-    // 1 GET endpoint + 1 parse-teams-url utility tool
-    expect(mockServer.tool).toHaveBeenCalledTimes(2);
+    // 1 GET endpoint + 3 utility tools
+    expect(mockServer.tool).toHaveBeenCalledTimes(4);
 
     const toolCalls = mockServer.tool.mock.calls.map((call: unknown[]) => call[0]);
     expect(toolCalls).toContain('list-mail-messages');
@@ -88,8 +88,8 @@ describe('Read-Only Mode', () => {
 
     registerGraphTools(mockServer, {} as GraphClient, options.readOnly);
 
-    // 3 mocked endpoints + 1 parse-teams-url utility tool
-    expect(mockServer.tool).toHaveBeenCalledTimes(4);
+    // 3 mocked endpoints + 3 utility tools
+    expect(mockServer.tool).toHaveBeenCalledTimes(6);
 
     const toolCalls = mockServer.tool.mock.calls.map((call: unknown[]) => call[0]);
     expect(toolCalls).toContain('list-mail-messages');

--- a/test/tool-filtering.test.ts
+++ b/test/tool-filtering.test.ts
@@ -51,8 +51,8 @@ describe('Tool Filtering', () => {
   it('should register all tools when no filter is provided', () => {
     registerGraphTools(server, graphClient, false);
 
-    // 5 mocked endpoints + 1 parse-teams-url utility tool
-    expect(toolSpy).toHaveBeenCalledTimes(6);
+    // 5 mocked endpoints + 3 utility tools
+    expect(toolSpy).toHaveBeenCalledTimes(8);
     expect(toolSpy).toHaveBeenCalledWith(
       'list-mail-messages',
       expect.any(String),
@@ -133,8 +133,8 @@ describe('Tool Filtering', () => {
   it('should handle invalid regex patterns gracefully', () => {
     registerGraphTools(server, graphClient, false, '[invalid regex');
 
-    // 5 mocked endpoints + 1 parse-teams-url utility tool (no filter applied on invalid regex)
-    expect(toolSpy).toHaveBeenCalledTimes(6);
+    // 5 mocked endpoints + 3 utility tools (no filter on invalid regex)
+    expect(toolSpy).toHaveBeenCalledTimes(8);
   });
 
   it('should combine read-only and filtering correctly', () => {

--- a/test/vtt-parser.test.ts
+++ b/test/vtt-parser.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { parseVtt, transcriptToMarkdown } from '../src/lib/vtt-parser.js';
+
+const SAMPLE_VTT = `WEBVTT
+
+0:0:0.0 --> 0:0:8.840
+<v Marc Bourget>Bonjour tout le monde, on commence le standup.</v>
+
+0:0:8.840 --> 0:0:15.120
+<v Clara Dupont>Oui, j'ai terminé le déploiement du WAF hier.</v>
+
+0:0:15.120 --> 0:0:22.500
+<v Marc Bourget>Parfait. Et pour le monitoring?</v>
+
+0:0:22.500 --> 0:0:30.0
+<v Clara Dupont>C'est en cours, je devrais finir aujourd'hui.</v>`;
+
+describe('parseVtt', () => {
+  it('should parse VTT content into structured entries', () => {
+    const entries = parseVtt(SAMPLE_VTT);
+    expect(entries).toHaveLength(4);
+    expect(entries[0]).toEqual({
+      startTime: '0:0:0.0',
+      endTime: '0:0:8.840',
+      speaker: 'Marc Bourget',
+      text: 'Bonjour tout le monde, on commence le standup.',
+    });
+  });
+
+  it('should handle accented characters in speaker names', () => {
+    const vtt = `WEBVTT
+
+0:0:0.0 --> 0:0:5.0
+<v José García>Hola a todos.</v>`;
+    const entries = parseVtt(vtt);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].speaker).toBe('José García');
+  });
+
+  it('should return empty array for invalid VTT', () => {
+    expect(parseVtt('')).toEqual([]);
+    expect(parseVtt('not a vtt file')).toEqual([]);
+  });
+
+  it('should skip the WEBVTT header block', () => {
+    const entries = parseVtt(SAMPLE_VTT);
+    expect(entries.every((e) => e.speaker !== '')).toBe(true);
+  });
+});
+
+describe('transcriptToMarkdown', () => {
+  it('should produce Markdown with participants and transcription', () => {
+    const entries = parseVtt(SAMPLE_VTT);
+    const md = transcriptToMarkdown(entries);
+
+    expect(md).toContain('## Participants');
+    expect(md).toContain('- Marc Bourget');
+    expect(md).toContain('- Clara Dupont');
+    expect(md).toContain('## Transcription');
+  });
+
+  it('should consolidate consecutive entries from the same speaker', () => {
+    const entries = parseVtt(SAMPLE_VTT);
+    const md = transcriptToMarkdown(entries);
+
+    // Marc Bourget speaks at 0:0:0.0 and 0:0:15.120 (not consecutive)
+    // so his name should appear twice as a header
+    const marcHeaders = md.match(/\*\*Marc Bourget\*\*/g);
+    expect(marcHeaders).toHaveLength(2);
+
+    // Clara Dupont speaks at 0:0:8.840 and 0:0:22.500 (not consecutive)
+    const claraHeaders = md.match(/\*\*Clara Dupont\*\*/g);
+    expect(claraHeaders).toHaveLength(2);
+  });
+
+  it('should consolidate truly consecutive same-speaker entries', () => {
+    const vtt = `WEBVTT
+
+0:0:0.0 --> 0:0:5.0
+<v Alice>First sentence.</v>
+
+0:0:5.0 --> 0:0:10.0
+<v Alice>Second sentence.</v>
+
+0:0:10.0 --> 0:0:15.0
+<v Bob>My turn.</v>`;
+
+    const entries = parseVtt(vtt);
+    const md = transcriptToMarkdown(entries);
+
+    // Alice should appear only once as header
+    const aliceHeaders = md.match(/\*\*Alice\*\*/g);
+    expect(aliceHeaders).toHaveLength(1);
+    expect(md).toContain('First sentence. Second sentence.');
+  });
+
+  it('should return placeholder for empty entries', () => {
+    const md = transcriptToMarkdown([]);
+    expect(md).toContain('No transcript entries found');
+  });
+});


### PR DESCRIPTION
## Summary

- Add \`save-meeting-recap\` tool: end-to-end meeting recap from any Teams URL
- Workflow: parse URL → find meeting → list transcripts → fetch VTT → convert to Markdown → optionally upload to OneDrive
- Single tool call replaces 5-step manual workflow

Includes \`parse-teams-url\` and \`get-meeting-transcript-markdown\` as prerequisites.

**Depends on**: #282 (parse-teams-url) and #283 (transcript-markdown) — this PR includes their code and should be merged after them, or standalone if preferred.

**New permission**: \`Files.ReadWrite\` (delegated, optional — only needed for OneDrive upload)

## Test plan

- [x] \`npm run verify\` passes (lint + build + 89 tests)
- [ ] Test full workflow: Teams recap URL → Markdown output
- [ ] Test OneDrive save path

🤖 Generated with [Claude Code](https://claude.com/claude-code)