### PR TITLE
fix: use delegated scopes for teamworkTag endpoints, remove app-only …

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -662,56 +662,49 @@
     "pathPattern": "/teams/{team-id}/tags",
     "method": "get",
     "toolName": "list-team-tags",
-    "workScopes": ["TeamworkTag.Read.All"],
+    "workScopes": ["TeamworkTag.Read"],
     "llmTip": "List all tags in a team. Returns tag id, displayName, memberCount, and tagType (standard or scheduled). Use list-joined-teams to find the team ID first."
   },
   {
     "pathPattern": "/teams/{team-id}/tags",
     "method": "post",
     "toolName": "create-team-tag",
-    "workScopes": ["TeamworkTag.ReadWrite.All"],
+    "workScopes": ["TeamworkTag.ReadWrite"],
     "llmTip": "Create a new tag in a team. Body requires displayName (max 40 chars) and an optional members array (max 25 at creation, each with a userId). Use list-team-members to find user IDs. Add more members individually with add-team-tag-member after creation."
   },
   {
     "pathPattern": "/teams/{team-id}/tags/{teamworkTag-id}",
     "method": "get",
     "toolName": "get-team-tag",
-    "workScopes": ["TeamworkTag.Read.All"],
+    "workScopes": ["TeamworkTag.Read"],
     "llmTip": "Get details of a specific tag including displayName, memberCount, and tagType. Use list-team-tags to find the tag ID."
   },
   {
     "pathPattern": "/teams/{team-id}/tags/{teamworkTag-id}",
     "method": "patch",
     "toolName": "update-team-tag",
-    "workScopes": ["TeamworkTag.ReadWrite.All"],
+    "workScopes": ["TeamworkTag.ReadWrite"],
     "llmTip": "Update a tag's displayName (max 40 chars). Use list-team-tags to find the tag ID."
   },
   {
     "pathPattern": "/teams/{team-id}/tags/{teamworkTag-id}",
     "method": "delete",
     "toolName": "delete-team-tag",
-    "workScopes": ["TeamworkTag.ReadWrite.All"],
+    "workScopes": ["TeamworkTag.ReadWrite"],
     "llmTip": "Permanently delete a tag from a team. This action is irreversible. Use list-team-tags to find the tag ID."
   },
   {
     "pathPattern": "/teams/{team-id}/tags/{teamworkTag-id}/members",
     "method": "get",
     "toolName": "list-team-tag-members",
-    "workScopes": ["TeamworkTag.Read.All"],
+    "workScopes": ["TeamworkTag.Read"],
     "llmTip": "List all members of a specific tag. Returns member id, displayName, tenantId, and userId. Use list-team-tags to find the tag ID."
-  },
-  {
-    "pathPattern": "/teams/{team-id}/tags/{teamworkTag-id}/members",
-    "method": "post",
-    "toolName": "add-team-tag-member",
-    "workScopes": ["TeamworkTag.ReadWrite.All"],
-    "llmTip": "Add a member to an existing tag. Body requires userId. Use list-team-members to find the user ID. Max 200 members per tag. Note: this operation requires application permissions (delegated not supported)."
   },
   {
     "pathPattern": "/teams/{team-id}/tags/{teamworkTag-id}/members/{teamworkTagMember-id}",
     "method": "delete",
     "toolName": "remove-team-tag-member",
-    "workScopes": ["TeamworkTag.ReadWrite.All"],
+    "workScopes": ["TeamworkTag.ReadWrite"],
     "llmTip": "Remove a member from a tag. Use list-team-tag-members to find the member ID."
   },
   {


### PR DESCRIPTION
…add-member

TeamworkTag.Read.All and TeamworkTag.ReadWrite.All are application-only permissions that fail with AADSTS650053 during device code flow login. Replaced with delegated equivalents (TeamworkTag.Read, TeamworkTag.ReadWrite).

Removed add-team-tag-member endpoint entirely as POST to tag members only supports application permissions per Microsoft Graph docs.

Fixes #293