### PR TITLE
feat: add SharePoint list item CRUD endpoints

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -734,6 +734,27 @@
     "llmTip": "Add $expand=fields to include actual column values. Without it, only metadata is returned."
   },
   {
+    "pathPattern": "/sites/{site-id}/lists/{list-id}/items",
+    "method": "post",
+    "toolName": "create-sharepoint-list-item",
+    "workScopes": ["Sites.ReadWrite.All"],
+    "llmTip": "Creates a new item in a SharePoint list. Body: { fields: { Title: 'Item name', ColumnName: 'value', ... } }. Use list-sharepoint-site-lists to find the list ID and get-sharepoint-site-list to discover available columns."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/lists/{list-id}/items/{listItem-id}",
+    "method": "patch",
+    "toolName": "update-sharepoint-list-item",
+    "workScopes": ["Sites.ReadWrite.All"],
+    "llmTip": "Updates fields on an existing list item. Body: { fields: { ColumnName: 'new value' } }. Send only the fields you want to change. Use $expand=fields on get-sharepoint-site-list-item to see current values first."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/lists/{list-id}/items/{listItem-id}",
+    "method": "delete",
+    "toolName": "delete-sharepoint-list-item",
+    "workScopes": ["Sites.ReadWrite.All"],
+    "llmTip": "Deletes a list item permanently. This cannot be undone — the item is moved to the site recycle bin."
+  },
+  {
     "pathPattern": "/sites/{site-id}/getByPath(path='{path}')",
     "method": "get",
     "toolName": "get-sharepoint-site-by-path",


### PR DESCRIPTION
## Summary
- Adds `create-sharepoint-list-item`, `update-sharepoint-list-item`, `delete-sharepoint-list-item`
- Completes CRUD for SharePoint lists (read already existed)
- Uses `Sites.ReadWrite.All` delegated scope
- Pure endpoints.json additions

## Test plan
- [ ] Verify all 3 tools appear in the MCP tool list
- [ ] Test create/update/delete list items with field values

🤖 Generated with [Claude Code](https://claude.com/claude-code)