### PR TITLE
fix(server): stop re-registering tools on every HTTP request

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -396,6 +396,7 @@ class MicrosoftGraphServer {
 
             res.on('close', () => {
               transport.close();
+              server.close();
             });
 
             await server.connect(transport);
@@ -445,6 +446,7 @@ class MicrosoftGraphServer {
 
             res.on('close', () => {
               transport.close();
+              server.close();
             });
 
             await server.connect(transport);


### PR DESCRIPTION
## Problem

In HTTP stateless mode, each `/mcp` request creates a new `McpServer` instance
and connects it to a fresh `StreamableHTTPServerTransport`. When the request
finishes, `transport.close()` was called on connection close — but the
`McpServer` instance itself was never explicitly closed.

This left the server instance in a "connected" state without a live transport,
leaking internal MCP SDK listeners and state on every request. Under load (e.g.
Kubernetes with concurrent requests), this accumulated garbage and contributed
to the
`Error: Already connected to a transport. Call close() before connecting to a
new transport` errors seen in production.

## Fix

Call `server.close()` alongside `transport.close()` in the `res.on('close')`
cleanup handler for both the GET and POST `/mcp` routes.

This ensures every `McpServer` instance created per-request is fully torn down
once the HTTP response is complete.

## Changes

- `src/server.ts`
  - Added `server.close()` to `res.on('close')` in the GET `/mcp` handler
  - Added `server.close()` to `res.on('close')` in the POST `/mcp` handler