### PR TITLE
feat: add list-chat-members endpoint

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -578,6 +578,14 @@
     "workScopes": ["Chat.Read"]
   },
   {
+    "pathPattern": "/chats/{chat-id}/members",
+    "method": "get",
+    "toolName": "list-chat-members",
+    "scopes": ["ChatMember.Read"],
+    "workScopes": ["ChatMember.Read"],
+    "llmTip": "Lists members of a chat. Each member has displayName, email, roles (owner/guest), and visibleHistoryStartDateTime. For meeting chats, use the chatInfo.threadId from get-online-meeting as the chat-id to see who participated in the meeting chat."
+  },
+  {
     "pathPattern": "/chats/{chat-id}/messages",
     "method": "get",
     "toolName": "list-chat-messages",


### PR DESCRIPTION
## Summary
- Adds `list-chat-members` endpoint to list members of a chat
- Returns displayName, email, roles (owner/guest), visibleHistoryStartDateTime
- Uses `ChatMember.Read` delegated scope
- llmTip explains how to use `chatInfo.threadId` from `get-online-meeting` to list meeting chat participants

## Motivation
Completes the chat API surface — currently you can list chats, get chat details, and read messages, but cannot list who is in a chat. Particularly useful for meeting chats where you want to know who was part of the conversation.

## Test plan
- [ ] Verify tool appears in the MCP tool list
- [ ] Test with a known chat-id returns member list with displayName and roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)