### PR TITLE
fix: remove personal account scope from list-chat-members endpoint

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -581,7 +581,6 @@
     "pathPattern": "/chats/{chat-id}/members",
     "method": "get",
     "toolName": "list-chat-members",
-    "scopes": ["ChatMember.Read"],
     "workScopes": ["ChatMember.Read"],
     "llmTip": "Lists members of a chat. Each member has displayName, email, roles (owner/guest), and visibleHistoryStartDateTime. For meeting chats, use the chatInfo.threadId from get-online-meeting as the chat-id to see who participated in the meeting chat."
   },


### PR DESCRIPTION
The /chats/{chat-id}/members endpoint does not support personal Microsoft accounts. Remove the delegated personal scope to prevent invalid_grant errors for consumer tenant users.