### PR TITLE
fix: validate --enabled-tools regex at startup

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,6 +131,20 @@ export function parseArgs(): CommandOptions {
     options.enabledTools = process.env.ENABLED_TOOLS;
   }
 
+  // Validate tool filter regex early — fail at startup instead of silently
+  // disabling the filter at runtime (which would expose all tools)
+  if (options.enabledTools) {
+    try {
+      new RegExp(options.enabledTools, 'i');
+    } catch {
+      console.error(
+        `Error: invalid --enabled-tools regex pattern: "${options.enabledTools}". ` +
+          `Without a valid filter, all tools would be exposed.`
+      );
+      process.exit(1);
+    }
+  }
+
   if (process.env.MS365_MCP_ORG_MODE === 'true' || process.env.MS365_MCP_ORG_MODE === '1') {
     options.orgMode = true;
   }


### PR DESCRIPTION
## Security fix — Low severity

**Problem**: If `--enabled-tools` or `ENABLED_TOOLS` contains an invalid regex (e.g., `[invalid`), the server logs an error but continues with **no filter applied** — exposing ALL tools. This is the opposite of what the operator intended: they wanted to restrict tools, but a typo silently disables the restriction.

**Fix**: Validate the regex at startup in `parseArgs()`. If it's invalid, print a clear error message and exit with code 1. The error message explains that without a valid filter, all tools would be exposed.

**Impact**: Startup with an invalid `--enabled-tools` regex now fails instead of silently exposing all tools. Valid regex patterns are unaffected.

## Test plan

- [x] `npm run verify` passes
- [ ] `npx tsx src/index.ts --enabled-tools "[invalid"` exits with error
- [ ] `npx tsx src/index.ts --enabled-tools "mail|calendar"` starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)