### PR TITLE
fix: stop forwarding PKCE code_challenge to Microsoft OAuth endpoint

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -249,14 +249,15 @@ class MicrosoftGraphServer {
         );
 
         // Only forward parameters that Microsoft OAuth 2.0 v2.0 supports
+        // Note: code_challenge/code_challenge_method are NOT forwarded because
+        // PKCE between the client (e.g. claude.ai) and this server is a separate
+        // flow from this server's auth with Microsoft.
         const allowedParams = [
           'response_type',
           'redirect_uri',
           'scope',
           'state',
           'response_mode',
-          'code_challenge',
-          'code_challenge_method',
           'prompt',
           'login_hint',
           'domain_hint',


### PR DESCRIPTION
The /authorize handler was forwarding claude.ai's code_challenge directly to Microsoft, which rejected it with AADSTS501491. The PKCE exchange between claude.ai and the MCP server is a separate flow from the server's own auth with Microsoft.

This fixes the OAuth flow for confidential clients (with client_secret). Full two-leg PKCE support for public clients is a separate effort.

Ref #266