### PR TITLE
fix: return new refresh token to client after server-side 401 retry

### DIFF
--- a/src/__tests__/graph-client-refresh.test.ts
+++ b/src/__tests__/graph-client-refresh.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { requestContext } from '../request-context.js';
+
+// Mock logger
+vi.mock('../logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock cloud-config
+vi.mock('../cloud-config.js', () => ({
+  getCloudEndpoints: () => ({
+    graphApi: 'https://graph.microsoft.com',
+    authority: 'https://login.microsoftonline.com',
+  }),
+}));
+
+// Mock microsoft-auth
+const mockRefreshAccessToken = vi.fn();
+vi.mock('../lib/microsoft-auth.js', () => ({
+  refreshAccessToken: (...args: any[]) => mockRefreshAccessToken(...args),
+}));
+
+// Mock toon
+vi.mock('@toon-format/toon', () => ({
+  encode: (data: any) => JSON.stringify(data),
+}));
+
+// Mock auth manager
+const mockAuthManager = {
+  getToken: vi.fn().mockResolvedValue('mock-access-token'),
+};
+
+const mockSecrets = {
+  clientId: 'test-client-id',
+  tenantId: 'test-tenant-id',
+  clientSecret: 'test-client-secret',
+  cloudType: 'global' as const,
+};
+
+// We need to import GraphClient after mocks are set up
+const { default: GraphClient } = await import('../graph-client.js');
+
+describe('GraphClient refresh token notification', () => {
+  let graphClient: InstanceType<typeof GraphClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    graphClient = new GraphClient(mockAuthManager as any, mockSecrets);
+  });
+
+  it('should call notifyTokenRefreshed when 401 triggers a token refresh', async () => {
+    const onTokenRefreshed = vi.fn();
+
+    // First call returns 401, second returns 200
+    const mockFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' })
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ value: 'ok' }), { status: 200 }));
+
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      access_token: 'new-access-token',
+      refresh_token: 'new-refresh-token-v2',
+      token_type: 'Bearer',
+      scope: 'User.Read',
+      expires_in: 3600,
+    });
+
+    await requestContext.run(
+      {
+        accessToken: 'expired-access-token',
+        refreshToken: 'old-refresh-token',
+        onTokenRefreshed,
+      },
+      async () => {
+        await graphClient.makeRequest('/me');
+      }
+    );
+
+    expect(onTokenRefreshed).toHaveBeenCalledWith('new-refresh-token-v2');
+    expect(onTokenRefreshed).toHaveBeenCalledTimes(1);
+    expect(mockRefreshAccessToken).toHaveBeenCalledWith(
+      'old-refresh-token',
+      'test-client-id',
+      'test-client-secret',
+      'test-tenant-id',
+      'global'
+    );
+
+    mockFetch.mockRestore();
+  });
+
+  it('should not call notifyTokenRefreshed when no 401 occurs', async () => {
+    const onTokenRefreshed = vi.fn();
+
+    const mockFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({ value: 'ok' }), { status: 200 }));
+
+    await requestContext.run(
+      {
+        accessToken: 'valid-access-token',
+        refreshToken: 'refresh-token',
+        onTokenRefreshed,
+      },
+      async () => {
+        await graphClient.makeRequest('/me');
+      }
+    );
+
+    expect(onTokenRefreshed).not.toHaveBeenCalled();
+    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+
+    mockFetch.mockRestore();
+  });
+
+  it('should not call notifyTokenRefreshed when refresh returns no refresh_token', async () => {
+    const onTokenRefreshed = vi.fn();
+
+    const mockFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' })
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ value: 'ok' }), { status: 200 }));
+
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      access_token: 'new-access-token',
+      // No refresh_token in response
+      token_type: 'Bearer',
+      scope: 'User.Read',
+      expires_in: 3600,
+    });
+
+    await requestContext.run(
+      {
+        accessToken: 'expired-access-token',
+        refreshToken: 'old-refresh-token',
+        onTokenRefreshed,
+      },
+      async () => {
+        await graphClient.makeRequest('/me');
+      }
+    );
+
+    expect(onTokenRefreshed).not.toHaveBeenCalled();
+
+    mockFetch.mockRestore();
+  });
+
+  it('should not throw when 401 occurs without onTokenRefreshed callback', async () => {
+    const mockFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' })
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ value: 'ok' }), { status: 200 }));
+
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      access_token: 'new-access-token',
+      refresh_token: 'new-refresh-token',
+      token_type: 'Bearer',
+      scope: 'User.Read',
+      expires_in: 3600,
+    });
+
+    await requestContext.run(
+      {
+        accessToken: 'expired-access-token',
+        refreshToken: 'old-refresh-token',
+        // No onTokenRefreshed callback
+      },
+      async () => {
+        const result = await graphClient.makeRequest('/me');
+        expect(result).toEqual({ value: 'ok' });
+      }
+    );
+
+    mockFetch.mockRestore();
+  });
+});

--- a/src/__tests__/graph-client-refresh.test.ts
+++ b/src/__tests__/graph-client-refresh.test.ts
@@ -185,3 +185,88 @@ describe('GraphClient refresh token notification', () => {
     mockFetch.mockRestore();
   });
 });
+
+describe('GraphClient context update after refresh', () => {
+  let graphClient: InstanceType<typeof GraphClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    graphClient = new GraphClient(mockAuthManager as any, mockSecrets);
+  });
+
+  it('should update context tokens so second call uses the new refresh token', async () => {
+    const onTokenRefreshed = vi.fn();
+
+    // First makeRequest: 401 -> refresh -> retry 200
+    // Second makeRequest: 401 -> refresh with NEW token -> retry 200
+    const mockFetch = vi
+      .spyOn(globalThis, 'fetch')
+      // First call: 401
+      .mockResolvedValueOnce(
+        new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' })
+      )
+      // First call retry: 200
+      .mockResolvedValueOnce(new Response(JSON.stringify({ value: 'first' }), { status: 200 }))
+      // Second call: 401
+      .mockResolvedValueOnce(
+        new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' })
+      )
+      // Second call retry: 200
+      .mockResolvedValueOnce(new Response(JSON.stringify({ value: 'second' }), { status: 200 }));
+
+    // First refresh returns rt-v2
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      access_token: 'at-v2',
+      refresh_token: 'rt-v2',
+      token_type: 'Bearer',
+      scope: 'User.Read',
+      expires_in: 3600,
+    });
+
+    // Second refresh returns rt-v3
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      access_token: 'at-v3',
+      refresh_token: 'rt-v3',
+      token_type: 'Bearer',
+      scope: 'User.Read',
+      expires_in: 3600,
+    });
+
+    await requestContext.run(
+      {
+        accessToken: 'at-v1',
+        refreshToken: 'rt-v1',
+        onTokenRefreshed,
+      },
+      async () => {
+        await graphClient.makeRequest('/me');
+        await graphClient.makeRequest('/calendars');
+      }
+    );
+
+    // Second refresh should use rt-v2 (updated context), NOT rt-v1
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(2);
+    expect(mockRefreshAccessToken).toHaveBeenNthCalledWith(
+      1,
+      'rt-v1',
+      'test-client-id',
+      'test-client-secret',
+      'test-tenant-id',
+      'global'
+    );
+    expect(mockRefreshAccessToken).toHaveBeenNthCalledWith(
+      2,
+      'rt-v2', // Must be the rotated token, not the original
+      'test-client-id',
+      'test-client-secret',
+      'test-tenant-id',
+      'global'
+    );
+
+    expect(onTokenRefreshed).toHaveBeenCalledTimes(2);
+    expect(onTokenRefreshed).toHaveBeenNthCalledWith(1, 'rt-v2');
+    expect(onTokenRefreshed).toHaveBeenNthCalledWith(2, 'rt-v3');
+
+    mockFetch.mockRestore();
+  });
+});

--- a/src/__tests__/request-context.test.ts
+++ b/src/__tests__/request-context.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { requestContext, getRequestTokens, notifyTokenRefreshed } from '../request-context.js';
+
+describe('request-context', () => {
+  describe('notifyTokenRefreshed', () => {
+    it('should call onTokenRefreshed callback with the new refresh token', async () => {
+      const callback = vi.fn();
+
+      await requestContext.run(
+        {
+          accessToken: 'test-access-token',
+          refreshToken: 'old-refresh-token',
+          onTokenRefreshed: callback,
+        },
+        () => {
+          notifyTokenRefreshed('new-refresh-token');
+        }
+      );
+
+      expect(callback).toHaveBeenCalledWith('new-refresh-token');
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw when no callback is set', async () => {
+      await requestContext.run(
+        {
+          accessToken: 'test-access-token',
+        },
+        () => {
+          expect(() => notifyTokenRefreshed('new-refresh-token')).not.toThrow();
+        }
+      );
+    });
+
+    it('should not throw when called outside of request context', () => {
+      expect(() => notifyTokenRefreshed('new-refresh-token')).not.toThrow();
+    });
+
+    it('should call callback multiple times if refresh happens multiple times', async () => {
+      const callback = vi.fn();
+
+      await requestContext.run(
+        {
+          accessToken: 'test-access-token',
+          onTokenRefreshed: callback,
+        },
+        () => {
+          notifyTokenRefreshed('rt-v2');
+          notifyTokenRefreshed('rt-v3');
+        }
+      );
+
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback).toHaveBeenNthCalledWith(1, 'rt-v2');
+      expect(callback).toHaveBeenNthCalledWith(2, 'rt-v3');
+    });
+  });
+
+  describe('getRequestTokens', () => {
+    it('should return tokens within request context', async () => {
+      await requestContext.run(
+        {
+          accessToken: 'at',
+          refreshToken: 'rt',
+        },
+        () => {
+          const tokens = getRequestTokens();
+          expect(tokens?.accessToken).toBe('at');
+          expect(tokens?.refreshToken).toBe('rt');
+        }
+      );
+    });
+
+    it('should return undefined outside of request context', () => {
+      expect(getRequestTokens()).toBeUndefined();
+    });
+  });
+});

--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -4,7 +4,7 @@ import { refreshAccessToken } from './lib/microsoft-auth.js';
 import { encode as toonEncode } from '@toon-format/toon';
 import type { AppSecrets } from './secrets.js';
 import { getCloudEndpoints } from './cloud-config.js';
-import { getRequestTokens } from './request-context.js';
+import { getRequestTokens, notifyTokenRefreshed } from './request-context.js';
 
 interface GraphRequestOptions {
   headers?: Record<string, string>;
@@ -66,6 +66,10 @@ class GraphClient {
         // Token expired, try to refresh
         const newTokens = await this.refreshAccessToken(refreshToken);
         accessToken = newTokens.accessToken;
+
+        if (newTokens.refreshToken) {
+          notifyTokenRefreshed(newTokens.refreshToken);
+        }
 
         // Retry the request with new token
         response = await this.performRequest(endpoint, accessToken, options);

--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -68,6 +68,11 @@ class GraphClient {
         accessToken = newTokens.accessToken;
 
         if (newTokens.refreshToken) {
+          // Update context so subsequent calls in this request use the new tokens
+          if (contextTokens) {
+            contextTokens.accessToken = newTokens.accessToken;
+            contextTokens.refreshToken = newTokens.refreshToken;
+          }
           notifyTokenRefreshed(newTokens.refreshToken);
         }
 

--- a/src/request-context.ts
+++ b/src/request-context.ts
@@ -3,10 +3,16 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 export interface RequestContext {
   accessToken: string;
   refreshToken?: string;
+  onTokenRefreshed?: (newRefreshToken: string) => void;
 }
 
 export const requestContext = new AsyncLocalStorage<RequestContext>();
 
 export function getRequestTokens(): RequestContext | undefined {
   return requestContext.getStore();
+}
+
+export function notifyTokenRefreshed(newRefreshToken: string): void {
+  const ctx = requestContext.getStore();
+  ctx?.onTokenRefreshed?.(newRefreshToken);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -408,6 +408,11 @@ class MicrosoftGraphServer {
                 {
                   accessToken: req.microsoftAuth.accessToken,
                   refreshToken: req.microsoftAuth.refreshToken,
+                  onTokenRefreshed: (newRefreshToken: string) => {
+                    if (!res.headersSent) {
+                      res.setHeader('x-microsoft-new-refresh-token', newRefreshToken);
+                    }
+                  },
                 },
                 handler
               );
@@ -457,6 +462,11 @@ class MicrosoftGraphServer {
                 {
                   accessToken: req.microsoftAuth.accessToken,
                   refreshToken: req.microsoftAuth.refreshToken,
+                  onTokenRefreshed: (newRefreshToken: string) => {
+                    if (!res.headersSent) {
+                      res.setHeader('x-microsoft-new-refresh-token', newRefreshToken);
+                    }
+                  },
                 },
                 handler
               );


### PR DESCRIPTION
## Summary

Fixes #336

When the server refreshes a token due to a `401` response from Microsoft Graph API in HTTP mode, the new refresh token was **silently discarded**. Due to Microsoft's [refresh token rotation](https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens#refresh-token-lifetime), this invalidated the client's stored refresh token, breaking subsequent requests.

## Changes

### `src/request-context.ts`
- Added `onTokenRefreshed` optional callback to `RequestContext` interface
- Added `notifyTokenRefreshed()` helper function that invokes the callback within the current async context

### `src/graph-client.ts`
- After a successful token refresh on 401 retry, calls `notifyTokenRefreshed()` with the new refresh token (+4 lines)

### `src/server.ts`
- Both GET and POST `/mcp` handlers now pass an `onTokenRefreshed` callback to `requestContext.run()` that sets the response header `x-microsoft-new-refresh-token` with the new refresh token
- Includes `res.headersSent` safety check

## Design

Uses a **callback pattern** to maintain separation of concerns:
- `graph-client.ts` has no knowledge of Express or `res` — it only calls `notifyTokenRefreshed()`
- `server.ts` binds the callback to `res.setHeader()` when setting up the request context
- The header is set **during** tool execution (before `StreamableHTTPServerTransport` writes the response), so it is included in the HTTP response

```
graph-client.ts                request-context.ts              server.ts
     |                               |                           |
     | 401 → refresh                 |                           |
     | new RT obtained               |                           |
     |-- notifyTokenRefreshed(RT) -->|                           |
     |                               |-- onTokenRefreshed(RT) -->|
     |                               |     res.setHeader(...)    |
     |                               |                           |
     | retry with new AT             |                           |
     |                    [transport writes response with header] |
```

## Clients

After this fix, HTTP mode clients should check for the `x-microsoft-new-refresh-token` response header on every `/mcp` response. If present, the client should update its stored refresh token with the new value.

## Tests

Added 10 new tests (all passing):
- `src/__tests__/request-context.test.ts` — callback invocation, edge cases (no callback, outside context, multiple calls)
- `src/__tests__/graph-client-refresh.test.ts` — 401 retry with callback, no 401 case, no refresh_token in response, missing callback

## Possibly related

- #287 — "Need to reregister OWUI client after X amount of time" may be a symptom of this issue