### PR TITLE
fix: add item count limit to fetchAllPages to prevent OOM

### DIFF
--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -387,8 +387,10 @@ async function executeGraphTool(
         let allItems = combinedResponse.value || [];
         let nextLink = combinedResponse['@odata.nextLink'];
         let pageCount = 1;
+        const maxPages = 100;
+        const maxItems = 10_000;
 
-        while (nextLink && pageCount < 100) {
+        while (nextLink && pageCount < maxPages && allItems.length < maxItems) {
           logger.info(`Fetching page ${pageCount + 1} from: ${nextLink}`);
 
           const url = new URL(nextLink);
@@ -414,8 +416,13 @@ async function executeGraphTool(
           }
         }
 
-        if (pageCount >= 100) {
-          logger.warn(`Reached maximum page limit (100) for pagination`);
+        if (pageCount >= maxPages) {
+          logger.warn(`Reached maximum page limit (${maxPages}) for pagination`);
+        }
+        if (allItems.length >= maxItems) {
+          logger.warn(
+            `Reached maximum item limit (${maxItems}) for pagination — truncated at ${allItems.length} items`
+          );
         }
 
         combinedResponse.value = allItems;


### PR DESCRIPTION
## Security fix — High severity

**Problem**: The `fetchAllPages` parameter fetches up to 100 pages with no limit on total items. With `$top=999` (Graph API max page size), a single request can load **~100,000 items** into memory before returning. This risks:
- Out-of-memory crash on constrained environments (containers, serverless)
- Massive response payload sent to the LLM, exceeding context window
- Slow response times blocking other requests

**Fix**: Add a `maxItems = 10,000` cap alongside the existing 100-page limit. The pagination loop stops at whichever limit is hit first. A warning is logged when the item limit is reached so callers know the result was truncated.

**Impact**: Requests that would have returned >10K items now stop at 10K with a log warning. The 100-page limit remains unchanged. Normal usage (small result sets) is unaffected.

## Test plan

- [x] `npm run verify` passes
- [ ] Test `fetchAllPages=true` with a large mailbox — verify it stops at 10K items
- [ ] Verify the log warning appears when the limit is hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)