### PR TITLE
feat: add Excel table endpoints

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -403,7 +403,7 @@
     "llmTip": "Lists all named tables in a workbook. Each table has id, name, showHeaders, showTotals, columns, and style. Use the table name or id with other table endpoints."
   },
   {
-    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/workbook/tables/{table-id}",
+    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/workbook/tables/{workbookTable-id}",
     "method": "get",
     "toolName": "get-excel-table",
     "isExcelOp": true,
@@ -411,7 +411,7 @@
     "llmTip": "Gets a specific table by name or ID. Returns table properties including columns, showHeaders, showTotals, and style."
   },
   {
-    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/workbook/tables/{table-id}/rows",
+    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/workbook/tables/{workbookTable-id}/rows",
     "method": "get",
     "toolName": "list-excel-table-rows",
     "isExcelOp": true,
@@ -419,7 +419,7 @@
     "llmTip": "Lists all rows in a table. Each row has index and values (array of cell values). Use $top and $skip for pagination on large tables."
   },
   {
-    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/workbook/tables/{table-id}/rows",
+    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/workbook/tables/{workbookTable-id}/rows",
     "method": "post",
     "toolName": "add-excel-table-rows",
     "isExcelOp": true,


### PR DESCRIPTION
## Summary
- Adds 4 endpoints for Excel table operations:
  - `list-excel-tables` — list named tables in a workbook
  - `get-excel-table` — get specific table properties
  - `list-excel-table-rows` — read table data
  - `add-excel-table-rows` — append rows to a table
- Uses `Files.Read`/`Files.ReadWrite` delegated scopes with `isExcelOp: true`
- Pure endpoints.json additions

## Test plan
- [ ] Verify all 4 tools appear in the MCP tool list
- [ ] Test list-excel-tables on a workbook with named tables
- [ ] Test add-excel-table-rows appends data correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)