### PR TITLE
fix: add logs/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,9 @@ dist
 .token-cache.json
 .selected-account.json
 
+# Server logs (may contain PII and token metadata)
+logs/
+
 openapi
 
 src/generated/client.ts


### PR DESCRIPTION
## Security fix — Low severity

**Problem**: The logger writes to a `logs/` directory next to the binary. These files can contain PII (user principal names, email addresses), token metadata, Graph API error details, and IP addresses. Without a `.gitignore` entry, `git add .` could accidentally commit them to a public repository.

**Fix**: Add `logs/` to `.gitignore` with a comment explaining why.

**Impact**: 1 line added to `.gitignore`. No code changes, no behavior change.

## Test plan

- [x] `npm run verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)