### PR TITLE
Add Teams tag management endpoints (teamworkTag)

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -633,6 +633,62 @@
     "workScopes": ["TeamMember.Read.All"]
   },
   {
+    "pathPattern": "/teams/{team-id}/tags",
+    "method": "get",
+    "toolName": "list-team-tags",
+    "workScopes": ["TeamworkTag.Read.All"],
+    "llmTip": "List all tags in a team. Returns tag id, displayName, memberCount, and tagType (standard or scheduled). Use list-joined-teams to find the team ID first."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/tags",
+    "method": "post",
+    "toolName": "create-team-tag",
+    "workScopes": ["TeamworkTag.ReadWrite.All"],
+    "llmTip": "Create a new tag in a team. Body requires displayName (max 40 chars) and an optional members array (max 25 at creation, each with a userId). Use list-team-members to find user IDs. Add more members individually with add-team-tag-member after creation."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/tags/{teamworkTag-id}",
+    "method": "get",
+    "toolName": "get-team-tag",
+    "workScopes": ["TeamworkTag.Read.All"],
+    "llmTip": "Get details of a specific tag including displayName, memberCount, and tagType. Use list-team-tags to find the tag ID."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/tags/{teamworkTag-id}",
+    "method": "patch",
+    "toolName": "update-team-tag",
+    "workScopes": ["TeamworkTag.ReadWrite.All"],
+    "llmTip": "Update a tag's displayName (max 40 chars). Use list-team-tags to find the tag ID."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/tags/{teamworkTag-id}",
+    "method": "delete",
+    "toolName": "delete-team-tag",
+    "workScopes": ["TeamworkTag.ReadWrite.All"],
+    "llmTip": "Permanently delete a tag from a team. This action is irreversible. Use list-team-tags to find the tag ID."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/tags/{teamworkTag-id}/members",
+    "method": "get",
+    "toolName": "list-team-tag-members",
+    "workScopes": ["TeamworkTag.Read.All"],
+    "llmTip": "List all members of a specific tag. Returns member id, displayName, tenantId, and userId. Use list-team-tags to find the tag ID."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/tags/{teamworkTag-id}/members",
+    "method": "post",
+    "toolName": "add-team-tag-member",
+    "workScopes": ["TeamworkTag.ReadWrite.All"],
+    "llmTip": "Add a member to an existing tag. Body requires userId. Use list-team-members to find the user ID. Max 200 members per tag. Note: this operation requires application permissions (delegated not supported)."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/tags/{teamworkTag-id}/members/{teamworkTagMember-id}",
+    "method": "delete",
+    "toolName": "remove-team-tag-member",
+    "workScopes": ["TeamworkTag.ReadWrite.All"],
+    "llmTip": "Remove a member from a tag. Use list-team-tag-members to find the member ID."
+  },
+  {
     "pathPattern": "/chats/{chat-id}/messages/{chatMessage-id}/replies",
     "method": "get",
     "toolName": "list-chat-message-replies",


### PR DESCRIPTION
## Summary

- Adds 8 new Microsoft Graph API endpoints for managing **Teams tags** (`teamworkTag` resource)
- All endpoints use **GA v1.0** paths — no beta APIs
- Includes LLM tips for discoverability and usage guidance

## New Endpoints

| Tool Name | Method | Graph API Path | Permission |
|-----------|--------|---------------|------------|
| `list-team-tags` | GET | `/teams/{team-id}/tags` | `TeamworkTag.Read.All` |
| `create-team-tag` | POST | `/teams/{team-id}/tags` | `TeamworkTag.ReadWrite.All` |
| `get-team-tag` | GET | `/teams/{team-id}/tags/{teamworkTag-id}` | `TeamworkTag.Read.All` |
| `update-team-tag` | PATCH | `/teams/{team-id}/tags/{teamworkTag-id}` | `TeamworkTag.ReadWrite.All` |
| `delete-team-tag` | DELETE | `/teams/{team-id}/tags/{teamworkTag-id}` | `TeamworkTag.ReadWrite.All` |
| `list-team-tag-members` | GET | `/teams/{team-id}/tags/{teamworkTag-id}/members` | `TeamworkTag.Read.All` |
| `add-team-tag-member` | POST | `/teams/{team-id}/tags/{teamworkTag-id}/members` | `TeamworkTag.ReadWrite.All` |
| `remove-team-tag-member` | DELETE | `/teams/{team-id}/tags/{teamworkTag-id}/members/{teamworkTagMember-id}` | `TeamworkTag.ReadWrite.All` |

## Why

Teams tags are used to @mention groups of users (e.g., `@Sales`, `@Support`). The Graph API has supported tag CRUD since v1.0, but these endpoints were missing from the MCP server.

## Constraints (from MS Graph docs)

- Tag `displayName`: max 40 characters
- Members per tag: max 200
- Members at creation: max 25 (add more individually after)
- `add-team-tag-member` requires **application-only** permissions (delegated not supported)

## References

- [teamworkTag resource](https://learn.microsoft.com/en-us/graph/api/resources/teamworktag?view=graph-rest-1.0)
- [teamworkTagMember resource](https://learn.microsoft.com/en-us/graph/api/resources/teamworktagmember?view=graph-rest-1.0)

## Test plan

- [x] Build succeeds (`npm run build`)
- [x] 8 new endpoint entries confirmed in `dist/endpoints.json`
- [x] Existing tests unaffected (pre-existing failures only)
- [ ] Manual verification: start server with `--org-mode`, call `list-team-tags` against a real team

🤖 Generated with [Claude Code](https://claude.com/claude-code)