### PR TITLE
feat: add group membership and directory endpoints

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -871,6 +871,41 @@
     "llmTip": "Lists people most relevant to the current user, ordered by relevance. Based on communication patterns, collaboration, and business relationships. Each person has displayName, emailAddresses, jobTitle, department, officeLocation. Use $search to find specific people by name. Use $top to limit results."
   },
   {
+    "pathPattern": "/me/memberOf",
+    "method": "get",
+    "toolName": "list-my-memberships",
+    "scopes": ["User.Read"],
+    "llmTip": "Lists all groups, directory roles, and administrative units the current user is a member of. Returns directoryObjects — use $filter=isof('microsoft.graph.group') to filter to groups only. Each group has displayName, mail, groupTypes, membershipRule."
+  },
+  {
+    "pathPattern": "/groups",
+    "method": "get",
+    "toolName": "list-groups",
+    "workScopes": ["Group.Read.All"],
+    "llmTip": "Lists organization groups (Microsoft 365 groups, security groups, distribution lists). Use $filter=groupTypes/any(g:g eq 'Unified') for M365 groups only. Use $filter=mailEnabled eq true and securityEnabled eq false for distribution lists. Use $search=\"displayName:keyword\" to search by name (requires ConsistencyLevel: eventual header). Use $select to limit fields."
+  },
+  {
+    "pathPattern": "/groups/{group-id}",
+    "method": "get",
+    "toolName": "get-group",
+    "workScopes": ["Group.Read.All"],
+    "llmTip": "Gets a specific group's details: displayName, description, mail, visibility, groupTypes, membershipRule, createdDateTime. Use $select to limit returned properties."
+  },
+  {
+    "pathPattern": "/groups/{group-id}/members",
+    "method": "get",
+    "toolName": "list-group-members",
+    "workScopes": ["GroupMember.Read.All"],
+    "llmTip": "Lists members of a group. Returns directoryObjects with displayName, mail, jobTitle, userPrincipalName. Use $select to limit fields. Use $top and pagination for large groups."
+  },
+  {
+    "pathPattern": "/groups/{group-id}/owners",
+    "method": "get",
+    "toolName": "list-group-owners",
+    "workScopes": ["GroupMember.Read.All"],
+    "llmTip": "Lists owners of a group. Owners can manage group settings and membership. Returns directoryObjects with displayName, mail, userPrincipalName."
+  },
+  {
     "pathPattern": "/me/chats",
     "method": "get",
     "toolName": "list-chats",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -874,7 +874,7 @@
     "pathPattern": "/me/memberOf",
     "method": "get",
     "toolName": "list-my-memberships",
-    "scopes": ["User.Read"],
+    "workScopes": ["Directory.Read.All"],
     "llmTip": "Lists all groups, directory roles, and administrative units the current user is a member of. Returns directoryObjects — use $filter=isof('microsoft.graph.group') to filter to groups only. Each group has displayName, mail, groupTypes, membershipRule."
   },
   {


### PR DESCRIPTION
## Summary
- Adds 5 endpoints for organization group discovery:
  - `list-my-memberships` — groups/roles the current user belongs to
  - `list-groups` — all organization groups with filtering
  - `get-group` — specific group details
  - `list-group-members` / `list-group-owners` — group membership
- Uses `User.Read`, `Group.Read.All`, `GroupMember.Read.All`, `Directory.Read.All` scopes
- Pure endpoints.json additions

## Test plan
- [ ] Verify all 5 tools appear in the MCP tool list
- [ ] Test list-groups with $filter for M365 groups
- [ ] Test list-group-members returns user details

🤖 Generated with [Claude Code](https://claude.com/claude-code)