### PR TITLE
fix: bound PKCE store size to prevent memory exhaustion

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -295,20 +295,34 @@ class MicrosoftGraphServer {
             .update(serverCodeVerifier)
             .digest('base64url');
 
+          // Clean up expired entries before adding new ones
+          const now = Date.now();
+          const maxAge = 10 * 60 * 1000; // 10 minutes
+          const maxEntries = 1000;
+          for (const [key, value] of this.pkceStore) {
+            if (now - value.createdAt > maxAge) {
+              this.pkceStore.delete(key);
+            }
+          }
+
+          // Reject if store is still at capacity after cleanup (prevents memory exhaustion)
+          if (this.pkceStore.size >= maxEntries) {
+            logger.warn(
+              `PKCE store at capacity (${maxEntries} entries) — rejecting new authorization request`
+            );
+            res.status(503).json({
+              error: 'server_busy',
+              error_description: 'Too many pending authorization requests. Try again later.',
+            });
+            return;
+          }
+
           this.pkceStore.set(state, {
             clientCodeChallenge,
             clientCodeChallengeMethod: clientCodeChallengeMethod || 'S256',
             serverCodeVerifier,
             createdAt: Date.now(),
           });
-
-          // Clean up entries older than 10 minutes
-          const now = Date.now();
-          for (const [key, value] of this.pkceStore) {
-            if (now - value.createdAt > 10 * 60 * 1000) {
-              this.pkceStore.delete(key);
-            }
-          }
 
           // Send our server-generated code_challenge to Microsoft
           microsoftAuthUrl.searchParams.set('code_challenge', serverCodeChallenge);


### PR DESCRIPTION
## Security fix — High severity (HTTP mode only)

**Problem**: The two-leg PKCE store (`Map` in memory) is unbounded. Each `/authorize` request adds an entry. Cleanup only runs on new entries and only evicts entries older than 10 minutes. An attacker can:
- Send thousands of `/authorize` requests in <10 minutes
- Each stores ~200 bytes of PKCE data (code_challenge, code_verifier, state)
- The Map grows without bound until the process runs out of memory

**Fix**:
- Move cleanup **before** inserting new entries (evict expired first)
- Add a hard cap of **1,000** concurrent pending PKCE entries
- Return **503 Service Unavailable** when the store is full after cleanup
- Log a warning when capacity is reached

In normal operation, authorization flows complete in seconds. 1,000 concurrent pending flows is extremely generous for legitimate use.

**Impact**: HTTP mode only. Stdio mode is unaffected (no PKCE store). Legitimate users would only hit this limit under extreme load or if the token exchange endpoint is down.

## Test plan

- [x] `npm run verify` passes
- [ ] Verify normal OAuth flow still works (store well under 1K)
- [ ] Verify 503 is returned when store is artificially filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)