### PR TITLE
feat: add --list-permissions CLI flag and simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,66 +94,32 @@ MS365_MCP_OUTPUT_FORMAT=toon npx @softeria/ms-365-mcp-server
 
 ## Supported Services & Tools
 
+The server provides 200+ tools covering most of the Microsoft Graph API surface. Each tool maps 1-to-1 to a Graph API endpoint and is defined declaratively in [`src/endpoints.json`](src/endpoints.json).
+
 ### Personal Account Tools (Available by default)
 
-**Email (Outlook)**
-<sub>list-mail-messages, list-mail-folders, list-mail-child-folders, list-mail-folder-messages, get-mail-message, send-mail,
-delete-mail-message, create-draft-email, move-mail-message, create-mail-folder, create-mail-child-folder,
-update-mail-folder, delete-mail-folder</sub>
-
-**Calendar**  
-<sub>list-calendars, list-calendar-events, get-calendar-event, get-calendar-view, create-calendar-event,
-update-calendar-event, delete-calendar-event</sub>
-
-**OneDrive Files**  
-<sub>list-drives, get-drive-root-item, list-folder-files, download-onedrive-file-content, upload-file-content,
-delete-onedrive-file</sub>
-
-**Excel Operations**  
-<sub>list-excel-worksheets, get-excel-range, create-excel-chart, format-excel-range, sort-excel-range</sub>
-
-**OneNote**  
-<sub>list-onenote-notebooks, list-onenote-notebook-sections, list-onenote-section-pages, get-onenote-page-content,
-create-onenote-page</sub>
-
-**To Do Tasks**  
-<sub>list-todo-task-lists, list-todo-tasks, get-todo-task, create-todo-task, update-todo-task, delete-todo-task</sub>
-
-**Planner**  
-<sub>list-planner-tasks, get-planner-plan, list-plan-tasks, get-planner-task, create-planner-task</sub>
-
-**Contacts**  
-<sub>list-outlook-contacts, get-outlook-contact, create-outlook-contact, update-outlook-contact,
-delete-outlook-contact</sub>
-
-**User Profile**  
-<sub>get-current-user</sub>
-
-**Search**  
-<sub>search-query</sub>
+Email (Outlook), Calendar, OneDrive Files, Excel, OneNote, To Do Tasks, Planner, Contacts, User Profile, Search
 
 ### Organization Account Tools (Requires --org-mode flag)
 
-**Teams & Chats**
-<sub>list-chats, get-chat, list-chat-messages, get-chat-message, send-chat-message, list-chat-message-replies,
-reply-to-chat-message, list-joined-teams, get-team, list-team-channels, get-team-channel, list-channel-messages,
-get-channel-message, send-channel-message, list-team-members</sub>
+Teams & Chats, Online Meetings, Transcripts & Recordings, Attendance Reports, SharePoint Sites & Lists, Shared Mailboxes & Calendars, User Management, Presence, Virtual Events
 
-**Online Meetings & Transcripts**
-<sub>list-online-meetings, list-meeting-transcripts, get-meeting-transcript-content</sub>
+### Required Graph API Permissions
 
-**SharePoint Sites**  
-<sub>search-sharepoint-sites, get-sharepoint-site, get-sharepoint-site-by-path, list-sharepoint-site-drives,
-get-sharepoint-site-drive-by-id, list-sharepoint-site-items, get-sharepoint-site-item, list-sharepoint-site-lists,
-get-sharepoint-site-list, list-sharepoint-site-list-items, get-sharepoint-site-list-item,
-get-sharepoint-sites-delta</sub>
+Permissions are requested dynamically based on which tools are enabled. Use `--list-permissions` to see the exact permissions for your configuration:
 
-**Shared Mailboxes**  
-<sub>list-shared-mailbox-messages, list-shared-mailbox-folder-messages, get-shared-mailbox-message,
-send-shared-mailbox-mail</sub>
+```bash
+# Personal mode (default)
+npx @softeria/ms-365-mcp-server --list-permissions
 
-**User Management**  
-<sub>list-users</sub>
+# Organization mode (includes Teams, SharePoint, etc.)
+npx @softeria/ms-365-mcp-server --org-mode --list-permissions
+
+# Filtered by preset
+npx @softeria/ms-365-mcp-server --preset mail --list-permissions
+```
+
+This is useful for enterprise environments where Graph API permissions must be pre-approved and admin-consented before deploying a new version.
 
 ## Organization/Work Mode
 
@@ -493,6 +459,7 @@ The following options can be used when running ms-365-mcp-server directly from t
 --login           Login using device code flow
 --logout          Log out and clear saved credentials
 --verify-login    Verify login without starting the server
+--list-permissions List all required Graph API permissions and exit (respects --org-mode, --preset, --enabled-tools)
 --org-mode        Enable organization/work mode from start (includes Teams, SharePoint, etc.)
 --work-mode       Alias for --org-mode
 --force-work-scopes Backwards compatibility alias for --org-mode (deprecated)

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -140,7 +140,8 @@ const SCOPE_HIERARCHY: ScopeHierarchy = {
 
 function buildScopesFromEndpoints(
   includeWorkAccountScopes: boolean = false,
-  enabledToolsPattern?: string
+  enabledToolsPattern?: string,
+  readOnly: boolean = false
 ): string[] {
   const scopesSet = new Set<string>();
 
@@ -158,6 +159,11 @@ function buildScopesFromEndpoints(
   }
 
   endpoints.default.forEach((endpoint) => {
+    // Skip write operations in read-only mode
+    if (readOnly && endpoint.method.toUpperCase() !== 'GET') {
+      return;
+    }
+
     // Skip endpoints that don't match the tool filter
     if (enabledToolsRegex && !enabledToolsRegex.test(endpoint.toolName)) {
       return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,7 @@ program
     'Use preset tool categories (comma-separated). Available: mail, calendar, files, personal, work, excel, contacts, tasks, onenote, search, users, all'
   )
   .option('--list-presets', 'List all available presets and exit')
+  .option('--list-permissions', 'List all required Graph API permissions and exit')
   .option(
     '--org-mode',
     'Enable organization/work mode from start (includes Teams, SharePoint, etc.)'
@@ -80,6 +81,7 @@ export interface CommandOptions {
   enabledTools?: string;
   preset?: string;
   listPresets?: boolean;
+  listPermissions?: boolean;
   orgMode?: boolean;
   workMode?: boolean;
   forceWorkScopes?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,9 +23,7 @@ async function main(): Promise<void> {
       const sorted = [...scopes].sort((a, b) => a.localeCompare(b));
       const mode = includeWorkScopes ? 'org' : 'personal';
       const filter = args.enabledTools ? args.enabledTools : undefined;
-      console.log(
-        JSON.stringify({ mode, readOnly, filter, permissions: sorted }, null, 2)
-      );
+      console.log(JSON.stringify({ mode, readOnly, filter, permissions: sorted }, null, 2));
       process.exit(0);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,13 +16,16 @@ async function main(): Promise<void> {
       logger.info('Organization mode enabled - including work account scopes');
     }
 
-    const scopes = buildScopesFromEndpoints(includeWorkScopes, args.enabledTools);
+    const readOnly = args.readOnly || false;
+    const scopes = buildScopesFromEndpoints(includeWorkScopes, args.enabledTools, readOnly);
 
     if (args.listPermissions) {
       const sorted = [...scopes].sort((a, b) => a.localeCompare(b));
       const mode = includeWorkScopes ? 'org' : 'personal';
       const filter = args.enabledTools ? args.enabledTools : undefined;
-      console.log(JSON.stringify({ mode, filter, permissions: sorted }, null, 2));
+      console.log(
+        JSON.stringify({ mode, readOnly, filter, permissions: sorted }, null, 2)
+      );
       process.exit(0);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,15 @@ async function main(): Promise<void> {
     }
 
     const scopes = buildScopesFromEndpoints(includeWorkScopes, args.enabledTools);
+
+    if (args.listPermissions) {
+      const sorted = [...scopes].sort((a, b) => a.localeCompare(b));
+      const mode = includeWorkScopes ? 'org' : 'personal';
+      const filter = args.enabledTools ? args.enabledTools : undefined;
+      console.log(JSON.stringify({ mode, filter, permissions: sorted }, null, 2));
+      process.exit(0);
+    }
+
     const authManager = await AuthManager.create(scopes);
     await authManager.loadTokenCache();
 


### PR DESCRIPTION
## Summary

- Add `--list-permissions` CLI flag that dynamically lists all required Graph API permissions, respecting `--org-mode`, `--preset`, and `--enabled-tools` settings
- Simplify the tool list in the README: replace exhaustive enumeration with a concise summary and link to [`src/endpoints.json`](src/endpoints.json)
- Document `--list-permissions` as the recommended way to get the current permission list (useful for enterprise admin consent workflows)

## Motivation

Addresses feedback from @eirikb and @anengineerdude:
- **@eirikb**: listing all tools in the README is a maintenance nightmare; permissions are dynamic and vary by configuration
- **@anengineerdude**: permissions matter for enterprise deployments where admin consent must be granted before deploying a new version

The `--list-permissions` flag solves both: it's always accurate, per-version, and respects the current tool filter / preset / org-mode settings.

## Example output

```bash
$ npx @softeria/ms-365-mcp-server --preset mail --list-permissions
{
  "mode": "personal",
  "filter": "mail|attachment|draft",
  "permissions": [
    "Mail.ReadWrite",
    "Mail.Send",
    "MailboxSettings.Read",
    "MailboxSettings.ReadWrite"
  ]
}
```

## Test plan

- [x] `npm run verify` passes (0 errors, 117 tests)
- [x] `--list-permissions` works in personal mode (12 permissions)
- [x] `--list-permissions --org-mode` works (44 permissions)
- [x] `--list-permissions --preset mail` filters correctly (4 permissions)
- [x] README renders correctly with simplified tool sections