### PR TITLE
feat: add places endpoints (rooms, room lists, update)

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1375,5 +1375,40 @@
     "toolName": "list-webinar-sessions",
     "workScopes": ["VirtualEvent.Read"],
     "llmTip": "Lists sessions for a webinar. Each session has startDateTime, endDateTime, joinWebUrl, subject, and is essentially an online meeting associated with the webinar."
+  },
+  {
+    "pathPattern": "/places/{place-id}/graph.room",
+    "method": "get",
+    "toolName": "get-room",
+    "workScopes": ["Place.Read.All"],
+    "llmTip": "Gets a place cast as a room, returning room-specific properties: displayName, emailAddress (for booking), capacity, building, floorNumber, floorLabel, isWheelChairAccessible, audioDeviceName, videoDeviceName, displayDeviceName. The place-id can be the room's ID or email address."
+  },
+  {
+    "pathPattern": "/places/{place-id}/graph.roomList",
+    "method": "get",
+    "toolName": "get-room-list",
+    "workScopes": ["Place.Read.All"],
+    "llmTip": "Gets a place cast as a room list, returning room list properties: displayName, emailAddress, address. Use the place-id (ID or email address) of the room list. Then use list-room-list-rooms to get the rooms within this list."
+  },
+  {
+    "pathPattern": "/places/{place-id}/graph.roomList/rooms",
+    "method": "get",
+    "toolName": "list-room-list-rooms",
+    "workScopes": ["Place.Read.All"],
+    "llmTip": "Lists rooms belonging to a specific room list. The place-id is the ID or email address of the room list (from get-room-list). Returns rooms with displayName, emailAddress, capacity, building, floorNumber, floorLabel, and AV equipment details. Combine with find-meeting-times to find available rooms for booking."
+  },
+  {
+    "pathPattern": "/places/{place-id}/graph.roomList/rooms/{room-id}",
+    "method": "get",
+    "toolName": "get-room-list-room",
+    "workScopes": ["Place.Read.All"],
+    "llmTip": "Gets a specific room within a room list. The place-id is the room list ID or email, and room-id is the specific room ID. Returns full room details including capacity, building, floor, and AV equipment."
+  },
+  {
+    "pathPattern": "/places/{place-id}",
+    "method": "patch",
+    "toolName": "update-place",
+    "workScopes": ["Place.ReadWrite.All"],
+    "llmTip": "Updates properties of a place (room, room list, building, floor, section, desk, workspace). Body can include: displayName, phone, capacity, building, floorNumber, floorLabel, tags, audioDeviceName, videoDeviceName, displayDeviceName, isWheelChairAccessible. Use get-room or get-room-list to verify current values before updating."
   }
 ]


### PR DESCRIPTION
## Summary

- Adds 5 endpoints for Microsoft Graph Places API:
  - `get-room` — get a place cast as room (room-specific properties)
  - `get-room-list` — get a place cast as room list
  - `list-room-list-rooms` — list rooms within a specific room list
  - `get-room-list-room` — get a specific room within a room list
  - `update-place` — update properties of a place (room, building, etc.)
- Permissions (delegated, work accounts only via `workScopes`):
  - `Place.Read.All` (read endpoints)
  - `Place.ReadWrite.All` (update endpoint)
- Complements the existing `find-meeting-times` tool for room booking workflows

## Test plan

- [ ] Verify `npm run verify` passes (0 errors)
- [ ] Verify `npm run build` succeeds
- [ ] Verify all 5 new tools appear in `--list-tools` output
- [ ] Test `get-room` with a known room ID or email address
- [ ] Test `list-room-list-rooms` to enumerate rooms in a room list
- [ ] Test `update-place` to modify room properties (displayName, capacity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)