### PR TITLE
feat: add user org hierarchy, profile photo, and people endpoints

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -646,14 +646,14 @@
     "pathPattern": "/me/manager",
     "method": "get",
     "toolName": "get-my-manager",
-    "scopes": ["User.Read.All"],
+    "workScopes": ["User.Read.All"],
     "llmTip": "Gets the current user's manager. Returns a directoryObject with displayName, mail, jobTitle, id. Use the id to chain further queries (e.g. get their direct reports or presence)."
   },
   {
     "pathPattern": "/me/directReports",
     "method": "get",
     "toolName": "list-my-direct-reports",
-    "scopes": ["User.Read.All"],
+    "workScopes": ["User.Read.All"],
     "llmTip": "Lists users who report directly to the current user. Returns directoryObjects with displayName, mail, jobTitle, id. Useful for building org charts or sending team-wide communications."
   },
   {
@@ -690,7 +690,7 @@
     "pathPattern": "/me/people",
     "method": "get",
     "toolName": "list-relevant-people",
-    "scopes": ["People.Read"],
+    "workScopes": ["People.Read"],
     "llmTip": "Lists people most relevant to the current user, ordered by relevance. Based on communication patterns, collaboration, and business relationships. Each person has displayName, emailAddresses, jobTitle, department, officeLocation. Use $search to find specific people by name. Use $top to limit results."
   },
   {


### PR DESCRIPTION
## Summary
- Adds 7 new endpoints for user organization and discovery:
  - `get-my-manager` / `get-user-manager` — get manager for self or any user
  - `list-my-direct-reports` / `list-user-direct-reports` — list direct reports
  - `get-my-profile-photo` / `get-user-profile-photo` — retrieve profile photos
  - `list-relevant-people` — people most relevant to the current user
- Uses `User.Read.All`, `User.Read`, and `People.Read` delegated scopes
- Pure endpoints.json additions, no code changes

## Motivation
Enables org chart traversal and people discovery. The manager/directReports endpoints allow walking the org hierarchy, while the People API surfaces frequent collaborators. Profile photos support richer user displays.

## Test plan
- [ ] Verify all 7 tools appear in the MCP tool list
- [ ] Test `get-my-manager` returns manager with displayName and mail
- [ ] Test `list-my-direct-reports` returns direct reports
- [ ] Test `list-relevant-people` returns people ordered by relevance

🤖 Generated with [Claude Code](https://claude.com/claude-code)