### PR TITLE
feat: add MCP server instructions and context handling

### DIFF
--- a/src/mcp-instructions.ts
+++ b/src/mcp-instructions.ts
@@ -1,0 +1,39 @@
+/** Shared context for MCP `initialize.instructions` (hosts that forward it to the model). */
+export type McpInstructionsContext = {
+  orgMode: boolean;
+  readOnly: boolean;
+  multiAccount: boolean;
+};
+
+function buildGeneralMcpInstructions(opts: McpInstructionsContext): string {
+  const parts = [
+    'Microsoft 365 MCP exposes Microsoft Graph through MCP tools. Use each tool name, description, and parameter schema as the source of truth.',
+    'Microsoft Graph OData: do not combine $filter with $search on the same request. For lists, prefer modest $top (or top) and $select; avoid very large pages unless the user needs them.',
+    'Mail and message $search uses KQL; the $search query parameter value must be double-quoted per Graph (see search-query-parameter in Microsoft Graph docs).',
+    'When you need an organizational user or recipient address, resolve it with list-users (or another directory tool); do not invent SMTP addresses.',
+    'Directory $search on collections such as /users or /groups requires ConsistencyLevel: eventual when the tool exposes that header.',
+    'Teams chat and channel messages: prefer HTML contentType in the body; plain text is often mangled by Graph.',
+  ];
+  if (opts.readOnly) parts.push('This server is read-only; write operations are disabled.');
+  if (opts.multiAccount)
+    parts.push('Multiple accounts: pass the account parameter when required (see list-accounts).');
+  if (!opts.orgMode)
+    parts.push('Work/school-only tools require starting the server with --org-mode.');
+  return parts.join(' ');
+}
+
+const DISCOVERY_MODE_INSTRUCTIONS_ADDON =
+  'DISCOVERY MODE ADD-ON: Graph is reached via search-tools then execute-tool (plus auth helpers). ' +
+  'Call search-tools with short keywords, then execute-tool with tool_name exactly as returned; put Graph parameters in the parameters object. ' +
+  'If search-tools returns no matches, retry with shorter or different keywords.';
+
+/**
+ * Full MCP `initialize.instructions` string: general guidance for every mode, plus a discovery-only suffix when applicable.
+ */
+export function buildMcpServerInstructions(
+  opts: McpInstructionsContext & { discovery: boolean }
+): string {
+  const general = buildGeneralMcpInstructions(opts);
+  if (!opts.discovery) return general;
+  return `${general} ${DISCOVERY_MODE_INSTRUCTIONS_ADDON}`;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import express, { Request, Response } from 'express';
 import logger, { enableConsoleLogging } from './logger.js';
 import { registerAuthTools } from './auth-tools.js';
 import { registerGraphTools, registerDiscoveryTools } from './graph-tools.js';
+import { buildMcpServerInstructions } from './mcp-instructions.js';
 import GraphClient from './graph-client.js';
 import AuthManager, { buildScopesFromEndpoints } from './auth.js';
 import { MicrosoftOAuthProvider } from './oauth-provider.js';
@@ -76,10 +77,20 @@ class MicrosoftGraphServer {
   }
 
   private createMcpServer(): McpServer {
-    const server = new McpServer({
-      name: 'Microsoft365MCP',
-      version: this.version,
-    });
+    const server = new McpServer(
+      {
+        name: 'Microsoft365MCP',
+        version: this.version,
+      },
+      {
+        instructions: buildMcpServerInstructions({
+          discovery: Boolean(this.options.discovery),
+          orgMode: Boolean(this.options.orgMode),
+          readOnly: Boolean(this.options.readOnly),
+          multiAccount: this.multiAccount,
+        }),
+      }
+    );
 
     const shouldRegisterAuthTools = !this.options.http || this.options.enableAuthTools;
     if (shouldRegisterAuthTools) {

--- a/test/mcp-instructions.test.ts
+++ b/test/mcp-instructions.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { buildMcpServerInstructions } from '../src/mcp-instructions.js';
+
+describe('buildMcpServerInstructions', () => {
+  const baseCtx = { orgMode: true, readOnly: false, multiAccount: false };
+
+  it('includes general Graph guidance for standard mode', () => {
+    const s = buildMcpServerInstructions({ ...baseCtx, discovery: false });
+    expect(s).toContain('Microsoft Graph');
+    expect(s).toContain('$filter');
+    expect(s).not.toContain('DISCOVERY MODE ADD-ON');
+  });
+
+  it('appends discovery addon when discovery is true', () => {
+    const s = buildMcpServerInstructions({ ...baseCtx, discovery: true });
+    expect(s).toContain('DISCOVERY MODE ADD-ON');
+    expect(s).toContain('search-tools');
+    expect(s).toContain('$filter');
+  });
+
+  it('adds read-only line when readOnly', () => {
+    const s = buildMcpServerInstructions({ ...baseCtx, discovery: false, readOnly: true });
+    expect(s).toContain('read-only');
+  });
+});


### PR DESCRIPTION
## Summary

Adds MCP `initialize.instructions` for all server modes with specific instructions based on MCP mode like discovery or org mode. 

## Motivation

Hosts that honor MCP server instructions can inject a short usage guide for the model. Standard mode previously had no instructions; discovery-only text didn’t cover normal tool listings. This uses one shared baseline and appends discovery-specific workflow only when needed.

This was in response to a comment made on one of my PR's about such a fix. I thought i would give it a try to take some load off of your shoulders. Feel free to make any changes:  https://github.com/Softeria/ms-365-mcp-server/pull/349#issuecomment-4184110434

## Changes

- **`src/graph-tools.ts`:** `buildMcpServerInstructions({ discovery, orgMode, readOnly, multiAccount })`, `McpInstructionsContext`, general instructions + `DISCOVERY_MODE_INSTRUCTIONS_ADDON`.
- **`src/server.ts`:** `createMcpServer()` always passes `{ instructions: buildMcpServerInstructions(...) }` to `new McpServer(...)`.
- **`test/mcp-instructions.test.ts`:** Tests for standard vs discovery text and read-only.