### PR TITLE
feat: AWS Lambda deployment with OAuth 2.1, custom tools, scope-based filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ CLAUDE.md
 
 # Finder metadata files
 .DS_Store
+.aws-sam/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: build-M365McpFunction
+
+build-M365McpFunction:
+	npm install
+	npx esbuild src/lambda.ts \
+		--bundle \
+		--platform=node \
+		--target=es2020 \
+		--format=esm \
+		--sourcemap \
+		--main-fields=module,main \
+		--banner:js="import { createRequire } from 'module'; const require = createRequire(import.meta.url);" \
+		--external:keytar \
+		--external:@azure/identity \
+		--external:@azure/keyvault-secrets \
+		--outfile=$(ARTIFACTS_DIR)/lambda.mjs
+	cp src/endpoints.json $(ARTIFACTS_DIR)/endpoints.json
+	cp package.json $(ARTIFACTS_DIR)/package.json

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "express": "^5.2.1",
     "js-yaml": "^4.1.0",
     "winston": "^3.17.0",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "@aws-sdk/client-ssm": "^3.0.0",
+    "@vendia/serverless-express": "^4.0.0"
   },
   "optionalDependencies": {
     "@azure/identity": "^4.5.0",

--- a/src/custom-tools/excel-write.ts
+++ b/src/custom-tools/excel-write.ts
@@ -1,0 +1,342 @@
+/**
+ * Custom Excel write tools that provide range writing, row appending,
+ * and range clearing with auto-detection of the last used row.
+ *
+ * These go beyond the generic data-driven endpoints because they
+ * require multi-step logic (e.g., finding the last used row before appending).
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import GraphClient from '../graph-client.js';
+import logger from '../logger.js';
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+interface DriveItemInfo {
+  id: string;
+  name: string;
+}
+
+function validateItemId(itemId: string): string {
+  if (!/^[A-Za-z0-9!_=-]+$/.test(itemId)) {
+    throw new Error('Invalid itemId format');
+  }
+  return itemId;
+}
+
+function validatePath(path: string): string {
+  if (!path.startsWith('/')) {
+    throw new Error('Path must be absolute (start with /)');
+  }
+  if (path.includes('..')) {
+    throw new Error('Path cannot contain ".." segments');
+  }
+  return path;
+}
+
+async function resolveDriveItem(
+  graphClient: GraphClient,
+  path?: string,
+  itemId?: string
+): Promise<DriveItemInfo> {
+  const endpoint = itemId
+    ? `/me/drive/items/${validateItemId(itemId)}`
+    : `/me/drive/root:${validatePath(path!)}`;
+  return (await graphClient.makeRequest(endpoint + '?$select=id,name')) as DriveItemInfo;
+}
+
+/** URL-encode a value and also escape single quotes for use in Graph API path segments. */
+function encodePathSegment(value: string): string {
+  return encodeURIComponent(value).replace(/'/g, '%27');
+}
+
+function colToLetter(index: number): string {
+  let letter = '';
+  let n = index;
+  while (n >= 0) {
+    letter = String.fromCharCode((n % 26) + 65) + letter;
+    n = Math.floor(n / 26) - 1;
+  }
+  return letter;
+}
+
+// ─── Tool registration ─────────────────────────────────────────────────────────
+
+export function registerExcelWriteTools(
+  server: McpServer,
+  graphClient: GraphClient,
+  readOnly: boolean = false,
+  enabledToolsRegex?: RegExp
+): number {
+  // Skip all write tools in read-only mode
+  if (readOnly) {
+    logger.info('Excel write tools: skipped (read-only mode)');
+    return 0;
+  }
+
+  let count = 0;
+
+  // ── write-excel-range ────────────────────────────────────────────────────────
+
+  if (!enabledToolsRegex || enabledToolsRegex.test('write-excel-range')) {
+    server.tool(
+      'write-excel-range',
+      `Write values to a specific cell range in an Excel worksheet.\nOverwrites existing cell values in the target range. Read the range first with get-excel-range to confirm current values before overwriting.\n\nArgs:\n  - path: File path \u2014 use this OR itemId\n  - itemId: OneDrive item ID \u2014 use this OR path\n  - sheetName: Worksheet name (get from list-excel-worksheets)\n  - range: Top-left cell or full range e.g. "A1", "B2:D4"\n  - values: 2D array \u2014 each inner array is one row. Example: [["Name","Score"],["Alice",95],["Bob",87]]\n\nReturns: Confirmation with the range written.\n\nCAUTION: Overwrites existing data. Always read the target range first.`,
+      {
+        path: z.string().describe('File path').optional(),
+        itemId: z.string().describe('OneDrive item ID').optional(),
+        sheetName: z.string().describe('Worksheet name'),
+        range: z.string().describe('Top-left cell or range e.g. "A1" or "B2:D5"'),
+        values: z
+          .array(z.array(z.union([z.string(), z.number(), z.boolean(), z.null()])))
+          .min(1)
+          .describe('2D array of values \u2014 each inner array is one row'),
+      },
+      {
+        title: 'write-excel-range',
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: true,
+      },
+      async ({ path, itemId, sheetName, range, values }) => {
+        if (!path && !itemId) {
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Provide path or itemId' }) }],
+            isError: true,
+          };
+        }
+        try {
+          const item = await resolveDriveItem(graphClient, path, itemId);
+          const sheetRef = encodePathSegment(sheetName);
+          const rangeRef = encodePathSegment(range);
+
+          const result = (await graphClient.makeRequest(
+            `/me/drive/items/${item.id}/workbook/worksheets('${sheetRef}')/range(address='${rangeRef}')`,
+            { method: 'PATCH', body: JSON.stringify({ values }) }
+          )) as { address: string };
+
+          const rowWord = values.length === 1 ? 'row' : 'rows';
+          const colWord = values[0].length === 1 ? 'column' : 'columns';
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Written ${values.length} ${rowWord} x ${values[0].length} ${colWord} to "${sheetName}" at ${result.address} in "${item.name}".`,
+              },
+            ],
+          };
+        } catch (error) {
+          logger.error(`write-excel-range error: ${(error as Error).message}`);
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Failed to write Excel range. Check the path, sheet name, and range.' }) }],
+            isError: true,
+          };
+        }
+      }
+    );
+    count++;
+  }
+
+  // ── append-excel-rows ────────────────────────────────────────────────────────
+
+  if (!enabledToolsRegex || enabledToolsRegex.test('append-excel-rows')) {
+    server.tool(
+      'append-excel-rows',
+      `Append one or more rows immediately after the last row of existing data in a worksheet.\nDetects the last used row automatically \u2014 no need to specify where to write.\nIdeal for logging, adding new records, or extending a table.\n\nArgs:\n  - path: File path \u2014 use this OR itemId\n  - itemId: OneDrive item ID \u2014 use this OR path\n  - sheetName: Worksheet name\n  - rows: 2D array \u2014 each inner array is one row to append. Must match the column count of existing data.\n  - startCol: Column letter where data starts (default: "A")\n\nReturns: Confirmation with the range written and next available empty row.`,
+      {
+        path: z.string().describe('File path').optional(),
+        itemId: z.string().describe('OneDrive item ID').optional(),
+        sheetName: z.string().describe('Worksheet name'),
+        rows: z
+          .array(z.array(z.union([z.string(), z.number(), z.boolean(), z.null()])))
+          .min(1)
+          .describe('2D array of rows to append'),
+        startCol: z
+          .string()
+          .regex(/^[A-Za-z]{1,3}$/, 'startCol must be 1-3 letters (A-XFD)')
+          .default('A')
+          .describe('Starting column letter(s) e.g. "A", "AA" (default: "A")')
+          .optional(),
+      },
+      {
+        title: 'append-excel-rows',
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+      async ({ path, itemId, sheetName, rows, startCol }) => {
+        if (!path && !itemId) {
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Provide path or itemId' }) }],
+            isError: true,
+          };
+        }
+        try {
+          const col = startCol ?? 'A';
+          const item = await resolveDriveItem(graphClient, path, itemId);
+          const sheetRef = encodePathSegment(sheetName);
+
+          // Find the last used row
+          const usedRange = (await graphClient.makeRequest(
+            `/me/drive/items/${item.id}/workbook/worksheets('${sheetRef}')/usedRange?$select=rowCount,columnCount`
+          )) as { rowCount: number; columnCount: number };
+
+          const nextRow = usedRange.rowCount + 1;
+          const colStart = col.toUpperCase();
+          // Convert column letters to 0-based index (A=0, Z=25, AA=26, etc.)
+          let colStartIdx = 0;
+          for (const ch of colStart) {
+            colStartIdx = colStartIdx * 26 + (ch.charCodeAt(0) - 64);
+          }
+          colStartIdx -= 1; // Convert to 0-based
+          const endCol = colToLetter(colStartIdx + rows[0].length - 1);
+          const writeRange = `${colStart}${nextRow}:${endCol}${nextRow + rows.length - 1}`;
+          const rangeRef = encodePathSegment(writeRange);
+
+          const result = (await graphClient.makeRequest(
+            `/me/drive/items/${item.id}/workbook/worksheets('${sheetRef}')/range(address='${rangeRef}')`,
+            { method: 'PATCH', body: JSON.stringify({ values: rows }) }
+          )) as { address: string };
+
+          const rowWord = rows.length === 1 ? 'row' : 'rows';
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Appended ${rows.length} ${rowWord} to "${sheetName}" at ${result.address} in "${item.name}". Next empty row: ${nextRow + rows.length}.`,
+              },
+            ],
+          };
+        } catch (error) {
+          logger.error(`append-excel-rows error: ${(error as Error).message}`);
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Failed to append rows. Check the path, sheet name, and data format.' }) }],
+            isError: true,
+          };
+        }
+      }
+    );
+    count++;
+  }
+
+  // ── clear-excel-range ────────────────────────────────────────────────────────
+
+  if (!enabledToolsRegex || enabledToolsRegex.test('clear-excel-range')) {
+    server.tool(
+      'clear-excel-range',
+      `Clear the contents of a cell range in an Excel worksheet.\nRemoves values but preserves cell formatting (borders, colors, number formats) by default.\nSet clearFormat=true to also wipe formatting.\n\nArgs:\n  - path: File path \u2014 use this OR itemId\n  - itemId: OneDrive item ID \u2014 use this OR path\n  - sheetName: Worksheet name\n  - range: Range to clear e.g. "A2:D10"\n  - clearFormat: Also clear formatting (default: false)\n\nReturns: Confirmation of the cleared range.\n\nCAUTION: Permanently removes cell values. Read range first to confirm.`,
+      {
+        path: z.string().describe('File path').optional(),
+        itemId: z.string().describe('OneDrive item ID').optional(),
+        sheetName: z.string().describe('Worksheet name'),
+        range: z.string().describe('Range to clear e.g. "A2:D10"'),
+        clearFormat: z
+          .boolean()
+          .default(false)
+          .describe('Also clear formatting (default: false)')
+          .optional(),
+      },
+      {
+        title: 'clear-excel-range',
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: true,
+      },
+      async ({ path, itemId, sheetName, range, clearFormat }) => {
+        if (!path && !itemId) {
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Provide path or itemId' }) }],
+            isError: true,
+          };
+        }
+        try {
+          const item = await resolveDriveItem(graphClient, path, itemId);
+          const sheetRef = encodePathSegment(sheetName);
+          const rangeRef = encodePathSegment(range);
+          const clearType = clearFormat ? 'All' : 'Contents';
+
+          await graphClient.makeRequest(
+            `/me/drive/items/${item.id}/workbook/worksheets('${sheetRef}')/range(address='${rangeRef}')/clear`,
+            { method: 'POST', body: JSON.stringify({ applyTo: clearType }) }
+          );
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Cleared ${clearFormat ? 'contents and formatting' : 'contents'} of "${range}" in sheet "${sheetName}" in "${item.name}".`,
+              },
+            ],
+          };
+        } catch (error) {
+          logger.error(`clear-excel-range error: ${(error as Error).message}`);
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Failed to clear range. Check the path, sheet name, and range.' }) }],
+            isError: true,
+          };
+        }
+      }
+    );
+    count++;
+  }
+
+  // ── create-workbook ─────────────────────────────────────────────────────────
+
+  if (!enabledToolsRegex || enabledToolsRegex.test('create-workbook')) {
+    // Minimal valid empty .xlsx (contains one blank Sheet1)
+    const EMPTY_XLSX_B64 =
+      'UEsDBBQAAAAIAHFgfVxuYbgN/gAAAC0CAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbK2RzU7DMBCEX8XytYqdckAIJe2BnyNwKA+w2JvEiv/kdUv69jhp4YAKXDit7JnZb2Q328lZdsBEJviWr0XNGXoVtPF9y193j9UNZ5TBa7DBY8uPSHy7aXbHiMRK1lPLh5zjrZSkBnRAIkT0RelCcpDLMfUyghqhR3lV19dSBZ/R5yrPO/imuccO9jazh6lcn3oktMTZ3ck4s1oOMVqjIBddHrz+RqnOBFGSi4cGE2lVDFxeJMzKz4Bz7rk8TDIa2Quk/ASuuORk5XtI41sIo/h9yYWWoeuMQh3U3pWIoJgQNA2I2VmxTOHA+NXf/MVMchnrfy7ytf+zh1y+e/MBUEsDBBQAAAAIAHFgfVyY2uuLrgAAACcBAAALAAAAX3JlbHMvLnJlbHONz8EOgjAMBuBXWXqXgQdjDIOLMeFq8AHmVgYB1mWbCm/vjmI8eGz69/vTsl7miT3Rh4GsgCLLgaFVpAdrBNzay+4ILERptZzIooAVA9RVecVJxnQS+sEFlgwbBPQxuhPnQfU4y5CRQ5s2HflZxjR6w51UozTI93l+4P7TgK3JGi3AN7oA1q4O/7Gp6waFZ1KPGW38UfGVSLL0BqOAZeIv8uOdaMwSCrwq+ebB6g1QSwMEFAAAAAgAcWB9XJ1sQ725AAAAGwEAAA8AAAB4bC93b3JrYm9vay54bWyNT0uuwjAMvErkPaRlgZ6qtmwQEmvgAKFxaURjV3b4vNsTfntWM9ZoxjP16h5Hc0XRwNRAOS/AIHXsA50aOOw3sz8wmhx5NzJhA/+osGrrG8v5yHw22U7awJDSVFmr3YDR6ZwnpKz0LNGlfMrJ6iTovA6IKY52URRLG10geCdU8ksG933ocM3dJSKld4jg6FIur0OYFNr69UE/aMjFXHr35GUe8sStzzvBSBUyka0vwba1/drsd1n7AFBLAwQUAAAACABxYH1cWv2Ca7EAAAAoAQAAGgAAAHhsL19yZWxzL3dvcmtib29rLnhtbC5yZWxzjc/JCsJADAbgVxlyt2k9iEinXkToVeoDDNN0oZ2Fybj07R08iAUPnkLyky+kPD7NLO4UeHRWQpHlIMhq1462l3Btzps9CI7Ktmp2liQsxHCsygvNKqYVHkbPIhmWJQwx+gMi64GM4sx5sinpXDAqpjb06JWeVE+4zfMdhm8D1qaoWwmhbgsQzeLpH9t13ajp5PTNkI0/TuDDhYkHophQFXqKEj4jxncpsqQCViWuPqxeUEsDBBQAAAAIAHFgfVyejKhOggAAAJwAAAAYAAAAeGwvd29ya3NoZWV0cy9zaGVldDEueG1sPYxLDsIwDAWvEnlPHVgghJJ0gzgBHMBqTFvROFUc8bk9URcs34zmuf6TFvPionMWD/vOgmEZcpxl9HC/XXcnMFpJIi1Z2MOXFfrg3rk8dWKupvWiHqZa1zOiDhMn0i6vLM08cklU2ywj6lqY4halBQ/WHjHRLBDcxi5UCYPD/3P4AVBLAQIUAxQAAAAIAHFgfVxuYbgN/gAAAC0CAAATAAAAAAAAAAAAAACAAQAAAABbQ29udGVudF9UeXBlc10ueG1sUEsBAhQDFAAAAAgAcWB9XJja64uuAAAAJwEAAAsAAAAAAAAAAAAAAIABLwEAAF9yZWxzLy5yZWxzUEsBAhQDFAAAAAgAcWB9XJ1sQ725AAAAGwEAAA8AAAAAAAAAAAAAAIABBgIAAHhsL3dvcmtib29rLnhtbFBLAQIUAxQAAAAIAHFgfVxa/YJrsQAAACgBAAAaAAAAAAAAAAAAAACAAewCAAB4bC9fcmVscy93b3JrYm9vay54bWwucmVsc1BLAQIUAxQAAAAIAHFgfVyejKhOggAAAJwAAAAYAAAAAAAAAAAAAACAAdUDAAB4bC93b3Jrc2hlZXRzL3NoZWV0MS54bWxQSwUGAAAAAAUABQBFAQAAjQQAAAAA';
+
+    server.tool(
+      'create-workbook',
+      `Create a new empty Excel workbook (.xlsx) in OneDrive.\nCreates a file with one blank worksheet (Sheet1) that you can then populate using write-excel-range or append-excel-rows.\n\nArgs:\n  - fileName: Name for the file (must end with .xlsx)\n  - folderPath: Folder path e.g. "/" for root, "/Documents/Reports" (default: "/")\n\nReturns: Item ID and name of the created workbook.`,
+      {
+        fileName: z.string().regex(/\.xlsx$/i, 'File name must end with .xlsx').describe('File name e.g. "Budget.xlsx"'),
+        folderPath: z.string().default('/').describe('Folder path e.g. "/" or "/Documents" (default: root)').optional(),
+      },
+      {
+        title: 'create-workbook',
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+      async ({ fileName, folderPath }) => {
+        try {
+          const folder = folderPath && folderPath !== '/' ? folderPath : '';
+          const uploadPath = `${folder}/${fileName}`.replace(/\/+/g, '/');
+          const endpoint = `/me/drive/root:${validatePath(uploadPath)}:/content`;
+
+          const xlsxBuffer = Buffer.from(EMPTY_XLSX_B64, 'base64');
+          const result = (await graphClient.makeRequest(endpoint, {
+            method: 'PUT',
+            body: xlsxBuffer as any,
+            headers: {
+              'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            },
+          })) as { id: string; name: string; webUrl?: string };
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Created workbook "${result.name}" (ID: ${result.id}).${result.webUrl ? ` Open in browser: ${result.webUrl}` : ''}\n\nUse write-excel-range with itemId="${result.id}" and sheetName="Sheet1" to add data.`,
+              },
+            ],
+          };
+        } catch (error) {
+          logger.error(`create-workbook error: ${(error as Error).message}`);
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Failed to create workbook. Check the file name and folder path.' }) }],
+            isError: true,
+          };
+        }
+      }
+    );
+    count++;
+  }
+
+  logger.info(`Excel write tools: ${count} registered`);
+  return count;
+}

--- a/src/custom-tools/word.ts
+++ b/src/custom-tools/word.ts
@@ -1,0 +1,438 @@
+/**
+ * Custom Word document tools that provide structured document reading,
+ * outline extraction, and in-document search via the Graph API's HTML
+ * conversion endpoint.
+ *
+ * These tools go beyond the generic data-driven endpoints because they
+ * require post-processing (HTML-to-structured-text parsing).
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import GraphClient from '../graph-client.js';
+import logger from '../logger.js';
+
+const CHARACTER_LIMIT = 50_000;
+
+// ─── HTML parsing helpers ──────────────────────────────────────────────────────
+
+interface WordSection {
+  heading: string;
+  level: number;
+  content: string;
+}
+
+function decodeHtmlEntities(text: string): string {
+  return text
+    // Named entities
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&mdash;/g, '\u2014')
+    .replace(/&ndash;/g, '\u2013')
+    .replace(/&hellip;/g, '\u2026')
+    .replace(/&lsquo;|&rsquo;/g, "'")
+    .replace(/&ldquo;|&rdquo;/g, '"')
+    .replace(/&copy;/g, '\u00a9')
+    .replace(/&reg;/g, '\u00ae')
+    .replace(/&trade;/g, '\u2122')
+    // Numeric hex entities: &#xNN;
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    // Numeric decimal entities: &#NNN;
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)));
+}
+
+function stripInlineHtml(html: string): string {
+  return decodeHtmlEntities(html.replace(/<[^>]+>/g, ''))
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Converts the Graph API's HTML preview of a Word document into structured
+ * plain text, preserving headings, paragraphs, lists, and tables as markdown.
+ */
+function htmlToStructuredText(html: string): { text: string; sections: WordSection[] } {
+  const sections: WordSection[] = [];
+  let currentHeading = '';
+  let currentLevel = 0;
+  let currentContent: string[] = [];
+
+  const flushSection = () => {
+    if (currentHeading || currentContent.length > 0) {
+      sections.push({
+        heading: currentHeading,
+        level: currentLevel,
+        content: currentContent.join('\n').trim(),
+      });
+      currentContent = [];
+    }
+  };
+
+  const processedHtml = html
+    // Headings
+    .replace(/<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi, (_match, level, content) => {
+      flushSection();
+      currentHeading = stripInlineHtml(content);
+      currentLevel = parseInt(level);
+      return '';
+    })
+    // Tables -> markdown
+    .replace(/<table[^>]*>([\s\S]*?)<\/table>/gi, (_match, tableContent) => {
+      const rows: string[][] = [];
+      const rowMatches = tableContent.matchAll(/<tr[^>]*>([\s\S]*?)<\/tr>/gi);
+      for (const rowMatch of rowMatches) {
+        const cells: string[] = [];
+        const cellMatches = rowMatch[1].matchAll(/<t[dh][^>]*>([\s\S]*?)<\/t[dh]>/gi);
+        for (const cellMatch of cellMatches) {
+          cells.push(stripInlineHtml(cellMatch[1]).trim());
+        }
+        rows.push(cells);
+      }
+      if (rows.length === 0) return '';
+      const colWidths = rows[0].map((_, i) => Math.max(...rows.map((r) => (r[i] || '').length)));
+      const formatted = rows
+        .map((row, ri) => {
+          const line =
+            '| ' + row.map((cell, ci) => cell.padEnd(colWidths[ci] || 0)).join(' | ') + ' |';
+          if (ri === 0) {
+            const sep =
+              '| ' + colWidths.map((w) => '-'.repeat(Math.max(w, 3))).join(' | ') + ' |';
+            return line + '\n' + sep;
+          }
+          return line;
+        })
+        .join('\n');
+      currentContent.push('\n' + formatted + '\n');
+      return '';
+    })
+    // Lists
+    .replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, (_match, content) => {
+      currentContent.push('\u2022 ' + stripInlineHtml(content).trim());
+      return '';
+    })
+    // Paragraphs
+    .replace(/<p[^>]*>([\s\S]*?)<\/p>/gi, (_match, content) => {
+      const text = stripInlineHtml(content).trim();
+      if (text) currentContent.push(text);
+      return '';
+    })
+    .replace(/<br\s*\/?>/gi, '\n');
+
+  const remaining = stripInlineHtml(processedHtml).trim();
+  if (remaining) currentContent.push(remaining);
+
+  flushSection();
+
+  const fullText = sections
+    .map((sec) => {
+      const prefix = sec.heading ? '#'.repeat(sec.level) + ' ' + sec.heading + '\n\n' : '';
+      return prefix + sec.content;
+    })
+    .join('\n\n')
+    .trim();
+
+  return { text: fullText, sections };
+}
+
+function truncate(text: string, label: string): string {
+  if (text.length <= CHARACTER_LIMIT) return text;
+  return (
+    text.substring(0, CHARACTER_LIMIT) +
+    `\n\n[Truncated at ${CHARACTER_LIMIT} chars. Document "${label}" has more content.]`
+  );
+}
+
+// ─── Input validation ──────���───────────────────────────────────────────────────
+
+/** Validate and sanitize itemId to prevent path traversal. */
+function validateItemId(itemId: string): string {
+  // Graph API item IDs are alphanumeric with hyphens, underscores, and sometimes ! or =
+  if (!/^[A-Za-z0-9!_=-]+$/.test(itemId)) {
+    throw new Error('Invalid itemId format');
+  }
+  return itemId;
+}
+
+/** Validate path to prevent traversal attacks. */
+function validatePath(path: string): string {
+  if (!path.startsWith('/')) {
+    throw new Error('Path must be absolute (start with /)');
+  }
+  if (path.includes('..')) {
+    throw new Error('Path cannot contain ".." segments');
+  }
+  return path;
+}
+
+// ─── Helper to fetch a drive item by path or id ────────────────────────────────
+
+interface DriveItemInfo {
+  id: string;
+  name: string;
+  lastModifiedDateTime?: string;
+  size?: number;
+  folder?: unknown;
+}
+
+async function resolveDriveItem(
+  graphClient: GraphClient,
+  path?: string,
+  itemId?: string
+): Promise<DriveItemInfo> {
+  const endpoint = itemId
+    ? `/me/drive/items/${validateItemId(itemId)}`
+    : `/me/drive/root:${validatePath(path!)}`;
+  const result = (await graphClient.makeRequest(endpoint + '?$select=id,name,lastModifiedDateTime,size,folder')) as DriveItemInfo;
+  return result;
+}
+
+async function fetchDocumentHtml(graphClient: GraphClient, itemId: string): Promise<string> {
+  // Graph API converts Word docs to HTML via ?format=html
+  const result = (await graphClient.makeRequest(
+    `/me/drive/items/${itemId}/content?format=html`,
+    { headers: { Accept: 'text/html' } }
+  )) as { rawResponse?: string } | string;
+
+  // makeRequest returns { rawResponse: html } for non-JSON responses
+  if (typeof result === 'string') return result;
+  if (result && typeof result === 'object' && 'rawResponse' in result) {
+    return result.rawResponse as string;
+  }
+  throw new Error('Failed to retrieve document HTML content');
+}
+
+// ─── Tool registration ─────────────────────────────────────────────────────────
+
+export function registerWordTools(
+  server: McpServer,
+  graphClient: GraphClient,
+  enabledToolsRegex?: RegExp
+): number {
+  let count = 0;
+
+  // ── read-word-document ───────────────────────────────────────────────────────
+
+  if (!enabledToolsRegex || enabledToolsRegex.test('read-word-document')) {
+    server.tool(
+      'read-word-document',
+      `Read the full text content of a Word (.docx) document from OneDrive.\nExtracts text, preserves heading structure, tables (as markdown), and lists.\n\nArgs:\n  - path: File path e.g. "/Documents/report.docx" \u2014 use this OR itemId\n  - itemId: OneDrive item ID \u2014 use this OR path\n\nReturns: Full document text with headings, tables, and lists preserved. Truncated at 50,000 chars for very large documents.`,
+      {
+        path: z.string().describe('File path e.g. /Documents/report.docx').optional(),
+        itemId: z.string().describe('OneDrive item ID').optional(),
+      },
+      {
+        title: 'read-word-document',
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+      async ({ path, itemId }) => {
+        if (!path && !itemId) {
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Provide path or itemId' }) }],
+            isError: true,
+          };
+        }
+        try {
+          const item = await resolveDriveItem(graphClient, path, itemId);
+
+          if (item.folder) {
+            return {
+              content: [{ type: 'text', text: `"${item.name}" is a folder, not a document.` }],
+            };
+          }
+
+          const name = item.name.toLowerCase();
+          if (!name.endsWith('.docx') && !name.endsWith('.doc')) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: `"${item.name}" doesn't appear to be a Word document. Use file download tools for plain text files.`,
+                },
+              ],
+            };
+          }
+
+          const html = await fetchDocumentHtml(graphClient, item.id);
+          const { text, sections } = htmlToStructuredText(html);
+
+          const header = [
+            `# ${item.name}`,
+            item.lastModifiedDateTime
+              ? `Last modified: ${new Date(item.lastModifiedDateTime).toLocaleString()}`
+              : '',
+            item.size ? `Size: ${(item.size / 1024).toFixed(1)} KB` : '',
+            `Sections: ${sections.filter((s) => s.heading).length} headings found`,
+            '---',
+          ]
+            .filter(Boolean)
+            .join('\n');
+
+          return { content: [{ type: 'text', text: truncate(`${header}\n\n${text}`, item.name) }] };
+        } catch (error) {
+          logger.error(`read-word-document error: ${(error as Error).message}`);
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Failed to read document. Check the path or itemId and try again.' }) }],
+            isError: true,
+          };
+        }
+      }
+    );
+    count++;
+  }
+
+  // ── get-word-outline ─────────────────────────────────────────────────────────
+
+  if (!enabledToolsRegex || enabledToolsRegex.test('get-word-outline')) {
+    server.tool(
+      'get-word-outline',
+      `Get the heading structure (table of contents) of a Word document without reading the full content.\nUseful for understanding what's in a large document before reading specific sections.\n\nArgs:\n  - path: File path \u2014 use this OR itemId\n  - itemId: OneDrive item ID \u2014 use this OR path\n\nReturns: Hierarchical list of all headings with their levels (H1, H2, H3\u2026).`,
+      {
+        path: z.string().describe('File path').optional(),
+        itemId: z.string().describe('OneDrive item ID').optional(),
+      },
+      {
+        title: 'get-word-outline',
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+      async ({ path, itemId }) => {
+        if (!path && !itemId) {
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Provide path or itemId' }) }],
+            isError: true,
+          };
+        }
+        try {
+          const item = await resolveDriveItem(graphClient, path, itemId);
+          const html = await fetchDocumentHtml(graphClient, item.id);
+          const { sections } = htmlToStructuredText(html);
+          const headings = sections.filter((s) => s.heading);
+
+          if (headings.length === 0) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: `"${item.name}" has no headings \u2014 it may be unstructured text.`,
+                },
+              ],
+            };
+          }
+
+          const outline = headings
+            .map((s) => {
+              const indent = '  '.repeat(Math.max(0, s.level - 1));
+              return `${indent}${'#'.repeat(s.level)} ${s.heading}`;
+            })
+            .join('\n');
+
+          return {
+            content: [
+              { type: 'text', text: `Document outline for "${item.name}":\n\n${outline}` },
+            ],
+          };
+        } catch (error) {
+          logger.error(`get-word-outline error: ${(error as Error).message}`);
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Failed to get document outline. Check the path or itemId and try again.' }) }],
+            isError: true,
+          };
+        }
+      }
+    );
+    count++;
+  }
+
+  // ── search-word-document ─────────────────────────────────────────────────────
+
+  if (!enabledToolsRegex || enabledToolsRegex.test('search-word-document')) {
+    server.tool(
+      'search-word-document',
+      `Search for specific text within a Word document and return matching sections with context.\nMore efficient than reading the full document when you need specific information.\n\nArgs:\n  - path: File path \u2014 use this OR itemId\n  - itemId: OneDrive item ID \u2014 use this OR path\n  - query: Text to search for (case-insensitive)\n  - contextChars: Characters of context around each match (default: 300)\n\nReturns: All matching paragraphs/sections containing the search term (up to 20 matches).`,
+      {
+        path: z.string().describe('File path').optional(),
+        itemId: z.string().describe('OneDrive item ID').optional(),
+        query: z.string().min(1).describe('Text to search for'),
+        contextChars: z
+          .number()
+          .int()
+          .min(50)
+          .max(1000)
+          .default(300)
+          .describe('Context window around matches')
+          .optional(),
+      },
+      {
+        title: 'search-word-document',
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+      async ({ path, itemId, query, contextChars }) => {
+        if (!path && !itemId) {
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Provide path or itemId' }) }],
+            isError: true,
+          };
+        }
+        try {
+          const ctxChars = contextChars ?? 300;
+          const item = await resolveDriveItem(graphClient, path, itemId);
+          const html = await fetchDocumentHtml(graphClient, item.id);
+          const { text } = htmlToStructuredText(html);
+
+          const lowerText = text.toLowerCase();
+          const lowerQuery = query.toLowerCase();
+          const matches: string[] = [];
+          let searchFrom = 0;
+
+          while (matches.length < 20) {
+            const idx = lowerText.indexOf(lowerQuery, searchFrom);
+            if (idx === -1) break;
+
+            const start = Math.max(0, idx - ctxChars);
+            const end = Math.min(text.length, idx + query.length + ctxChars);
+            let snippet = text.substring(start, end);
+            if (start > 0) snippet = '...' + snippet;
+            if (end < text.length) snippet = snippet + '...';
+
+            matches.push(snippet);
+            searchFrom = idx + query.length;
+          }
+
+          if (matches.length === 0) {
+            return {
+              content: [
+                { type: 'text', text: `No matches found for "${query}" in "${item.name}".` },
+              ],
+            };
+          }
+
+          const result = [
+            `Found ${matches.length} match(es) for "${query}" in "${item.name}":`,
+            ...matches.map((m, i) => `--- Match ${i + 1} ---\n${m}`),
+          ].join('\n\n');
+
+          return { content: [{ type: 'text', text: result }] };
+        } catch (error) {
+          logger.error(`search-word-document error: ${(error as Error).message}`);
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Failed to search document. Check the path or itemId and try again.' }) }],
+            isError: true,
+          };
+        }
+      }
+    );
+    count++;
+  }
+
+  logger.info(`Word tools: ${count} registered`);
+  return count;
+}

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,0 +1,388 @@
+/**
+ * AWS Lambda handler entry point.
+ *
+ * Wraps the MCP server's HTTP/Express app in a serverless-express adapter
+ * so it can run behind API Gateway. Uses custom OAuth 2.1 endpoints with
+ * Microsoft as the upstream provider.
+ *
+ * Deploy via SAM: see template.yaml at the project root.
+ */
+
+import 'dotenv/config';
+import express, { Request, Response } from 'express';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import logger from './logger.js';
+import { registerGraphTools } from './graph-tools.js';
+import { registerWordTools } from './custom-tools/word.js';
+import { registerExcelWriteTools } from './custom-tools/excel-write.js';
+import GraphClient from './graph-client.js';
+import AuthManager, { buildScopesFromEndpoints } from './auth.js';
+import { getSecrets } from './secrets.js';
+import { version } from './version.js';
+import { getCloudEndpoints } from './cloud-config.js';
+import { requestContext } from './request-context.js';
+import {
+  exchangeCodeForToken,
+  microsoftBearerTokenAuthMiddleware,
+  refreshAccessToken,
+} from './lib/microsoft-auth.js';
+
+let cachedApp: express.Express | null = null;
+let serverlessExpress: any = null;
+
+/**
+ * Decode the `scp` claim from a Microsoft JWT to get granted scopes.
+ * No signature verification — that's handled by the Graph API itself.
+ */
+function getScopesFromToken(accessToken: string): Set<string> {
+  try {
+    const payload = accessToken.split('.')[1];
+    const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString());
+    const scp: string = decoded.scp || '';
+    return new Set(scp.split(' ').filter(Boolean));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Map from Microsoft Graph scope → tool names that require it.
+ * A tool is enabled if ANY of its scopes are granted (read scope enables read tools,
+ * write scope enables write tools). Custom tools (Word, Excel write) are mapped here too.
+ */
+const SCOPE_TO_TOOLS: Record<string, string[]> = {
+  'User.Read': ['get-current-user'],
+  'Mail.Read': [
+    'list-mail-messages', 'list-mail-folders', 'list-mail-child-folders',
+    'list-mail-folder-messages', 'get-mail-message', 'list-mail-attachments', 'get-mail-attachment',
+  ],
+  'Mail.ReadWrite': [
+    'create-mail-folder', 'create-mail-child-folder', 'update-mail-folder', 'delete-mail-folder',
+    'create-draft-email', 'delete-mail-message', 'move-mail-message', 'update-mail-message',
+    'add-mail-attachment', 'delete-mail-attachment', 'create-forward-draft',
+    'create-reply-draft', 'create-reply-all-draft',
+  ],
+  'Mail.Send': [
+    'send-mail', 'forward-mail-message', 'reply-mail-message',
+    'reply-all-mail-message', 'send-draft-message',
+  ],
+  'Calendars.Read': [
+    'list-calendar-events', 'get-calendar-event', 'list-specific-calendar-events',
+    'get-specific-calendar-event', 'get-calendar-view', 'get-specific-calendar-view',
+    'list-calendar-event-instances', 'list-calendars',
+  ],
+  'Calendars.ReadWrite': [
+    'create-calendar-event', 'update-calendar-event', 'delete-calendar-event',
+    'create-specific-calendar-event', 'update-specific-calendar-event', 'delete-specific-calendar-event',
+  ],
+  'Files.Read': [
+    'list-drives', 'get-drive-root-item', 'get-root-folder', 'list-folder-files',
+    'download-onedrive-file-content', 'get-excel-range', 'list-excel-worksheets',
+    'read-word-document', 'get-word-outline', 'search-word-document',
+  ],
+  'Files.ReadWrite': [
+    'delete-onedrive-file', 'upload-file-content', 'create-excel-chart',
+    'format-excel-range', 'sort-excel-range',
+    'create-workbook', 'write-excel-range', 'append-excel-rows', 'clear-excel-range',
+  ],
+  'Files.Read.All': ['search-query'],
+  'Notes.Read': [
+    'list-onenote-notebooks', 'list-onenote-notebook-sections',
+    'list-onenote-section-pages', 'get-onenote-page-content',
+  ],
+  'Notes.Create': ['create-onenote-page', 'create-onenote-section-page'],
+  'Tasks.Read': [
+    'list-todo-task-lists', 'list-todo-tasks', 'get-todo-task',
+    'list-planner-tasks', 'get-planner-plan', 'list-plan-tasks',
+    'get-planner-task', 'get-planner-task-details',
+  ],
+  'Tasks.ReadWrite': [
+    'create-todo-task', 'update-todo-task', 'delete-todo-task',
+    'create-planner-task', 'update-planner-task', 'update-planner-task-details',
+  ],
+  'Contacts.Read': ['list-outlook-contacts', 'get-outlook-contact'],
+  'Contacts.ReadWrite': ['create-outlook-contact', 'update-outlook-contact', 'delete-outlook-contact'],
+  'People.Read': ['search-query'],
+  'OnlineMeetings.Read': ['list-online-meetings'],
+};
+
+/**
+ * Build an enabledTools regex pattern from the granted Microsoft scopes.
+ * Returns undefined if no scopes found (falls back to ENABLED_TOOLS env var).
+ */
+function buildToolFilterFromToken(accessToken: string): string | undefined {
+  const grantedScopes = getScopesFromToken(accessToken);
+  if (grantedScopes.size === 0) return undefined;
+
+  const allowedTools = new Set<string>();
+  for (const [scope, tools] of Object.entries(SCOPE_TO_TOOLS)) {
+    if (grantedScopes.has(scope)) {
+      for (const tool of tools) allowedTools.add(tool);
+    }
+  }
+
+  if (allowedTools.size === 0) return undefined;
+
+  // Build a regex that matches any of the allowed tool names exactly
+  return `^(${[...allowedTools].join('|')})$`;
+}
+
+async function createApp(): Promise<express.Express> {
+  if (cachedApp) return cachedApp;
+
+  const orgMode = process.env.MS365_MCP_ORG_MODE === 'true';
+  const readOnly = process.env.READ_ONLY === 'true';
+  const enabledTools = process.env.ENABLED_TOOLS;
+  const toon = process.env.MS365_MCP_OUTPUT_FORMAT === 'toon';
+
+  const secrets = await getSecrets();
+  const scopes = buildScopesFromEndpoints(orgMode, enabledTools);
+  const authManager = await AuthManager.create(scopes);
+  await authManager.loadTokenCache();
+
+  const outputFormat = toon ? 'toon' : 'json';
+  const graphClient = new GraphClient(authManager, secrets, outputFormat);
+  const cloudEndpoints = getCloudEndpoints(secrets.cloudType);
+  const tenantId = secrets.tenantId || 'common';
+  const clientId = secrets.clientId;
+  const clientSecret = secrets.clientSecret;
+
+  const app = express();
+  app.set('trust proxy', true);
+  app.use(express.json({ limit: '1mb' }));
+  app.use(express.urlencoded({ extended: true }));
+
+  // Request logging
+  app.use((req, _res, next) => {
+    logger.info(`${req.method} ${req.path}`);
+    next();
+  });
+
+  // CORS headers
+  const corsOrigin = process.env.MS365_MCP_CORS_ORIGIN || '*';
+  app.use((req, res, next) => {
+    res.header('Access-Control-Allow-Origin', corsOrigin);
+    res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+    res.header(
+      'Access-Control-Allow-Headers',
+      'Origin, X-Requested-With, Content-Type, Accept, Authorization, mcp-protocol-version'
+    );
+    if (req.method === 'OPTIONS') {
+      res.sendStatus(200);
+      return;
+    }
+    next();
+  });
+
+  // OAuth Authorization Server Discovery
+  app.get('/.well-known/oauth-authorization-server', (req, res) => {
+    const protocol = req.secure || req.headers['x-forwarded-proto'] === 'https' ? 'https' : 'http';
+    const origin = `${protocol}://${req.get('host')}`;
+
+    res.json({
+      issuer: origin,
+      authorization_endpoint: `${origin}/authorize`,
+      token_endpoint: `${origin}/token`,
+      registration_endpoint: `${origin}/register`,
+      response_types_supported: ['code'],
+      response_modes_supported: ['query'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      token_endpoint_auth_methods_supported: ['none'],
+      code_challenge_methods_supported: ['S256'],
+      scopes_supported: scopes,
+    });
+  });
+
+  // OAuth Protected Resource Discovery — path-specific per RFC 9728
+  const prmHandler = (req: Request, res: Response) => {
+    const protocol = req.secure || req.headers['x-forwarded-proto'] === 'https' ? 'https' : 'http';
+    const origin = `${protocol}://${req.get('host')}`;
+
+    res.json({
+      resource: `${origin}/mcp`,
+      authorization_servers: [origin],
+      scopes_supported: scopes,
+      bearer_methods_supported: ['header'],
+      resource_documentation: origin,
+    });
+  };
+  app.get('/.well-known/oauth-protected-resource', prmHandler);
+  app.get('/.well-known/oauth-protected-resource/mcp', prmHandler);
+
+  // Dynamic client registration
+  app.post('/register', (req, res) => {
+    const body = req.body;
+    const regClientId = `mcp-client-${Date.now()}`;
+
+    res.status(201).json({
+      client_id: regClientId,
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+      redirect_uris: body.redirect_uris || [],
+      grant_types: body.grant_types || ['authorization_code', 'refresh_token'],
+      response_types: body.response_types || ['code'],
+      token_endpoint_auth_method: body.token_endpoint_auth_method || 'none',
+      client_name: body.client_name || 'MCP Client',
+    });
+  });
+
+  // Authorization endpoint — redirects to Microsoft
+  app.get('/authorize', (req, res) => {
+    const url = new URL(req.url!, `${req.protocol}://${req.get('host')}`);
+
+    const microsoftAuthUrl = new URL(
+      `${cloudEndpoints.authority}/${tenantId}/oauth2/v2.0/authorize`
+    );
+
+    // Pass through standard OAuth parameters (except scope — we override it below)
+    const allowedParams = [
+      'response_type', 'redirect_uri', 'state', 'response_mode',
+      'code_challenge', 'code_challenge_method', 'prompt', 'login_hint', 'domain_hint',
+    ];
+
+    allowedParams.forEach((param) => {
+      const value = url.searchParams.get(param);
+      if (value) microsoftAuthUrl.searchParams.set(param, value);
+    });
+
+    microsoftAuthUrl.searchParams.set('client_id', clientId);
+
+    // Request the full set of delegated Microsoft Graph scopes.
+    // These must also be added as "Delegated permissions" in the Azure app registration
+    // under API permissions > Microsoft Graph.
+    microsoftAuthUrl.searchParams.set(
+      'scope',
+      'offline_access openid profile User.Read Mail.ReadWrite Mail.Send Calendars.ReadWrite Files.ReadWrite Files.Read.All Notes.Read Notes.Create Tasks.ReadWrite Contacts.ReadWrite People.Read OnlineMeetings.Read'
+    );
+
+    res.redirect(microsoftAuthUrl.toString());
+  });
+
+  // Token exchange endpoint
+  app.post('/token', async (req, res) => {
+    try {
+      const body = req.body;
+
+      if (!body?.grant_type) {
+        res.status(400).json({
+          error: 'invalid_request',
+          error_description: 'grant_type parameter is required',
+        });
+        return;
+      }
+
+      if (body.grant_type === 'authorization_code') {
+        const result = await exchangeCodeForToken(
+          body.code as string,
+          body.redirect_uri as string,
+          clientId,
+          clientSecret,
+          tenantId,
+          body.code_verifier as string | undefined,
+          secrets.cloudType
+        );
+        res.json(result);
+      } else if (body.grant_type === 'refresh_token') {
+        const result = await refreshAccessToken(
+          body.refresh_token as string,
+          clientId,
+          clientSecret,
+          tenantId,
+          secrets.cloudType
+        );
+        res.json(result);
+      } else {
+        res.status(400).json({
+          error: 'unsupported_grant_type',
+          error_description: `Grant type '${body.grant_type}' is not supported`,
+        });
+      }
+    } catch (error) {
+      logger.error(`Token endpoint error: ${(error as Error).message}`);
+      res.status(500).json({
+        error: 'server_error',
+        error_description: 'Internal server error during token exchange',
+      });
+    }
+  });
+
+  // MCP endpoint — protected by Microsoft bearer token
+  const mcpHandler = async (
+    req: Request & { microsoftAuth?: { accessToken: string; refreshToken: string } },
+    res: Response
+  ) => {
+    const handler = async () => {
+      // Derive allowed tools from the token's granted scopes; fall back to env var
+      const tokenFilter = req.microsoftAuth
+        ? buildToolFilterFromToken(req.microsoftAuth.accessToken)
+        : undefined;
+      const toolFilter = tokenFilter || enabledTools;
+
+      const server = new McpServer({ name: 'Microsoft365MCP', version });
+      registerGraphTools(server, graphClient, readOnly, toolFilter, orgMode, authManager, false, []);
+
+      // Custom tools also respect the token-derived filter
+      const customRegex = toolFilter ? new RegExp(toolFilter, 'i') : undefined;
+      registerWordTools(server, graphClient, customRegex);
+      registerExcelWriteTools(server, graphClient, readOnly, customRegex);
+
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true,
+      });
+      await server.connect(transport);
+      await transport.handleRequest(req as any, res as any, req.body);
+    };
+
+    try {
+      if (req.microsoftAuth) {
+        await requestContext.run(
+          {
+            accessToken: req.microsoftAuth.accessToken,
+            refreshToken: req.microsoftAuth.refreshToken,
+          },
+          handler
+        );
+      } else {
+        await handler();
+      }
+    } catch (error) {
+      logger.error(`MCP handler error: ${(error as Error).message}`);
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: '2.0',
+          error: { code: -32603, message: 'Internal server error' },
+          id: null,
+        });
+      }
+    }
+  };
+
+  app.get('/mcp', microsoftBearerTokenAuthMiddleware, mcpHandler);
+  app.post('/mcp', microsoftBearerTokenAuthMiddleware, mcpHandler);
+
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok', version });
+  });
+
+  // Catch-all for unmatched routes
+  app.use((req, res) => {
+    res.status(404).json({ error: 'not_found', path: req.originalUrl });
+  });
+
+  cachedApp = app;
+  return app;
+}
+
+export const handler = async (
+  event: Record<string, unknown>,
+  context: Record<string, unknown>
+): Promise<unknown> => {
+  if (!serverlessExpress) {
+    const app = await createApp();
+    const serverlessExpressModule = await import('@vendia/serverless-express');
+    const createHandler = serverlessExpressModule.default ?? serverlessExpressModule;
+    serverlessExpress = createHandler({ app });
+  }
+  return serverlessExpress(event, context);
+};

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -1,8 +1,10 @@
 /**
- * Secrets management module with optional Azure Key Vault support.
+ * Secrets management module with optional Azure Key Vault and AWS SSM support.
  *
- * When MS365_MCP_KEYVAULT_URL is set, secrets are fetched from Azure Key Vault.
- * Otherwise, secrets are read from environment variables (default behaviour).
+ * Priority:
+ *   1. MS365_MCP_KEYVAULT_URL → Azure Key Vault
+ *   2. MS365_MCP_SSM_PREFIX   → AWS Systems Manager Parameter Store
+ *   3. (default)              → Environment variables
  */
 
 import logger from './logger.js';
@@ -92,15 +94,85 @@ class KeyVaultSecretsProvider implements SecretsProvider {
 }
 
 /**
+ * AWS Systems Manager Parameter Store secrets provider.
+ * Requires @aws-sdk/client-ssm package.
+ *
+ * Parameter name mapping (using the configured prefix, default "/m365-mcp"):
+ *   - {prefix}/client-id     -> clientId
+ *   - {prefix}/tenant-id     -> tenantId     (optional, defaults to 'common')
+ *   - {prefix}/client-secret -> clientSecret  (optional)
+ *   - {prefix}/cloud-type    -> cloudType     (optional, defaults to 'global')
+ *
+ * All parameters are fetched with decryption enabled so SecureString values work.
+ * Set MS365_MCP_SSM_PREFIX to enable (e.g., "/m365-mcp" or "/prod/ms365").
+ * Optionally set MS365_MCP_SSM_REGION to override the AWS region.
+ */
+class SsmSecretsProvider implements SecretsProvider {
+  private prefix: string;
+
+  constructor(prefix: string) {
+    this.prefix = prefix.replace(/\/+$/, ''); // strip trailing slashes
+  }
+
+  private async getParameter(name: string): Promise<string | undefined> {
+    const { SSMClient, GetParameterCommand } = await import('@aws-sdk/client-ssm');
+    const region = process.env.MS365_MCP_SSM_REGION;
+    const ssm = new SSMClient(region ? { region } : {});
+    try {
+      const result = await ssm.send(
+        new GetParameterCommand({ Name: `${this.prefix}/${name}`, WithDecryption: true })
+      );
+      return result.Parameter?.Value ?? undefined;
+    } catch (error) {
+      // ParameterNotFound is non-fatal for optional params
+      if ((error as { name?: string }).name === 'ParameterNotFound') {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  async getSecrets(): Promise<AppSecrets> {
+    logger.info(`Fetching secrets from AWS SSM with prefix: ${this.prefix}`);
+
+      this.getParameter('client-id'),
+      this.getParameter('tenant-id'),
+      this.getParameter('client-secret'),
+      this.getParameter('cloud-type'),
+      
+    ]);
+
+    if (!clientId) {
+      throw new Error(`Required SSM parameter ${this.prefix}/client-id not found`);
+    }
+
+    logger.info('Successfully retrieved secrets from AWS SSM');
+
+    return {
+      clientId,
+      tenantId: tenantId || 'common',
+      clientSecret,
+      cloudType: parseCloudType(cloudTypeRaw),
+      
+    };
+  }
+}
+
+/**
  * Creates a secrets provider based on environment configuration.
- * Uses Key Vault if MS365_MCP_KEYVAULT_URL is set, otherwise uses environment variables.
+ * Priority: Key Vault > AWS SSM > Environment variables.
  */
 function createSecretsProvider(): SecretsProvider {
   const vaultUrl = process.env.MS365_MCP_KEYVAULT_URL;
-
   if (vaultUrl) {
     logger.info('Key Vault URL configured, using Azure Key Vault for secrets');
     return new KeyVaultSecretsProvider(vaultUrl);
+  }
+
+  const ssmPrefix = process.env.MS365_MCP_SSM_PREFIX;
+  if (ssmPrefix) {
+    logger.info('SSM prefix configured, using AWS Systems Manager Parameter Store for secrets');
+    return new SsmSecretsProvider(ssmPrefix);
   }
 
   logger.info('Using environment variables for secrets');

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,8 @@ import express, { Request, Response } from 'express';
 import logger, { enableConsoleLogging } from './logger.js';
 import { registerAuthTools } from './auth-tools.js';
 import { registerGraphTools, registerDiscoveryTools } from './graph-tools.js';
+import { registerWordTools } from './custom-tools/word.js';
+import { registerExcelWriteTools } from './custom-tools/excel-write.js';
 import GraphClient from './graph-client.js';
 import AuthManager, { buildScopesFromEndpoints } from './auth.js';
 import { MicrosoftOAuthProvider } from './oauth-provider.js';
@@ -95,6 +97,18 @@ class MicrosoftGraphServer {
         this.accountNames
       );
     }
+
+    // Register custom tools (Word, Excel write) that need logic beyond data-driven endpoints
+    let enabledToolsRegex: RegExp | undefined;
+    if (this.options.enabledTools) {
+      try {
+        enabledToolsRegex = new RegExp(this.options.enabledTools, 'i');
+      } catch {
+        // Invalid regex — ignore filter
+      }
+    }
+    registerWordTools(server, this.graphClient!, enabledToolsRegex);
+    registerExcelWriteTools(server, this.graphClient!, this.options.readOnly, enabledToolsRegex);
 
     return server;
   }

--- a/src/tool-categories.ts
+++ b/src/tool-categories.ts
@@ -36,8 +36,8 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   },
   excel: {
     name: 'excel',
-    pattern: /excel|worksheet|workbook|range|chart/i,
-    description: 'Excel spreadsheet operations',
+    pattern: /excel|worksheet|workbook|range|chart|append/i,
+    description: 'Excel spreadsheet operations (including write/append/clear)',
   },
   contacts: {
     name: 'contacts',

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,112 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  Microsoft 365 MCP Server — Lambda deployment with SSM secrets and OAuth 2.1.
+  Deploy with: sam build && sam deploy
+
+Parameters:
+  SsmPrefix:
+    Type: String
+    Default: /m365-mcp
+    Description: >
+      SSM Parameter Store prefix for secrets.
+      Expected parameters: {prefix}/client-id, {prefix}/client-secret (optional),
+      {prefix}/tenant-id (optional), {prefix}/cloud-type (optional).
+
+Globals:
+  Function:
+    Timeout: 30
+    MemorySize: 256
+    Runtime: nodejs20.x
+    Environment:
+      Variables:
+        MS365_MCP_SSM_PREFIX: !Ref SsmPrefix
+        NODE_OPTIONS: --enable-source-maps
+
+Resources:
+  M365McpFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: m365-mcp-server
+      CodeUri: ./
+      Handler: lambda.handler
+      Description: MCP server bridging Claude to Microsoft 365 via Graph API
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ssm:GetParameter
+              Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${SsmPrefix}/*'
+      Events:
+        McpPost:
+          Type: HttpApi
+          Properties:
+            Path: /mcp
+            Method: POST
+        McpGet:
+          Type: HttpApi
+          Properties:
+            Path: /mcp
+            Method: GET
+        McpDelete:
+          Type: HttpApi
+          Properties:
+            Path: /mcp
+            Method: DELETE
+        HealthCheck:
+          Type: HttpApi
+          Properties:
+            Path: /health
+            Method: GET
+        OAuthDiscovery:
+          Type: HttpApi
+          Properties:
+            Path: /.well-known/oauth-authorization-server
+            Method: GET
+        OAuthResource:
+          Type: HttpApi
+          Properties:
+            Path: /.well-known/oauth-protected-resource
+            Method: GET
+        OAuthResourceMcp:
+          Type: HttpApi
+          Properties:
+            Path: /.well-known/oauth-protected-resource/mcp
+            Method: GET
+        OAuthRegister:
+          Type: HttpApi
+          Properties:
+            Path: /register
+            Method: POST
+        OAuthAuthorize:
+          Type: HttpApi
+          Properties:
+            Path: /authorize
+            Method: GET
+        OAuthToken:
+          Type: HttpApi
+          Properties:
+            Path: /token
+            Method: POST
+        OAuthTokenOptions:
+          Type: HttpApi
+          Properties:
+            Path: /token
+            Method: OPTIONS
+        McpOptions:
+          Type: HttpApi
+          Properties:
+            Path: /mcp
+            Method: OPTIONS
+        RegisterOptions:
+          Type: HttpApi
+          Properties:
+            Path: /register
+            Method: OPTIONS
+    Metadata:
+      BuildMethod: makefile
+
+Outputs:
+  McpEndpointUrl:
+    Description: MCP endpoint URL to add to Claude Settings > Connectors
+    Value: !Sub 'https://${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com/mcp'


### PR DESCRIPTION
## Summary
- Full AWS Lambda deployment via SAM with OAuth 2.1 proxy (Claude → Lambda → Microsoft)
- Dynamic tool filtering: decodes the Microsoft JWT's `scp` claim to only register tools the user has permissions for
- Custom Word tools (read, outline, search) and Excel write tools (write-range, append-rows, clear-range, create-workbook)
- AWS SSM Parameter Store integration for secrets (client-id, tenant-id, client-secret, cloud-type)
- Stateless MCP transport with `enableJsonResponse` for Lambda compatibility (fixes "Promise never settled" crashes)
- Makefile-based esbuild bundling

## Architecture
```
Claude Desktop → API Gateway → Lambda (Express)
  ├─ /.well-known/* → OAuth discovery
  ├─ /authorize → redirect to Microsoft login
  ├─ /token → exchange code with Microsoft
  ├─ /register → dynamic client registration
  └─ /mcp → Bearer token auth → MCP tools → Graph API
```

## New files
- `src/lambda.ts` — Lambda handler with OAuth 2.1 proxy and scope-based tool filtering
- `src/custom-tools/word.ts` — Word document tools (read, outline, search)
- `src/custom-tools/excel-write.ts` — Excel write tools + create-workbook
- `template.yaml` — SAM template with API Gateway routes
- `Makefile` — esbuild bundling for Lambda

## Test plan
- [ ] `sam build && sam deploy` creates working stack
- [ ] OAuth flow completes: Claude Desktop → Microsoft login → connector connected
- [ ] Tool filtering matches granted scopes (e.g., only mail tools if only Mail.ReadWrite granted)
- [ ] `create-workbook` creates empty .xlsx in OneDrive
- [ ] `write-excel-range` / `append-excel-rows` populate workbook data
- [ ] Word tools read .docx files from OneDrive
- [ ] Health endpoint responds without auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)