### PR TITLE
fix: restrict default CORS origin from wildcard to localhost

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -169,7 +169,7 @@ class MicrosoftGraphServer {
       app.use(express.urlencoded({ extended: true }));
 
       // Add CORS headers for all routes
-      const corsOrigin = process.env.MS365_MCP_CORS_ORIGIN || '*';
+      const corsOrigin = process.env.MS365_MCP_CORS_ORIGIN || 'http://localhost:3000';
       app.use((req, res, next) => {
         res.header('Access-Control-Allow-Origin', corsOrigin);
         res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');


### PR DESCRIPTION
## Security fix — Critical severity (HTTP mode only)

**Problem**: The HTTP mode CORS default is `Access-Control-Allow-Origin: *`. This allows **any website** to make cross-origin requests to the MCP server, including:
- OAuth endpoints (`/authorize`, `/token`)
- MCP tool endpoints (`/mcp`)
- Discovery endpoints (`/.well-known/*`)

A malicious page visited by an authenticated user could invoke Graph API tools (read emails, send messages, access files) via the MCP server.

**Fix**: Change default from `*` to `http://localhost:3000`. Deployments needing broader access can set `MS365_MCP_CORS_ORIGIN` to their specific origin, or explicitly to `*` if they accept the risk.

**Impact**: HTTP mode only. Stdio mode is unaffected. Existing deployments that rely on `*` must set `MS365_MCP_CORS_ORIGIN=*` explicitly. This is a **breaking change** for HTTP mode deployments accessed from origins other than localhost.

## Test plan

- [x] `npm run verify` passes
- [ ] Verify localhost MCP client still works in HTTP mode
- [ ] Verify cross-origin requests from other origins are blocked unless `MS365_MCP_CORS_ORIGIN` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)