### PR TITLE
feat: add get-planner-task-details endpoint (#290)

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -496,6 +496,12 @@
   },
   {
     "pathPattern": "/planner/tasks/{plannerTask-id}/details",
+    "method": "get",
+    "toolName": "get-planner-task-details",
+    "scopes": ["Tasks.Read"]
+  },
+  {
+    "pathPattern": "/planner/tasks/{plannerTask-id}/details",
     "method": "patch",
     "toolName": "update-planner-task-details",
     "scopes": ["Tasks.ReadWrite"]


### PR DESCRIPTION
Adds GET /planner/tasks/{id}/details so users can retrieve the taskDetails ETag needed for update-planner-task-details.