### PR TITLE
feat: add channel files folder and OneDrive search endpoints

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -518,6 +518,14 @@
     "llmTip": "Lists version history of a file. Each version has id, lastModifiedDateTime, lastModifiedBy, and size. Use the version id with /versions/{id}/content to download a specific version."
   },
   {
+    "pathPattern": "/drives/{drive-id}/search(q='{q}')",
+    "method": "get",
+    "toolName": "search-onedrive-files",
+    "scopes": ["Files.Read"],
+    "skipEncoding": ["q"],
+    "llmTip": "Searches for files in a drive by name or content. The q parameter searches file names, metadata, and file content. Returns matching driveItems with id, name, webUrl, size, lastModifiedDateTime. Use list-drives first to get the drive-id."
+  },
+  {
     "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/workbook/worksheets/{workbookWorksheet-id}/charts/add",
     "method": "post",
     "toolName": "create-excel-chart",
@@ -1017,6 +1025,13 @@
     "method": "get",
     "toolName": "list-team-members",
     "workScopes": ["TeamMember.Read.All"]
+  },
+  {
+    "pathPattern": "/teams/{team-id}/channels/{channel-id}/filesFolder",
+    "method": "get",
+    "toolName": "get-channel-files-folder",
+    "workScopes": ["ChannelSettings.Read.All"],
+    "llmTip": "Gets the SharePoint driveItem (folder) that contains the files for a Teams channel. Returns id, name, webUrl, and parentReference with driveId. Use the driveId and id with OneDrive/SharePoint endpoints (list-folder-files) to browse and download channel files."
   },
   {
     "pathPattern": "/chats/{chat-id}/messages/{chatMessage-id}/replies",


### PR DESCRIPTION
## Summary
- Adds `get-channel-files-folder` — get the SharePoint driveItem backing a Teams channel's files tab
- Adds `search-onedrive-files` — search files by name or content within a drive
- Uses `ChannelSettings.Read.All`, `Files.Read`, and `Files.Read.All` delegated scopes
- Pure endpoints.json additions, no code changes

## Motivation
`get-channel-files-folder` bridges Teams channels to SharePoint/OneDrive — returns the driveId and folder id needed to browse channel files using existing drive endpoints. `search-onedrive-files` fills a gap in the drive API surface by enabling file search by name or content.

## Test plan
- [ ] Verify both tools appear in the MCP tool list
- [ ] Test `get-channel-files-folder` returns driveItem with driveId and webUrl
- [ ] Test `search-onedrive-files` returns matching files with name and webUrl

🤖 Generated with [Claude Code](https://claude.com/claude-code)