### PR TITLE
feat: add OneNote CRUD endpoints

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -443,10 +443,31 @@
     "scopes": ["Notes.Read"]
   },
   {
+    "pathPattern": "/me/onenote/notebooks",
+    "method": "post",
+    "toolName": "create-onenote-notebook",
+    "scopes": ["Notes.Create"],
+    "llmTip": "Creates a new OneNote notebook. Body: { displayName: 'Notebook Name' }. The name must be unique across the user's notebooks."
+  },
+  {
     "pathPattern": "/me/onenote/notebooks/{notebook-id}/sections",
     "method": "get",
     "toolName": "list-onenote-notebook-sections",
     "scopes": ["Notes.Read"]
+  },
+  {
+    "pathPattern": "/me/onenote/notebooks/{notebook-id}/sections",
+    "method": "post",
+    "toolName": "create-onenote-section",
+    "scopes": ["Notes.Create"],
+    "llmTip": "Creates a new section in a notebook. Body: { displayName: 'Section Name' }."
+  },
+  {
+    "pathPattern": "/me/onenote/sections",
+    "method": "get",
+    "toolName": "list-all-onenote-sections",
+    "scopes": ["Notes.Read"],
+    "llmTip": "Lists all sections across all notebooks. Use list-onenote-notebook-sections to list sections within a specific notebook instead."
   },
   {
     "pathPattern": "/me/onenote/sections/{onenoteSection-id}/pages",
@@ -475,6 +496,21 @@
     "scopes": ["Notes.Create"],
     "contentType": "text/html",
     "llmTip": "Body must be a full HTML document (with <html><head><title>...</title></head><body>...</body></html>). Partial HTML fails silently."
+  },
+  {
+    "pathPattern": "/me/onenote/pages/{onenotePage-id}/content",
+    "method": "patch",
+    "toolName": "update-onenote-page",
+    "scopes": ["Notes.ReadWrite"],
+    "contentType": "application/json",
+    "llmTip": "Updates page content using PATCH commands. Body is an array of patch actions: [{ target: 'body', action: 'append', content: '<p>New content</p>' }]. Actions: 'append' (add to end), 'replace' (replace target), 'insert' (insert after target). Target can be 'body', 'title', or a specific element ID."
+  },
+  {
+    "pathPattern": "/me/onenote/pages/{onenotePage-id}",
+    "method": "delete",
+    "toolName": "delete-onenote-page",
+    "scopes": ["Notes.ReadWrite"],
+    "llmTip": "Deletes a OneNote page permanently. This cannot be undone."
   },
   {
     "pathPattern": "/me/todo/lists",


### PR DESCRIPTION
## Summary
- Adds 5 endpoints to complement existing OneNote read/create operations:
  - `create-onenote-notebook` — create new notebooks
  - `create-onenote-section` — create sections in notebooks
  - `list-all-onenote-sections` — list sections across all notebooks
  - `update-onenote-page` — patch page content (append, replace, insert)
  - `delete-onenote-page` — delete pages
- Uses `Notes.Create`/`Notes.ReadWrite` delegated scopes
- Pure endpoints.json additions

## Test plan
- [ ] Verify all 5 tools appear in the MCP tool list
- [ ] Test create-onenote-notebook creates a new notebook
- [ ] Test update-onenote-page with append action

🤖 Generated with [Claude Code](https://claude.com/claude-code)