### PR TITLE
fix: OData param encoding, kebab-case path params, spec-gap llmTips

### DIFF
--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -19,7 +19,11 @@ vi.mock('../logger.js', () => ({
 // Mock the generated client — we supply our own endpoint definitions per test
 const mockEndpoints: any[] = [];
 vi.mock('../generated/client.js', () => ({
-  api: { get endpoints() { return mockEndpoints; } },
+  api: {
+    get endpoints() {
+      return mockEndpoints;
+    },
+  },
 }));
 
 // Mock endpoints.json — we supply our own config per test
@@ -103,7 +107,10 @@ async function loadModule() {
 
 /** Minimal McpServer mock that captures registered tools */
 function createMockServer() {
-  const tools = new Map<string, { description: string; schema: any; handler: Function }>();
+  const tools = new Map<
+    string,
+    { description: string; schema: any; handler: (...args: any[]) => any }
+  >();
   return {
     tool: vi.fn(
       (
@@ -111,7 +118,7 @@ function createMockServer() {
         description: string,
         schema: any,
         annotations: any,
-        handler: Function
+        handler: (...args: any[]) => any
       ) => {
         tools.set(name, { description, schema, handler });
       }
@@ -154,7 +161,7 @@ describe('graph-tools', () => {
       expect(graphClient.graphRequest).toHaveBeenCalledTimes(1);
       const [url] = graphClient.graphRequest.mock.calls[0];
       // $count=true should appear in query string
-      expect(url).toContain('%24count=true');
+      expect(url).toContain('$count=true');
     });
   });
 
@@ -289,9 +296,7 @@ describe('graph-tools', () => {
       const endpoint = makeEndpoint({
         alias: 'download-file',
         path: '/me/drive/items/:driveItem-id/content',
-        parameters: [
-          { name: 'driveItem-id', type: 'Path', schema: z.string() },
-        ],
+        parameters: [{ name: 'driveItem-id', type: 'Path', schema: z.string() }],
       });
       const config = makeConfig({
         toolName: 'download-file',
@@ -376,9 +381,7 @@ describe('graph-tools', () => {
         alias: 'get-mail-message2',
         method: 'get',
         path: '/me/messages/:messageId',
-        parameters: [
-          { name: 'messageId', type: 'Path', schema: z.string() },
-        ],
+        parameters: [{ name: 'messageId', type: 'Path', schema: z.string() }],
       });
       const config = makeConfig({
         toolName: 'get-mail-message2',

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -110,13 +110,15 @@
     "pathPattern": "/me/messages/{message-id}",
     "method": "delete",
     "toolName": "delete-mail-message",
-    "scopes": ["Mail.ReadWrite"]
+    "scopes": ["Mail.ReadWrite"],
+    "llmTip": "Soft delete — moves to Deleted Items. To permanently delete, delete again from Deleted Items."
   },
   {
     "pathPattern": "/me/messages/{message-id}/move",
     "method": "post",
     "toolName": "move-mail-message",
-    "scopes": ["Mail.ReadWrite"]
+    "scopes": ["Mail.ReadWrite"],
+    "llmTip": "destinationId accepts folder ID or well-known name (inbox, drafts, sentitems, deleteditems, junkemail, archive)."
   },
   {
     "pathPattern": "/me/messages/{message-id}",
@@ -128,7 +130,8 @@
     "pathPattern": "/me/messages/{message-id}/attachments",
     "method": "post",
     "toolName": "add-mail-attachment",
-    "scopes": ["Mail.ReadWrite"]
+    "scopes": ["Mail.ReadWrite"],
+    "llmTip": "Max 3MB. Body requires @odata.type: {\"@odata.type\": \"#microsoft.graph.fileAttachment\", \"name\": \"file.pdf\", \"contentBytes\": \"<base64>\"}."
   },
   {
     "pathPattern": "/me/messages/{message-id}/attachments",
@@ -192,7 +195,8 @@
     "pathPattern": "/me/messages/{message-id}/send",
     "method": "post",
     "toolName": "send-draft-message",
-    "scopes": ["Mail.Send"]
+    "scopes": ["Mail.Send"],
+    "llmTip": "No request body needed — just call with the message ID. Draft must exist in Drafts folder."
   },
   {
     "pathPattern": "/me/events",
@@ -200,7 +204,8 @@
     "toolName": "list-calendar-events",
     "scopes": ["Calendars.Read"],
     "supportsTimezone": true,
-    "supportsExpandExtendedProperties": true
+    "supportsExpandExtendedProperties": true,
+    "llmTip": "WARNING: Does NOT expand recurring events — only returns seriesMaster. Use get-calendar-view instead to see individual occurrences within a date range."
   },
   {
     "pathPattern": "/me/events/{event-id}",
@@ -222,13 +227,14 @@
     "method": "patch",
     "toolName": "update-calendar-event",
     "scopes": ["Calendars.ReadWrite"],
-    "llmTip": "CRITICAL: Do not try to guess the email address of the recipients. Use the list-users tool to find the email address of the recipients."
+    "llmTip": "CRITICAL: Do not try to guess the email address of the recipients. Use the list-users tool to find the email address of the recipients. WARNING: Setting attendees replaces the entire attendee list — include all attendees, not just new ones."
   },
   {
     "pathPattern": "/me/events/{event-id}",
     "method": "delete",
     "toolName": "delete-calendar-event",
-    "scopes": ["Calendars.ReadWrite"]
+    "scopes": ["Calendars.ReadWrite"],
+    "llmTip": "Deleting a seriesMaster deletes ALL occurrences of the recurring event. To cancel a single occurrence, delete that specific instance ID from list-calendar-event-instances."
   },
   {
     "pathPattern": "/me/calendars/{calendar-id}/events",
@@ -236,7 +242,8 @@
     "toolName": "list-specific-calendar-events",
     "scopes": ["Calendars.Read"],
     "supportsTimezone": true,
-    "supportsExpandExtendedProperties": true
+    "supportsExpandExtendedProperties": true,
+    "llmTip": "WARNING: Does NOT expand recurring events — only returns seriesMaster. Use get-specific-calendar-view instead."
   },
   {
     "pathPattern": "/me/calendars/{calendar-id}/events/{event-id}",
@@ -258,13 +265,14 @@
     "method": "patch",
     "toolName": "update-specific-calendar-event",
     "scopes": ["Calendars.ReadWrite"],
-    "llmTip": "CRITICAL: Do not try to guess the email address of the recipients. Use the list-users tool to find the email address of the recipients."
+    "llmTip": "CRITICAL: Do not try to guess the email address of the recipients. Use the list-users tool to find the email address of the recipients. WARNING: Setting attendees replaces the entire attendee list — include all attendees, not just new ones."
   },
   {
     "pathPattern": "/me/calendars/{calendar-id}/events/{event-id}",
     "method": "delete",
     "toolName": "delete-specific-calendar-event",
-    "scopes": ["Calendars.ReadWrite"]
+    "scopes": ["Calendars.ReadWrite"],
+    "llmTip": "Deleting a seriesMaster deletes ALL occurrences. To cancel a single occurrence, use the specific instance ID."
   },
   {
     "pathPattern": "/me/calendarView",
@@ -334,7 +342,8 @@
     "method": "get",
     "toolName": "download-onedrive-file-content",
     "scopes": ["Files.Read"],
-    "returnDownloadUrl": true
+    "returnDownloadUrl": true,
+    "llmTip": "Returns a temporary download URL, NOT the file content directly."
   },
   {
     "pathPattern": "/drives/{drive-id}/items/{driveItem-id}",
@@ -346,7 +355,8 @@
     "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/content",
     "method": "put",
     "toolName": "upload-file-content",
-    "scopes": ["Files.ReadWrite"]
+    "scopes": ["Files.ReadWrite"],
+    "llmTip": "Max 4MB. For new files use path format: /items/root:/path/to/file.txt:/content. Overwrites existing files without warning."
   },
   {
     "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/workbook/worksheets/{workbookWorksheet-id}/charts/add",
@@ -413,14 +423,16 @@
     "method": "post",
     "toolName": "create-onenote-page",
     "scopes": ["Notes.Create"],
-    "contentType": "text/html"
+    "contentType": "text/html",
+    "llmTip": "Body must be a full HTML document (with <html><head><title>...</title></head><body>...</body></html>). Partial HTML or plain text fails silently or creates malformed pages."
   },
   {
     "pathPattern": "/me/onenote/sections/{onenoteSection-id}/pages",
     "method": "post",
     "toolName": "create-onenote-section-page",
     "scopes": ["Notes.Create"],
-    "contentType": "text/html"
+    "contentType": "text/html",
+    "llmTip": "Body must be a full HTML document (with <html><head><title>...</title></head><body>...</body></html>). Partial HTML fails silently."
   },
   {
     "pathPattern": "/me/todo/lists",
@@ -465,7 +477,8 @@
     "pathPattern": "/me/planner/tasks",
     "method": "get",
     "toolName": "list-planner-tasks",
-    "scopes": ["Tasks.Read"]
+    "scopes": ["Tasks.Read"],
+    "llmTip": "Priority values: 0=Urgent, 1=Important, 3=Medium, 5=Low, 9=unset."
   },
   {
     "pathPattern": "/planner/plans/{plannerPlan-id}",
@@ -477,13 +490,15 @@
     "pathPattern": "/planner/plans/{plannerPlan-id}/tasks",
     "method": "get",
     "toolName": "list-plan-tasks",
-    "scopes": ["Tasks.Read"]
+    "scopes": ["Tasks.Read"],
+    "llmTip": "Priority values: 0=Urgent, 1=Important, 3=Medium, 5=Low, 9=unset."
   },
   {
     "pathPattern": "/planner/tasks/{plannerTask-id}",
     "method": "get",
     "toolName": "get-planner-task",
-    "scopes": ["Tasks.Read"]
+    "scopes": ["Tasks.Read"],
+    "llmTip": "Response includes @odata.etag — save it, required as If-Match header for update-planner-task. Use includeHeaders=true to capture it."
   },
   {
     "pathPattern": "/planner/tasks",
@@ -495,25 +510,29 @@
     "pathPattern": "/planner/tasks/{plannerTask-id}",
     "method": "patch",
     "toolName": "update-planner-task",
-    "scopes": ["Tasks.ReadWrite"]
+    "scopes": ["Tasks.ReadWrite"],
+    "llmTip": "CRITICAL: Requires If-Match header with the task's @odata.etag value, otherwise returns 412 Precondition Failed. Get the ETag from get-planner-task with includeHeaders=true. Priority values: 0=Urgent, 1=Important, 3=Medium, 5=Low, 9=unset."
   },
   {
     "pathPattern": "/planner/tasks/{plannerTask-id}/details",
     "method": "get",
     "toolName": "get-planner-task-details",
-    "scopes": ["Tasks.Read"]
+    "scopes": ["Tasks.Read"],
+    "llmTip": "Response includes @odata.etag — required for update-planner-task-details. Use includeHeaders=true."
   },
   {
     "pathPattern": "/planner/tasks/{plannerTask-id}/details",
     "method": "patch",
     "toolName": "update-planner-task-details",
-    "scopes": ["Tasks.ReadWrite"]
+    "scopes": ["Tasks.ReadWrite"],
+    "llmTip": "CRITICAL: Requires If-Match header with ETag from get-planner-task-details (use includeHeaders=true). Checklist items use GUID keys: {\"checklist\": {\"<guid>\": {\"title\": \"...\", \"isChecked\": false}}}."
   },
   {
     "pathPattern": "/me/contacts",
     "method": "get",
     "toolName": "list-outlook-contacts",
-    "scopes": ["Contacts.Read"]
+    "scopes": ["Contacts.Read"],
+    "llmTip": "$filter only supports startswith() — contains() and eq on emailAddresses do not work. Use $search as alternative for broader matching."
   },
   {
     "pathPattern": "/me/contacts/{contact-id}",
@@ -531,7 +550,8 @@
     "pathPattern": "/me/contacts/{contact-id}",
     "method": "patch",
     "toolName": "update-outlook-contact",
-    "scopes": ["Contacts.ReadWrite"]
+    "scopes": ["Contacts.ReadWrite"],
+    "llmTip": "emailAddresses array is replaced entirely — include all addresses, not just new ones."
   },
   {
     "pathPattern": "/me/contacts/{contact-id}",
@@ -573,7 +593,8 @@
     "pathPattern": "/chats/{chat-id}/messages",
     "method": "post",
     "toolName": "send-chat-message",
-    "workScopes": ["ChatMessage.Send"]
+    "workScopes": ["ChatMessage.Send"],
+    "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API."
   },
   {
     "pathPattern": "/me/joinedTeams",
@@ -615,13 +636,15 @@
     "pathPattern": "/teams/{team-id}/channels/{channel-id}/messages",
     "method": "post",
     "toolName": "send-channel-message",
-    "workScopes": ["ChannelMessage.Send"]
+    "workScopes": ["ChannelMessage.Send"],
+    "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API."
   },
   {
     "pathPattern": "/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies",
     "method": "post",
     "toolName": "reply-to-channel-message",
-    "workScopes": ["ChannelMessage.Send"]
+    "workScopes": ["ChannelMessage.Send"],
+    "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API."
   },
   {
     "pathPattern": "/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies",
@@ -645,7 +668,8 @@
     "pathPattern": "/chats/{chat-id}/messages/{chatMessage-id}/replies",
     "method": "post",
     "toolName": "reply-to-chat-message",
-    "workScopes": ["ChatMessage.Send"]
+    "workScopes": ["ChatMessage.Send"],
+    "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API."
   },
   {
     "pathPattern": "/sites",
@@ -699,13 +723,15 @@
     "pathPattern": "/sites/{site-id}/lists/{list-id}/items",
     "method": "get",
     "toolName": "list-sharepoint-site-list-items",
-    "workScopes": ["Sites.Read.All"]
+    "workScopes": ["Sites.Read.All"],
+    "llmTip": "Add $expand=fields to include actual column values. Without it, only metadata is returned."
   },
   {
     "pathPattern": "/sites/{site-id}/lists/{list-id}/items/{listItem-id}",
     "method": "get",
     "toolName": "get-sharepoint-site-list-item",
-    "workScopes": ["Sites.Read.All"]
+    "workScopes": ["Sites.Read.All"],
+    "llmTip": "Add $expand=fields to include actual column values. Without it, only metadata is returned."
   },
   {
     "pathPattern": "/sites/{site-id}/getByPath(path='{path}')",
@@ -770,18 +796,21 @@
     "pathPattern": "/groups/{group-id}/conversations",
     "method": "get",
     "toolName": "list-group-conversations",
-    "workScopes": ["Group.Read.All"]
+    "workScopes": ["Group.Read.All"],
+    "llmTip": "Legacy — Microsoft recommends Teams channels instead of group conversations."
   },
   {
     "pathPattern": "/groups/{group-id}/threads",
     "method": "get",
     "toolName": "list-group-threads",
-    "workScopes": ["Group.Read.All"]
+    "workScopes": ["Group.Read.All"],
+    "llmTip": "Legacy — Microsoft recommends Teams channels instead of group threads."
   },
   {
     "pathPattern": "/groups/{group-id}/threads/{conversationThread-id}/reply",
     "method": "post",
     "toolName": "reply-to-group-thread",
-    "workScopes": ["Group.ReadWrite.All"]
+    "workScopes": ["Group.ReadWrite.All"],
+    "llmTip": "Legacy — Microsoft recommends Teams channels instead of group threads."
   }
 ]

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -521,6 +521,58 @@ export function registerGraphTools(
         .optional();
     }
 
+    // Override OData parameter descriptions with spec-gap guidance
+    if (paramSchema['filter'] !== undefined || paramSchema['$filter'] !== undefined) {
+      const key = paramSchema['$filter'] !== undefined ? '$filter' : 'filter';
+      paramSchema[key] = z
+        .string()
+        .describe(
+          'OData filter expression. Add $count=true for advanced filters (flag/flagStatus, contains()). Cannot combine with $search.'
+        )
+        .optional();
+    }
+    if (paramSchema['search'] !== undefined || paramSchema['$search'] !== undefined) {
+      const key = paramSchema['$search'] !== undefined ? '$search' : 'search';
+      paramSchema[key] = z
+        .string()
+        .describe('KQL search query — wrap value in double quotes. Cannot combine with $filter.')
+        .optional();
+    }
+    if (paramSchema['select'] !== undefined || paramSchema['$select'] !== undefined) {
+      const key = paramSchema['$select'] !== undefined ? '$select' : 'select';
+      paramSchema[key] = z
+        .string()
+        .describe('Comma-separated fields to return, e.g. id,subject,from,receivedDateTime')
+        .optional();
+    }
+    if (paramSchema['orderby'] !== undefined || paramSchema['$orderby'] !== undefined) {
+      const key = paramSchema['$orderby'] !== undefined ? '$orderby' : 'orderby';
+      paramSchema[key] = z
+        .string()
+        .describe('Sort expression, e.g. receivedDateTime desc')
+        .optional();
+    }
+    if (paramSchema['top'] !== undefined || paramSchema['$top'] !== undefined) {
+      const key = paramSchema['$top'] !== undefined ? '$top' : 'top';
+      paramSchema[key] = z.number().describe('Max items per page').optional();
+    }
+    if (paramSchema['skip'] !== undefined || paramSchema['$skip'] !== undefined) {
+      const key = paramSchema['$skip'] !== undefined ? '$skip' : 'skip';
+      paramSchema[key] = z
+        .number()
+        .describe('Items to skip for pagination. Not supported with $search.')
+        .optional();
+    }
+    if (paramSchema['count'] !== undefined || paramSchema['$count'] !== undefined) {
+      const countKey = paramSchema['$count'] !== undefined ? '$count' : 'count';
+      paramSchema[countKey] = z
+        .boolean()
+        .describe(
+          'Set true to enable advanced query mode (ConsistencyLevel: eventual). Required for complex $filter on flag/flagStatus or contains().'
+        )
+        .optional();
+    }
+
     // Add account parameter for multi-account mode.
     // Layer 2: Account names are surfaced in the description (not as a strict enum) so the LLM
     // sees available accounts upfront without a round-trip, but accounts added mid-session via

--- a/test/calendar-view.test.ts
+++ b/test/calendar-view.test.ts
@@ -221,7 +221,7 @@ describe('Calendar View Tools', () => {
 
       const calledPath = (mockGraphClient.graphRequest as ReturnType<typeof vi.fn>).mock
         .calls[0][0] as string;
-      expect(calledPath).toContain('%24expand=singleValueExtendedProperties');
+      expect(calledPath).toContain('$expand=singleValueExtendedProperties');
     });
 
     it('should append to existing $expand when expandExtendedProperties is set', async () => {
@@ -237,7 +237,7 @@ describe('Calendar View Tools', () => {
 
       const calledPath = (mockGraphClient.graphRequest as ReturnType<typeof vi.fn>).mock
         .calls[0][0] as string;
-      expect(calledPath).toContain('%24expand=extensions%2CsingleValueExtendedProperties');
+      expect(calledPath).toContain('$expand=extensions,singleValueExtendedProperties');
     });
 
     it('should pass $top query parameter when provided', async () => {
@@ -252,7 +252,7 @@ describe('Calendar View Tools', () => {
 
       const calledPath = (mockGraphClient.graphRequest as ReturnType<typeof vi.fn>).mock
         .calls[0][0] as string;
-      expect(calledPath).toContain('%24top=50');
+      expect(calledPath).toContain('$top=50');
     });
 
     it('should call graphRequest with correct path for event instances', async () => {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   sourcemap: false,
   dts: false,
   publicDir: false,
-  onSuccess: 'chmod +x dist/index.js',
+  onSuccess: process.platform === 'win32' ? undefined : 'chmod +x dist/index.js',
   loader: {
     '.json': 'copy',
   },


### PR DESCRIPTION
Cherry-picked the good stuff from @RaoulJacobs' PRs #259 and #269. Thanks Raoul for the thorough work on these!

Bug fixes (from Raoul):
- Kebab-case path params now resolve correctly (message-id to messageId)
- Query param keys no longer URL-encoded ($filter was becoming %24filter)
- Commas preserved in OData values ($select=id,subject,from no longer breaks)
- Missing path params auto-injected into tool schema so LLMs know what to provide

On top of that:
- OData parameter descriptions with spec-gap info ($filter/$search can't combine, $count=true for advanced queries)
- 29 spec-gap-only llmTips, things like recurring calendar events not expanding, Planner ETag requirements, SharePoint needing $expand=fields, Teams requiring HTML contentType. Only tips that cover real API quirks missing from the spec, skipped anything an LLM would figure out on its own.
- Windows build fix (skip chmod on win32)

Intentionally left out the ImmutableId header change (too broad) and the guidance-style llmTips (body format examples, $select suggestions etc, just fills context).