### PR TITLE
feat: add calendar event response endpoints

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -237,6 +237,27 @@
     "llmTip": "Deleting a seriesMaster deletes ALL occurrences of the recurring event. To cancel a single occurrence, delete that specific instance ID from list-calendar-event-instances."
   },
   {
+    "pathPattern": "/me/events/{event-id}/accept",
+    "method": "post",
+    "toolName": "accept-calendar-event",
+    "scopes": ["Calendars.ReadWrite"],
+    "llmTip": "Accepts a meeting invitation. Optional body: { sendResponse: true, comment: 'I will attend.' }. Set sendResponse to false to accept silently without notifying the organizer."
+  },
+  {
+    "pathPattern": "/me/events/{event-id}/decline",
+    "method": "post",
+    "toolName": "decline-calendar-event",
+    "scopes": ["Calendars.ReadWrite"],
+    "llmTip": "Declines a meeting invitation. Optional body: { sendResponse: true, comment: 'Cannot attend, conflict.' }. The event remains in the calendar as declined unless the user deletes it."
+  },
+  {
+    "pathPattern": "/me/events/{event-id}/tentativelyAccept",
+    "method": "post",
+    "toolName": "tentatively-accept-calendar-event",
+    "scopes": ["Calendars.ReadWrite"],
+    "llmTip": "Tentatively accepts a meeting invitation. Optional body: { sendResponse: true, comment: 'I might be able to attend.' }. Use proposedNewTime to suggest an alternative: { proposedNewTime: { start: { dateTime, timeZone }, end: { dateTime, timeZone } } }."
+  },
+  {
     "pathPattern": "/me/calendars/{calendar-id}/events",
     "method": "get",
     "toolName": "list-specific-calendar-events",


### PR DESCRIPTION
## Summary
- Adds `accept-calendar-event`, `decline-calendar-event`, `tentatively-accept-calendar-event`
- Enables responding to meeting invitations with optional comments and proposed new times
- Uses `Calendars.ReadWrite` delegated scope
- Pure endpoints.json additions

## Test plan
- [ ] Verify all 3 tools appear in the MCP tool list
- [ ] Test accept/decline/tentative with sendResponse option

🤖 Generated with [Claude Code](https://claude.com/claude-code)