### PR TITLE
fix: move log directory to user home with secure permissions

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,12 +2,14 @@ import winston from 'winston';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
+import os from 'os';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const logsDir = path.join(__dirname, '..', 'logs');
+const logsDir =
+  process.env.MS365_MCP_LOG_DIR || path.join(os.homedir(), '.ms-365-mcp-server', 'logs');
 
 if (!fs.existsSync(logsDir)) {
-  fs.mkdirSync(logsDir);
+  fs.mkdirSync(logsDir, { recursive: true, mode: 0o700 });
 }
 
 const logger = winston.createLogger({


### PR DESCRIPTION
## Security fix — High severity

**Problem**: Logs are written to `__dirname/../logs/` — a path relative to the package binary. When installed globally via npm, this may:
- Point to a shared/unwritable directory
- Write logs with default permissions (world-readable on some systems)
- Be inside node_modules where they're invisible but persist

Log files contain PII: user emails from Graph API responses, IP addresses from sign-in logs, and token acquisition metadata.

**Fix**:
- Default log directory: `~/.ms-365-mcp-server/logs/`
- Configurable via `MS365_MCP_LOG_DIR` environment variable
- Directory created with `mode: 0o700` (owner-only access)
- Uses `recursive: true` for parent directory creation

**Impact**: Log file location changes from `./logs/` to `~/.ms-365-mcp-server/logs/`. Users with existing log monitoring should set `MS365_MCP_LOG_DIR` to their preferred path.

## Test plan

- [x] `npm run verify` passes
- [ ] Verify logs appear in `~/.ms-365-mcp-server/logs/` on fresh start
- [ ] Verify `MS365_MCP_LOG_DIR=/tmp/test-logs` overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)