### PR TITLE
feat: add user presence endpoints

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -947,7 +947,7 @@
     "pathPattern": "/me/presence",
     "method": "get",
     "toolName": "get-my-presence",
-    "scopes": ["Presence.Read"],
+    "workScopes": ["Presence.Read"],
     "llmTip": "Gets the current user's presence status. Returns availability (Available, Busy, DoNotDisturb, BeRightBack, Away, Offline) and activity (InACall, InAMeeting, Presenting, OutOfOffice, etc.). Useful to check your own status before scheduling."
   },
   {


### PR DESCRIPTION
## Summary
- Adds `get-my-presence`, `get-user-presence`, and `get-presences-by-user-id` endpoints
- New functional domain: user presence/availability status from Microsoft Teams
- Uses `Presence.Read` (own status) and `Presence.Read.All` (other users) delegated scopes
- Pure endpoints.json additions, no code changes

## Motivation
Presence endpoints allow checking user availability (Available, Busy, DoNotDisturb, Away, Offline) and activity (InACall, InAMeeting, Presenting, OutOfOffice). Useful for scheduling workflows and team availability dashboards. The batch endpoint (`get-presences-by-user-id`) supports up to 650 users per request.

## Test plan
- [ ] Verify all 3 new tools appear in the MCP tool list
- [ ] Test `get-my-presence` returns availability and activity
- [ ] Test `get-user-presence` with a valid user ID
- [ ] Test `get-presences-by-user-id` with multiple user IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)