### PR TITLE
revert: undo PKCE code_challenge removal that broke Claude Code OAuth

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -249,15 +249,14 @@ class MicrosoftGraphServer {
         );
 
         // Only forward parameters that Microsoft OAuth 2.0 v2.0 supports
-        // Note: code_challenge/code_challenge_method are NOT forwarded because
-        // PKCE between the client (e.g. claude.ai) and this server is a separate
-        // flow from this server's auth with Microsoft.
         const allowedParams = [
           'response_type',
           'redirect_uri',
           'scope',
           'state',
           'response_mode',
+          'code_challenge',
+          'code_challenge_method',
           'prompt',
           'login_hint',
           'domain_hint',


### PR DESCRIPTION
Reverts #341. Removing code_challenge forwarding breaks OAuth for Claude Code, which relies on the PKCE challenge being proxied through to Microsoft. The original issue #266 is specific to claude.ai web and needs a different approach.