### PR TITLE
feat: add trending insights endpoint

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1442,5 +1442,12 @@
     "toolName": "update-place",
     "workScopes": ["Place.ReadWrite.All"],
     "llmTip": "Updates properties of a place (room, room list, building, floor, section, desk, workspace). Body can include: displayName, phone, capacity, building, floorNumber, floorLabel, tags, audioDeviceName, videoDeviceName, displayDeviceName, isWheelChairAccessible. Use get-room or get-room-list to verify current values before updating."
+  },
+  {
+    "pathPattern": "/me/insights/trending",
+    "method": "get",
+    "toolName": "list-trending-insights",
+    "workScopes": ["Sites.Read.All"],
+    "llmTip": "Lists documents trending around the current user. Each item has resourceVisualization (title, type, previewImageUrl, containerDisplayName), resourceReference (webUrl, id, type), and weight (relevance score). Use $filter=resourceVisualization/type eq 'PowerPoint' to filter by file type. Use $orderby=weight/value desc to sort by relevance."
   }
 ]


### PR DESCRIPTION
## Summary

- Adds 1 endpoint for Microsoft Graph Insights API:
  - `list-trending-insights` — documents trending around the user
- Note: `/me/insights/used` and `/me/insights/shared` are deprecated by Microsoft (removal date 2028-01-01) and excluded
- Permission: `Sites.Read.All` (delegated, work accounts only via `workScopes`)
- Includes detailed `llmTip` with `$filter` and `$orderby` examples

## Test plan

- [ ] Verify `npm run verify` passes (0 errors, including `endpoints-validation` test)
- [ ] Verify `npm run build` succeeds
- [ ] Verify the new tool appears in `--list-tools` output
- [ ] Test `list-trending-insights` returns documents with `resourceVisualization` and `weight`

🤖 Generated with [Claude Code](https://claude.com/claude-code)