### PR TITLE
feat: add transcript and recording metadata endpoints

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -772,7 +772,7 @@
     "pathPattern": "/me/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}",
     "method": "get",
     "toolName": "get-meeting-transcript",
-    "scopes": ["OnlineMeetingTranscript.Read.All"],
+    "workScopes": ["OnlineMeetingTranscript.Read.All"],
     "llmTip": "Gets metadata for a specific transcript: createdDateTime, contentCorrelationId (links transcript to its recording), meetingId, meetingOrganizer. Use contentCorrelationId to match a transcript with its recording. For the actual transcript text, use get-meeting-transcript-content instead."
   },
   {


### PR DESCRIPTION
## Summary
- Adds `get-meeting-transcript` and `get-meeting-recording` endpoints for metadata access
- Returns `createdDateTime`, `contentCorrelationId`, `meetingOrganizer` without downloading content
- `contentCorrelationId` links a transcript to its corresponding recording

## Motivation
Currently you can list transcripts/recordings and download their content, but there's no way to get metadata for a specific transcript or recording by ID. The `contentCorrelationId` field is key for correlating transcripts with their recordings in recurring meetings.

## Test plan
- [ ] Verify both tools appear in the MCP tool list
- [ ] Test `get-meeting-transcript` returns metadata with contentCorrelationId
- [ ] Test `get-meeting-recording` returns metadata with contentCorrelationId

🤖 Generated with [Claude Code](https://claude.com/claude-code)