### PR TITLE
feat: add inbox mail rules CRUD endpoints

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -199,32 +199,32 @@
     "llmTip": "No request body needed — just call with the message ID. Draft must exist in Drafts folder."
   },
   {
-    "pathPattern": "/me/mailFolders/inbox/messageRules",
+    "pathPattern": "/me/mailFolders/{mailFolder-id}/messageRules",
     "method": "get",
     "toolName": "list-mail-rules",
     "scopes": ["MailboxSettings.Read"],
-    "llmTip": "Lists all inbox rules. Each rule has displayName, sequence, isEnabled, conditions (fromAddresses, subjectContains, etc.), actions (moveToFolder, forwardTo, delete, etc.), and exceptions."
+    "llmTip": "Lists all message rules for a mail folder. Use the Inbox folder ID (get it from list-mail-folders) for inbox rules. Each rule has displayName, sequence, isEnabled, conditions (fromAddresses, subjectContains, etc.), actions (moveToFolder, forwardTo, delete, etc.), and exceptions."
   },
   {
-    "pathPattern": "/me/mailFolders/inbox/messageRules",
+    "pathPattern": "/me/mailFolders/{mailFolder-id}/messageRules",
     "method": "post",
     "toolName": "create-mail-rule",
     "scopes": ["MailboxSettings.ReadWrite"],
-    "llmTip": "Creates an inbox rule. Body: { displayName: 'Rule name', sequence: 1, isEnabled: true, conditions: { fromAddresses: [{ emailAddress: { address: 'user@example.com' } }] }, actions: { moveToFolder: 'folder-id' } }. Actions: moveToFolder, copyToFolder, forwardTo, forwardAsAttachmentTo, delete, markAsRead, markImportance, stopProcessingRules."
+    "llmTip": "Creates a message rule for a mail folder. Use the Inbox folder ID (get it from list-mail-folders) for inbox rules. Body: { displayName: 'Rule name', sequence: 1, isEnabled: true, conditions: { fromAddresses: [{ emailAddress: { address: 'user@example.com' } }] }, actions: { moveToFolder: 'folder-id' } }. Actions: moveToFolder, copyToFolder, forwardTo, forwardAsAttachmentTo, delete, markAsRead, markImportance, stopProcessingRules."
   },
   {
-    "pathPattern": "/me/mailFolders/inbox/messageRules/{messageRule-id}",
+    "pathPattern": "/me/mailFolders/{mailFolder-id}/messageRules/{messageRule-id}",
     "method": "patch",
     "toolName": "update-mail-rule",
     "scopes": ["MailboxSettings.ReadWrite"],
-    "llmTip": "Updates an existing inbox rule. Send only the properties to change. Common use: { isEnabled: false } to disable a rule, or update conditions/actions."
+    "llmTip": "Updates an existing message rule. Use the Inbox folder ID (get it from list-mail-folders) for inbox rules. Send only the properties to change. Common use: { isEnabled: false } to disable a rule, or update conditions/actions."
   },
   {
-    "pathPattern": "/me/mailFolders/inbox/messageRules/{messageRule-id}",
+    "pathPattern": "/me/mailFolders/{mailFolder-id}/messageRules/{messageRule-id}",
     "method": "delete",
     "toolName": "delete-mail-rule",
     "scopes": ["MailboxSettings.ReadWrite"],
-    "llmTip": "Deletes an inbox rule permanently."
+    "llmTip": "Deletes a message rule permanently. Use the Inbox folder ID (get it from list-mail-folders) for inbox rules."
   },
   {
     "pathPattern": "/me/events",


### PR DESCRIPTION
## Summary
- Adds `list-mail-rules`, `create-mail-rule`, `update-mail-rule`, `delete-mail-rule`
- Enables managing inbox rules (auto-forward, move to folder, categorize, delete, mark as read)
- Uses `MailboxSettings.Read`/`MailboxSettings.ReadWrite` delegated scopes
- Pure endpoints.json additions

## Test plan
- [ ] Verify all 4 tools appear in the MCP tool list
- [ ] Test list-mail-rules returns existing rules
- [ ] Test create-mail-rule with conditions and actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)