### PR TITLE
feat: add Teams and channel management endpoints

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -908,7 +908,7 @@
     "pathPattern": "/teams/{team-id}/channels/{channel-id}",
     "method": "patch",
     "toolName": "update-team-channel",
-    "workScopes": ["Channel.ReadBasic.All"],
+    "workScopes": ["ChannelSettings.ReadWrite.All"],
     "llmTip": "Updates channel properties. Body: { displayName: 'New Name', description: 'New description' }. The General channel cannot be renamed."
   },
   {


### PR DESCRIPTION
## Summary
- Adds 7 new endpoints for team lifecycle management:
  - `update-team` — update team settings (member/messaging/fun settings)
  - `create-team-channel` / `update-team-channel` / `delete-team-channel` — channel CRUD
  - `add-team-member` / `remove-team-member` — membership management
  - `list-channel-tabs` — list pinned tabs in a channel
- Uses `TeamSettings.ReadWrite.All`, `Channel.Create`, `Channel.Delete.All`, `TeamMember.ReadWrite.All`, `TeamsTab.Read.All` scopes
- Pure endpoints.json additions

## Test plan
- [ ] Verify all 7 tools appear in the MCP tool list
- [ ] Test create-team-channel with standard and private types
- [ ] Test add/remove team member

🤖 Generated with [Claude Code](https://claude.com/claude-code)