### PR TITLE
docs: add production deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,10 @@ The Key Vault integration uses `DefaultAzureCredential` from the Azure Identity 
 
 The Azure Key Vault packages (`@azure/identity` and `@azure/keyvault-secrets`) are optional dependencies. They are only loaded when `MS365_MCP_KEYVAULT_URL` is configured. If you don't use Key Vault, these packages are not required.
 
+## Production Deployment
+
+See [docs/deployment.md](docs/deployment.md) for a full guide to hosting the server for organization-wide access, including Docker, Azure Container Apps, Azure App Service, Azure AD app registration, reverse proxy setup, client configuration, and exposed endpoints.
+
 ## Contributing
 
 We welcome contributions! Before submitting a pull request, please ensure your changes meet our quality standards.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,189 @@
+# Production Deployment
+
+The server can be hosted centrally so that multiple users in an organization share a single MCP endpoint. Each user
+authenticates with their own Microsoft account via OAuth — the server is stateless and does not store tokens.
+
+## Architecture
+
+```
+MCP Clients (Claude Desktop, Claude Code, Open WebUI, ...)
+         │  Streamable HTTP + OAuth 2.1
+         ▼
+   ┌─────────────────────────────┐
+   │  ms-365-mcp-server --http   │  Azure Container Apps / App Service / Docker
+   │  (stateless, no token store)│
+   └─────────────┬───────────────┘
+                 │  Bearer token (per-user)
+                 ▼
+         Microsoft Graph API
+```
+
+## Docker
+
+A `Dockerfile` is included for containerized deployments:
+
+```bash
+# Build the image
+docker build -t ms-365-mcp-server .
+
+# Run with environment variables
+docker run -p 3000:3000 \
+  -e MS365_MCP_CLIENT_ID=your-client-id \
+  -e MS365_MCP_TENANT_ID=your-tenant-id \
+  -e MS365_MCP_CLIENT_SECRET=your-secret \
+  -e MS365_MCP_ORG_MODE=true \
+  ms-365-mcp-server \
+  --http 3000 --org-mode
+```
+
+For production, use Azure Key Vault instead of environment variables for secrets (see [Azure Key Vault Integration](../README.md#azure-key-vault-integration)):
+
+```bash
+docker run -p 3000:3000 \
+  -e MS365_MCP_KEYVAULT_URL=https://your-keyvault.vault.azure.net \
+  -e MS365_MCP_ORG_MODE=true \
+  -e MS365_MCP_BASE_URL=https://mcp.example.com \
+  ms-365-mcp-server \
+  --http 3000 --org-mode
+```
+
+## Azure Container Apps
+
+1. **Push the image** to Azure Container Registry:
+
+   ```bash
+   az acr build --registry yourregistry --image ms365-mcp-server:latest .
+   ```
+
+2. **Create the Container App** with system-assigned managed identity:
+
+   ```bash
+   az containerapp create \
+     --name mcp-server \
+     --resource-group your-rg \
+     --environment your-cae \
+     --image yourregistry.azurecr.io/ms365-mcp-server:latest \
+     --target-port 3000 \
+     --ingress external \
+     --min-replicas 1 \
+     --max-replicas 3 \
+     --cpu 0.5 --memory 1Gi \
+     --system-assigned \
+     --env-vars \
+       "MS365_MCP_KEYVAULT_URL=https://your-keyvault.vault.azure.net" \
+       "MS365_MCP_ORG_MODE=true" \
+       "MS365_MCP_BASE_URL=https://mcp.example.com" \
+     --command "node" "dist/index.js" "--http" "3000" "--org-mode"
+   ```
+
+3. **Grant Key Vault access** to the managed identity:
+
+   ```bash
+   PRINCIPAL_ID=$(az containerapp show --name mcp-server --resource-group your-rg \
+     --query identity.principalId -o tsv)
+   az keyvault set-policy --name your-keyvault --object-id $PRINCIPAL_ID \
+     --secret-permissions get list
+   ```
+
+## Azure App Service
+
+```bash
+az webapp create \
+  --name mcp-server \
+  --resource-group your-rg \
+  --plan your-plan \
+  --runtime "NODE:20-lts" \
+  --assign-identity
+
+az webapp config appsettings set --name mcp-server --resource-group your-rg \
+  --settings \
+    MS365_MCP_KEYVAULT_URL="https://your-keyvault.vault.azure.net" \
+    MS365_MCP_ORG_MODE="true" \
+    MS365_MCP_BASE_URL="https://mcp-server.azurewebsites.net" \
+    WEBSITES_PORT="3000"
+
+az webapp config set --name mcp-server --resource-group your-rg \
+  --startup-file "node dist/index.js --http 3000 --org-mode"
+```
+
+## Azure AD App Registration (for organizations)
+
+When deploying for an organization, create a dedicated app registration instead of using the built-in client ID:
+
+1. **Create the app** in [Azure Portal](https://portal.azure.com) > App registrations > New registration
+   - Name: `MS365 MCP Server`
+   - Supported account types: **Accounts in this organizational directory only** (single tenant)
+   - Redirect URI: your server's callback URL
+
+2. **Add API permissions** > Microsoft Graph > Delegated permissions
+   Run `npx @softeria/ms-365-mcp-server --org-mode --list-permissions` to print the exact list of permissions required for your enabled tools.
+
+3. **Grant admin consent** to skip per-user consent prompts:
+
+   ```bash
+   az ad app permission admin-consent --id your-app-client-id
+   ```
+
+4. **Create a client secret** under Certificates & secrets, then store it in Key Vault
+
+5. **Store credentials** in Key Vault (see [Azure Key Vault Integration](../README.md#azure-key-vault-integration))
+
+## Reverse Proxy / Custom Domain
+
+When running behind a reverse proxy or custom domain, set `MS365_MCP_BASE_URL` so OAuth discovery endpoints return the correct public URL:
+
+```bash
+# Via environment variable
+MS365_MCP_BASE_URL=https://mcp.example.com
+
+# Or via CLI flag
+--base-url https://mcp.example.com
+```
+
+Without this, `/.well-known/oauth-authorization-server` would advertise `http://localhost:3000` as the authorization endpoint.
+
+## Client Configuration
+
+Once deployed, users connect by pointing their MCP client to the server URL:
+
+**Claude Desktop:**
+
+```json
+{
+  "mcpServers": {
+    "ms365": {
+      "type": "streamable-http",
+      "url": "https://mcp.example.com/mcp"
+    }
+  }
+}
+```
+
+**Claude Code:**
+
+```bash
+claude mcp add ms365 --transport http https://mcp.example.com/mcp
+```
+
+The client automatically discovers OAuth endpoints and opens a browser for authentication on first use.
+
+## Security Considerations
+
+- **Stateless**: the server does not store tokens — each request carries the user's Bearer token
+- **Admin consent**: grant tenant-wide consent to avoid per-user consent prompts
+- **Managed identity**: use managed identity for Key Vault access (no secrets in environment variables)
+- **Read-only mode**: use `--read-only` to disable all write operations (send, delete, update, create)
+- **Tool filtering**: use `--enabled-tools <regex>` or `--preset <names>` to restrict available tools
+- **CORS**: configure `MS365_MCP_CORS_ORIGIN` to restrict allowed origins (defaults to `http://localhost:3000`); set explicitly when clients run on a different origin
+
+## Exposed Endpoints
+
+| Path                                      | Method   | Description                     | Auth Required |
+| ----------------------------------------- | -------- | ------------------------------- | ------------- |
+| `/`                                       | GET      | Health check                    | No            |
+| `/mcp`                                    | GET/POST | MCP protocol endpoint           | Bearer token  |
+| `/authorize`                              | GET      | OAuth — redirect to Microsoft   | No            |
+| `/token`                                  | POST     | OAuth — code exchange / refresh | No            |
+| `/register`                               | POST     | OAuth — dynamic registration    | No            |
+| `/.well-known/oauth-authorization-server` | GET      | OAuth server metadata           | No            |
+| `/.well-known/oauth-protected-resource`   | GET      | Protected resource metadata     | No            |


### PR DESCRIPTION
## Summary

- Add a production deployment guide as a new `docs/deployment.md` file, with a short pointer from the README
- Covers Docker, Azure Container Apps, Azure App Service, reverse proxy, Azure AD app registration, client configuration, security, and exposed endpoints
- Documents the existing but undocumented `Dockerfile`, `--base-url` flag, `MS365_MCP_CORS_ORIGIN`, and how HTTP mode + OAuth works for multi-user deployments

## Motivation

The project has all the pieces for production deployment (Dockerfile, HTTP transport, OAuth, Key Vault, CORS, base-url), but no documentation tying them together. Users asking "how do I deploy this for my organization?" currently have to piece it together from CLI flags and source code.

Per @eirikb's suggestion, the content now lives in `docs/deployment.md` rather than inflating the README. The README gets a 3-line pointer right after the Azure Key Vault section.

## Test plan

- [ ] Verify README and `docs/deployment.md` render correctly on GitHub
- [ ] Verify internal links work (`../README.md#azure-key-vault-integration`, `docs/deployment.md`)
- [ ] No code changes — docs only