### PR TITLE
feat: add To Do task linked resources endpoints

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -474,6 +474,27 @@
     "scopes": ["Tasks.ReadWrite"]
   },
   {
+    "pathPattern": "/me/todo/lists/{todoTaskList-id}/tasks/{todoTask-id}/linkedResources",
+    "method": "get",
+    "toolName": "list-todo-linked-resources",
+    "scopes": ["Tasks.Read"],
+    "llmTip": "Lists resources linked to a To Do task (emails, URLs, etc.). Each linked resource has displayName, webUrl, applicationName, and externalId."
+  },
+  {
+    "pathPattern": "/me/todo/lists/{todoTaskList-id}/tasks/{todoTask-id}/linkedResources",
+    "method": "post",
+    "toolName": "create-todo-linked-resource",
+    "scopes": ["Tasks.ReadWrite"],
+    "llmTip": "Links a resource to a To Do task. Body: { webUrl: 'https://...', applicationName: 'Mail', displayName: 'Related email', externalId: 'optional-id' }. Use to link tasks to emails, files, or web pages for context."
+  },
+  {
+    "pathPattern": "/me/todo/lists/{todoTaskList-id}/tasks/{todoTask-id}/linkedResources/{linkedResource-id}",
+    "method": "delete",
+    "toolName": "delete-todo-linked-resource",
+    "scopes": ["Tasks.ReadWrite"],
+    "llmTip": "Removes a linked resource from a To Do task."
+  },
+  {
     "pathPattern": "/me/planner/tasks",
     "method": "get",
     "toolName": "list-planner-tasks",


### PR DESCRIPTION
## Summary
- Adds `list-todo-linked-resources`, `create-todo-linked-resource`, `delete-todo-linked-resource`
- Enables linking tasks to emails, files, or URLs for context
- Uses `Tasks.Read`/`Tasks.ReadWrite` delegated scopes
- Pure endpoints.json additions

## Test plan
- [ ] Verify all 3 tools appear in the MCP tool list
- [ ] Test create-todo-linked-resource links a URL to a task

🤖 Generated with [Claude Code](https://claude.com/claude-code)