### PR TITLE
fix: persist rotated refresh tokens to prevent session disconnects

### DIFF
--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -5,6 +5,7 @@ import { encode as toonEncode } from '@toon-format/toon';
 import type { AppSecrets } from './secrets.js';
 import { getCloudEndpoints } from './cloud-config.js';
 import { getRequestTokens } from './request-context.js';
+import { storeTokens } from './token-store.js';
 
 interface GraphRequestOptions {
   headers?: Record<string, string>;
@@ -66,6 +67,15 @@ class GraphClient {
         // Token expired, try to refresh
         const newTokens = await this.refreshAccessToken(refreshToken);
         accessToken = newTokens.accessToken;
+
+        // Persist rotated tokens so subsequent requests and client refreshes use the new RT
+        if (newTokens.refreshToken) {
+          if (contextTokens) {
+            contextTokens.accessToken = newTokens.accessToken;
+            contextTokens.refreshToken = newTokens.refreshToken;
+          }
+          storeTokens(refreshToken, newTokens.accessToken, newTokens.refreshToken);
+        }
 
         // Retry the request with new token
         response = await this.performRequest(endpoint, accessToken, options);

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,12 @@ import type { CommandOptions } from './cli.ts';
 import { getSecrets, type AppSecrets } from './secrets.js';
 import { getCloudEndpoints } from './cloud-config.js';
 import { requestContext } from './request-context.js';
+import {
+  initTokenStore,
+  getLatestRefreshToken,
+  storeTokens,
+  cleanupTokenStore,
+} from './token-store.js';
 import crypto from 'node:crypto';
 
 /**
@@ -425,6 +431,13 @@ class MicrosoftGraphServer {
             const clientId = this.secrets!.clientId;
             const clientSecret = this.secrets?.clientSecret;
 
+            // Use the latest refresh token from store (may have been rotated by a 401 retry)
+            const clientRT = body.refresh_token as string;
+            const latestRT = getLatestRefreshToken(clientRT);
+            if (latestRT !== clientRT) {
+              logger.info('Refresh endpoint: Using rotated refresh token from store');
+            }
+
             // Log whether using public or confidential client
             if (clientSecret) {
               logger.info('Refresh endpoint: Using confidential client with client_secret');
@@ -433,12 +446,18 @@ class MicrosoftGraphServer {
             }
 
             const result = await refreshAccessToken(
-              body.refresh_token as string,
+              latestRT,
               clientId,
               clientSecret,
               tenantId,
               this.secrets!.cloudType
             );
+
+            // Persist the new tokens
+            if (result.refresh_token) {
+              storeTokens(clientRT, result.access_token, result.refresh_token);
+            }
+
             res.json(result);
           } else {
             res.status(400).json({
@@ -570,6 +589,14 @@ class MicrosoftGraphServer {
       app.get('/', (req, res) => {
         res.send('Microsoft 365 MCP Server is running');
       });
+
+      // Initialize token rotation store (persists Azure AD tokens across 401 retries)
+      const tokenStoreDir =
+        process.env.MS365_MCP_TOKEN_STORE_DIR || new URL('..', import.meta.url).pathname;
+      initTokenStore(tokenStoreDir);
+
+      // Cleanup expired sessions every hour
+      setInterval(cleanupTokenStore, 60 * 60 * 1000);
 
       if (host) {
         app.listen(port, host, () => {

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import logger from './logger.js';
+
+interface StoredTokens {
+  accessToken: string;
+  refreshToken: string;
+  updatedAt: number;
+}
+
+const tokenMap = new Map<string, StoredTokens>();
+let storePath: string | undefined;
+
+export function initTokenStore(dataDir?: string): void {
+  if (!dataDir) return;
+  storePath = path.join(dataDir, 'token-cache.json');
+  try {
+    const data = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
+    for (const [k, v] of Object.entries(data)) {
+      tokenMap.set(k, v as StoredTokens);
+    }
+    logger.info(`Token store loaded: ${tokenMap.size} sessions`);
+  } catch {
+    logger.info('Token store: starting fresh');
+  }
+}
+
+function save(): void {
+  if (!storePath) return;
+  try {
+    const tmp = storePath + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(Object.fromEntries(tokenMap)));
+    fs.renameSync(tmp, storePath);
+  } catch (e) {
+    logger.error('Token store save failed:', e);
+  }
+}
+
+/**
+ * Derive a stable session key from the refresh token prefix.
+ * The first refresh token in a session establishes the key;
+ * subsequent rotations update the stored tokens but keep the same key.
+ */
+function sessionKey(refreshToken: string): string {
+  return refreshToken.slice(0, 16);
+}
+
+export function storeTokens(
+  originalRefreshToken: string,
+  accessToken: string,
+  refreshToken: string
+): void {
+  const key = sessionKey(originalRefreshToken);
+  tokenMap.set(key, { accessToken, refreshToken, updatedAt: Date.now() });
+  // Also index by the new refresh token prefix for future lookups
+  const newKey = sessionKey(refreshToken);
+  if (newKey !== key) {
+    tokenMap.set(newKey, { accessToken, refreshToken, updatedAt: Date.now() });
+  }
+  save();
+  logger.info('Token store: session updated');
+}
+
+export function getLatestRefreshToken(refreshToken: string): string {
+  const key = sessionKey(refreshToken);
+  const stored = tokenMap.get(key);
+  if (stored && stored.refreshToken !== refreshToken) {
+    logger.info('Token store: returning rotated refresh token');
+    return stored.refreshToken;
+  }
+  return refreshToken;
+}
+
+// Cleanup sessions older than 7 days
+export function cleanupTokenStore(): void {
+  const cutoff = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  for (const [key, value] of tokenMap) {
+    if (value.updatedAt < cutoff) {
+      tokenMap.delete(key);
+    }
+  }
+  save();
+}


### PR DESCRIPTION
## Summary

Fixes #336

When a Microsoft Graph API call returns `401`, the server refreshes the access token using the client-provided refresh token and retries the request. Due to Microsoft's [refresh token rotation](https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens#refresh-token-lifetime), the old refresh token is invalidated and a new one is issued.

**The problem:** The new refresh token is silently discarded. The client (e.g. claude.ai) still holds the old, now-invalid refresh token. The next time the client tries to refresh, Microsoft rejects it — the session disconnects.

**The fix:** Server-side token persistence. After a successful 401 retry, the rotated tokens are stored in a file-backed cache. When the client later calls the `/token` endpoint with its stale refresh token, the server transparently substitutes the latest valid one from the store.

## What this fixes

Active sessions that span multiple token lifetimes (~1h per Azure AD access token). Without this fix, the first 401 retry consumes the refresh token and subsequent refreshes fail. With this fix, sessions survive indefinitely during active use.

## What this does NOT fix

Overnight disconnects where Azure AD itself expires the refresh token due to inactivity. That is a separate issue requiring a different architectural approach (e.g. server-side session management decoupled from Azure AD token lifetime).

## Changes

### `src/token-store.ts` (new file, 83 lines)
- File-backed token store mapping sessions to their latest Azure AD tokens
- Sessions are keyed by refresh token prefix (stable across rotations)
- Automatic cleanup of sessions older than 7 days
- Atomic writes (write-to-tmp + rename)

### `src/graph-client.ts` (+10 lines)
- After a successful 401 retry with token refresh:
  - Updates the `RequestContext` so subsequent calls in the same request chain use the new tokens
  - Persists the rotated tokens to the store via `storeTokens()`

### `src/server.ts` (+19 lines)
- `/token` endpoint (`refresh_token` grant): checks the store for a more recent refresh token before calling Azure AD, and persists the result
- Token store initialized at server startup
- Hourly cleanup of expired sessions

## Design decisions

- **File-backed store, not in-memory only** — survives container restarts (important for Docker deployments with auto-updates via Watchtower etc.)
- **Session key = first 16 chars of refresh token** — stable identifier that doesn't change across rotations. Both the original and rotated token prefix are indexed for lookup
- **No new dependencies** — uses only `node:fs` and `node:path`
- **Backward compatible** — if no rotation occurs, behavior is identical to before. The store is only consulted when a refresh token is presented to `/token`
- **Transparent to clients** — no protocol changes, no new headers, no client-side changes needed. Works with claude.ai, Claude Desktop, ChatGPT, and any other MCP client

## How to verify

1. Connect from claude.ai and use any tool (triggers initial auth)
2. Wait >1h for the access token to expire
3. Use another tool — this triggers a 401 retry with token refresh
4. Check logs for `Token store: session updated`
5. Wait another >1h and repeat
6. Previously this would disconnect; with the fix, the session persists

## Relationship to #337

PR #337 (draft) takes a different approach: returning the new refresh token via a custom HTTP response header (`x-microsoft-new-refresh-token`). That approach requires the client to read and process custom headers, which claude.ai and most MCP clients do not do. This PR solves the problem server-side, requiring no client changes.