### PR TITLE
fix: correct list-chats to use beta API for viewpoint, add llmTips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,10 @@ dist
 # Server logs (may contain PII and token metadata)
 logs/
 
+# LLM eval ephemeral outputs
+test/llm-tip-eval-results.json
+test/.eval-tmp/
+
 openapi
 
 src/generated/client.ts

--- a/README.md
+++ b/README.md
@@ -589,6 +589,30 @@ The Key Vault integration uses `DefaultAzureCredential` from the Azure Identity 
 
 The Azure Key Vault packages (`@azure/identity` and `@azure/keyvault-secrets`) are optional dependencies. They are only loaded when `MS365_MCP_KEYVAULT_URL` is configured. If you don't use Key Vault, these packages are not required.
 
+## Testing
+
+### Unit tests
+
+```bash
+npm test
+```
+
+Includes endpoint config validation (`test/endpoints-validation.test.ts`) and graph-tools logic tests (`src/__tests__/graph-tools.test.ts`).
+
+### LLM tip evals
+
+Non-deterministic tests that verify llmTips in `endpoints.json` actually guide an LLM to make correct tool calls. Requires the `claude` CLI.
+
+```bash
+npx tsx test/llm-tip-evals.ts           # run all evals
+npx tsx test/llm-tip-evals.ts --verbose  # show full LLM responses
+npx tsx test/llm-tip-evals.ts --filter chat  # run evals matching "chat"
+```
+
+Set `CLAUDE_BIN` to override the Claude CLI path (defaults to `~/.local/bin/claude`).
+
+Results are written to `test/llm-tip-eval-results.json` (gitignored). Add new eval cases by appending to the `evalCases` array in `test/llm-tip-evals.ts`.
+
 ## Contributing
 
 We welcome contributions! Before submitting a pull request, please ensure your changes meet our quality standards.

--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -525,4 +525,61 @@ describe('graph-tools', () => {
       expect(tool!.schema['timezone']).toBeUndefined();
     });
   });
+
+  // ---- apiVersion passthrough ----
+  describe('apiVersion passthrough to graph client', () => {
+    it('should pass apiVersion from endpoint config to graphRequest options', async () => {
+      const endpoint = makeEndpoint({
+        alias: 'list-chats',
+        path: '/me/chats',
+      });
+      const config = makeConfig({
+        toolName: 'list-chats',
+        pathPattern: '/me/chats',
+        workScopes: ['Chat.Read'],
+        apiVersion: 'beta',
+      });
+      delete config.scopes;
+
+      mockEndpoints.push(endpoint);
+      mockEndpointsJson = [config];
+
+      const graphClient = createMockGraphClient([
+        { content: [{ type: 'text', text: JSON.stringify({ value: [] }) }] },
+      ]);
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any, undefined, false, true);
+
+      const tool = server.tools.get('list-chats');
+      expect(tool).toBeDefined();
+      await tool!.handler({ select: 'id,chatType,viewpoint' });
+
+      expect(graphClient.graphRequest).toHaveBeenCalledTimes(1);
+      const [, options] = graphClient.graphRequest.mock.calls[0];
+      expect(options.apiVersion).toBe('beta');
+    });
+
+    it('should NOT set apiVersion when endpoint config has no apiVersion', async () => {
+      const endpoint = makeEndpoint();
+      const config = makeConfig();
+      mockEndpoints.push(endpoint);
+      mockEndpointsJson = [config];
+
+      const graphClient = createMockGraphClient([
+        { content: [{ type: 'text', text: JSON.stringify({ value: [] }) }] },
+      ]);
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('test-tool');
+      await tool!.handler({});
+
+      const [, options] = graphClient.graphRequest.mock.calls[0];
+      expect(options.apiVersion).toBeUndefined();
+    });
+  });
 });

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -919,7 +919,9 @@
     "pathPattern": "/me/chats",
     "method": "get",
     "toolName": "list-chats",
-    "workScopes": ["Chat.Read"]
+    "workScopes": ["Chat.Read"],
+    "apiVersion": "beta",
+    "llmTip": "To detect unread chats, include 'viewpoint' in $select (it is a complex property, NOT a navigation property — do NOT use $expand). This returns viewpoint.lastMessageReadDateTime. Compare against lastUpdatedDateTime — if lastUpdated > lastRead, the chat has unread messages. Use $orderby=lastMessagePreview/createdDateTime desc to get most recent chats first."
   },
   {
     "pathPattern": "/chats/{chat-id}",
@@ -938,7 +940,8 @@
     "pathPattern": "/chats/{chat-id}/messages",
     "method": "get",
     "toolName": "list-chat-messages",
-    "workScopes": ["ChatMessage.Read"]
+    "workScopes": ["ChatMessage.Read"],
+    "llmTip": "Lists messages in a specific chat. Supports $orderby=lastModifiedDateTime desc (descending only) and $top (max 50). Per-chat delta is NOT supported by Graph — for 'what's new' use $orderby=lastModifiedDateTime desc with $top and filter client-side by date. Note: $filter on createdDateTime returns 400, but $filter=lastModifiedDateTime gt {datetime} may work."
   },
   {
     "pathPattern": "/chats/{chat-id}/messages/{chatMessage-id}",

--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -51,6 +51,7 @@ interface GraphRequestOptions {
   excludeResponse?: boolean;
   accessToken?: string;
   refreshToken?: string;
+  apiVersion?: string; // Graph API version override (e.g., 'beta'). Defaults to 'v1.0'.
 
   [key: string]: unknown;
 }
@@ -211,7 +212,8 @@ class GraphClient {
     options: GraphRequestOptions
   ): Promise<Response> {
     const cloudEndpoints = getCloudEndpoints(this.secrets.cloudType);
-    const url = `${cloudEndpoints.graphApi}/v1.0${endpoint}`;
+    const version = options.apiVersion || 'v1.0';
+    const url = `${cloudEndpoints.graphApi}/${version}${endpoint}`;
 
     logger.info(`[GRAPH CLIENT] Final URL being sent to Microsoft: ${url}`);
 

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -28,6 +28,7 @@ interface EndpointConfig {
   contentType?: string;
   acceptType?: string; // Custom Accept header for endpoints returning non-JSON content (e.g., text/vtt)
   readOnly?: boolean; // When true, allow this endpoint in read-only mode even if method is not GET
+  apiVersion?: string; // Graph API version override (e.g., 'beta'). Defaults to 'v1.0'.
 }
 
 const endpointsData = JSON.parse(
@@ -326,10 +327,15 @@ async function executeGraphTool(
       excludeResponse?: boolean;
       queryParams?: Record<string, string>;
       accessToken?: string;
+      apiVersion?: string;
     } = {
       method: tool.method.toUpperCase(),
       headers,
     };
+
+    if (config?.apiVersion) {
+      options.apiVersion = config.apiVersion;
+    }
 
     if (options.method !== 'GET' && body) {
       if (config?.contentType === 'text/html') {

--- a/test/endpoints-validation.test.ts
+++ b/test/endpoints-validation.test.ts
@@ -13,15 +13,17 @@ const { api } = await import('../src/generated/client.js');
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-interface Endpoint {
+interface EndpointFull {
   toolName: string;
   pathPattern: string;
   method: string;
   scopes?: string[];
   workScopes?: string[];
+  apiVersion?: string;
+  llmTip?: string;
 }
 
-const endpoints: Endpoint[] = JSON.parse(
+const endpoints: EndpointFull[] = JSON.parse(
   readFileSync(path.join(__dirname, '..', 'src', 'endpoints.json'), 'utf8')
 );
 
@@ -45,7 +47,10 @@ describe('endpoints.json validation', () => {
 
   it('should have a matching generated client endpoint for every entry', () => {
     const generatedTools = new Set(api.endpoints.map((e) => e.alias));
-    const orphans = endpoints.filter((e) => !generatedTools.has(e.toolName));
+    // Beta endpoints are not in the v1.0 OpenAPI spec and are registered separately at runtime
+    const orphans = endpoints.filter(
+      (e) => !generatedTools.has(e.toolName) && !e.apiVersion
+    );
 
     if (orphans.length > 0) {
       const details = orphans
@@ -56,5 +61,36 @@ describe('endpoints.json validation', () => {
           `Run npm run generate, or check that the path and method exist in the OpenAPI spec.\n${details}`
       );
     }
+  });
+});
+
+describe('chat endpoint config invariants', () => {
+  it('list-chats must use beta API for viewpoint support', () => {
+    const listChats = endpoints.find((e) => e.toolName === 'list-chats');
+    expect(listChats).toBeDefined();
+    expect(listChats!.apiVersion).toBe('beta');
+  });
+
+  it('list-chats llmTip must reference $select (not $expand) for viewpoint', () => {
+    const listChats = endpoints.find((e) => e.toolName === 'list-chats');
+    expect(listChats).toBeDefined();
+    expect(listChats!.llmTip).toBeDefined();
+    expect(listChats!.llmTip).toContain('$select');
+    expect(listChats!.llmTip).not.toContain('$expand=viewpoint');
+  });
+
+  it('list-chat-messages-delta must NOT exist (per-chat delta is not supported by Graph)', () => {
+    // /chats/{chat-id}/messages/delta() appears in Graph OData metadata but the backend
+    // returns "Change tracking is not supported against microsoft.graph.chatMessage".
+    // See: https://github.com/microsoftgraph/msgraph-metadata/issues/607
+    const chatDelta = endpoints.find((e) => e.toolName === 'list-chat-messages-delta');
+    expect(chatDelta).toBeUndefined();
+  });
+
+  it('list-chat-messages must have an llmTip guiding toward date-based filtering', () => {
+    const listChatMessages = endpoints.find((e) => e.toolName === 'list-chat-messages');
+    expect(listChatMessages).toBeDefined();
+    expect(listChatMessages!.llmTip).toBeDefined();
+    expect(listChatMessages!.llmTip).toContain('lastModifiedDateTime');
   });
 });

--- a/test/llm-tip-evals.ts
+++ b/test/llm-tip-evals.ts
@@ -1,0 +1,416 @@
+#!/usr/bin/env tsx
+/**
+ * LLM Tip Eval Harness
+ *
+ * Tests whether the llmTips in endpoints.json actually guide an LLM to make
+ * correct tool calls. Feeds tool schemas + descriptions to Claude via CLI,
+ * gives it a user intent, and checks the generated tool call parameters.
+ *
+ * No Graph API calls — just verifies the LLM reads the tips correctly.
+ *
+ * Usage:
+ *   npx tsx test/llm-tip-evals.ts              # run all evals
+ *   npx tsx test/llm-tip-evals.ts --filter chat # run evals matching "chat"
+ *   npx tsx test/llm-tip-evals.ts --verbose     # show full LLM responses
+ */
+
+import { readFileSync } from 'fs';
+import { execSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ── Types ──
+
+interface EndpointConfig {
+  toolName: string;
+  pathPattern: string;
+  method: string;
+  scopes?: string[];
+  workScopes?: string[];
+  apiVersion?: string;
+  llmTip?: string;
+}
+
+interface ToolCallAssertion {
+  /** The tool name we expect the LLM to call */
+  expectedTool: string;
+  /** Params that MUST be present with specific values or patterns */
+  requiredParams?: Record<string, string | RegExp | boolean>;
+  /** Params that must NOT be present */
+  forbiddenParams?: Record<string, string | RegExp>;
+  /** Strings that MUST appear somewhere in the response */
+  responseContains?: string[];
+  /** Strings that must NOT appear in the response */
+  responseNotContains?: string[];
+}
+
+interface EvalCase {
+  id: string;
+  description: string;
+  /** The user intent to send to Claude */
+  userPrompt: string;
+  /** Which tools to expose (by toolName). Only these are available. */
+  availableTools: string[];
+  /** What we assert about the LLM's tool call */
+  assertions: ToolCallAssertion;
+}
+
+// ── Load endpoints ──
+
+const endpoints: EndpointConfig[] = JSON.parse(
+  readFileSync(path.join(__dirname, '..', 'src', 'endpoints.json'), 'utf8')
+);
+
+function buildToolDescription(ep: EndpointConfig): string {
+  let desc = `${ep.method.toUpperCase()} ${ep.pathPattern}`;
+  if (ep.apiVersion) desc += ` [API: ${ep.apiVersion}]`;
+  if (ep.llmTip) desc += `\n\nTIP: ${ep.llmTip}`;
+  return desc;
+}
+
+function buildToolSchema(ep: EndpointConfig): object {
+  const params: Record<string, object> = {};
+
+  // Extract path params
+  const pathParams = ep.pathPattern.matchAll(/\{([^}]+)\}/g);
+  for (const match of pathParams) {
+    params[match[1]] = { type: 'string', description: `Path parameter: ${match[1]}` };
+  }
+
+  // Standard OData params for GET
+  if (ep.method === 'get') {
+    params['filter'] = { type: 'string', description: 'OData $filter expression' };
+    params['select'] = { type: 'string', description: 'Comma-separated fields to return' };
+    params['expand'] = {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Navigation properties to expand',
+    };
+    params['orderby'] = { type: 'string', description: 'Sort expression' };
+    params['top'] = { type: 'number', description: 'Page size' };
+  }
+
+  return {
+    type: 'object',
+    properties: params,
+  };
+}
+
+// ── Eval cases ──
+
+const evalCases: EvalCase[] = [
+  {
+    id: 'unread-chats-viewpoint',
+    description: 'LLM should use $select (not $expand) for viewpoint on list-chats',
+    userPrompt: 'Show me which of my Teams chats have unread messages.',
+    availableTools: ['list-chats', 'list-chat-messages'],
+    assertions: {
+      expectedTool: 'list-chats',
+      requiredParams: {
+        select: /viewpoint/i,
+      },
+      forbiddenParams: {
+        expand: /viewpoint/i,
+      },
+    },
+  },
+  {
+    id: 'chat-messages-no-delta',
+    description: 'LLM should use list-chat-messages with date ordering, not attempt delta',
+    userPrompt:
+      "What new messages are in my chat since yesterday? The chat ID is 19:abc123@thread.v2",
+    availableTools: ['list-chat-messages'],
+    assertions: {
+      expectedTool: 'list-chat-messages',
+      requiredParams: {
+        'chat-id': '19:abc123@thread.v2',
+        orderby: /lastModifiedDateTime/i,
+      },
+    },
+  },
+  {
+    id: 'channel-delta-used',
+    description: 'LLM should use channel messages delta for incremental channel sync',
+    userPrompt:
+      "Get me new messages in the General channel since last sync. Team ID is team-123, channel ID is channel-456.",
+    availableTools: ['list-channel-messages', 'list-channel-messages-delta'],
+    assertions: {
+      expectedTool: 'list-channel-messages-delta',
+      requiredParams: {
+        'team-id': 'team-123',
+        'channel-id': 'channel-456',
+      },
+    },
+  },
+  {
+    id: 'unread-detection-workflow',
+    description:
+      'When asked about unread chats, LLM should mention comparing lastMessageReadDateTime vs lastUpdatedDateTime',
+    userPrompt:
+      'How can I detect which chats have unread messages? Just explain the approach, don\'t call any tools.',
+    availableTools: ['list-chats', 'list-chat-messages'],
+    assertions: {
+      expectedTool: '', // no tool call expected
+      responseContains: ['lastMessageReadDateTime', 'lastUpdatedDateTime'],
+    },
+  },
+];
+
+// ── Runner ──
+
+function buildSystemPrompt(tools: EndpointConfig[]): string {
+  const toolDescriptions = tools
+    .map((t) => {
+      const schema = JSON.stringify(buildToolSchema(t), null, 2);
+      return `### ${t.toolName}\n${buildToolDescription(t)}\n\nParameters:\n\`\`\`json\n${schema}\n\`\`\``;
+    })
+    .join('\n\n');
+
+  return `You are a Microsoft Graph API assistant. You have access to these tools:
+
+${toolDescriptions}
+
+When the user asks you to do something, respond with the tool call you would make.
+Format your response as:
+
+TOOL: <tool-name>
+PARAMS:
+\`\`\`json
+{ ... }
+\`\`\`
+
+If no tool call is needed, just respond with your explanation.
+IMPORTANT: Follow the TIP instructions in each tool description carefully.`;
+}
+
+interface EvalResult {
+  id: string;
+  description: string;
+  passed: boolean;
+  failures: string[];
+  response: string;
+}
+
+function parseToolCall(response: string): { tool: string; params: Record<string, unknown> } | null {
+  const toolMatch = response.match(/TOOL:\s*(\S+)/);
+  if (!toolMatch) return null;
+
+  const paramsMatch = response.match(/PARAMS:\s*```(?:json)?\s*([\s\S]*?)```/);
+  let params: Record<string, unknown> = {};
+  if (paramsMatch) {
+    try {
+      params = JSON.parse(paramsMatch[1]);
+    } catch {
+      // Try to extract individual key-value pairs
+    }
+  }
+
+  return { tool: toolMatch[1], params };
+}
+
+function checkAssertion(
+  response: string,
+  toolCall: { tool: string; params: Record<string, unknown> } | null,
+  assertions: ToolCallAssertion
+): string[] {
+  const failures: string[] = [];
+
+  // Check expected tool
+  if (assertions.expectedTool) {
+    if (!toolCall) {
+      failures.push(`Expected tool call to '${assertions.expectedTool}' but no tool was called`);
+      return failures;
+    }
+    if (toolCall.tool !== assertions.expectedTool) {
+      failures.push(
+        `Expected tool '${assertions.expectedTool}' but got '${toolCall.tool}'`
+      );
+    }
+  }
+
+  // Check required params
+  if (assertions.requiredParams && toolCall) {
+    for (const [key, expected] of Object.entries(assertions.requiredParams)) {
+      const actual = toolCall.params[key];
+      const actualStr = typeof actual === 'string' ? actual : JSON.stringify(actual);
+
+      if (actual === undefined) {
+        // Also check if the param appears anywhere in the response as a fallback
+        if (expected instanceof RegExp) {
+          if (!expected.test(response)) {
+            failures.push(`Required param '${key}' not found in tool call or response`);
+          }
+        } else {
+          failures.push(`Required param '${key}' missing from tool call`);
+        }
+      } else if (expected instanceof RegExp) {
+        if (!expected.test(actualStr || '')) {
+          failures.push(`Param '${key}' = '${actualStr}' does not match ${expected}`);
+        }
+      } else if (typeof expected === 'boolean') {
+        if (actual !== expected) {
+          failures.push(`Param '${key}' = ${actual}, expected ${expected}`);
+        }
+      } else if (actualStr !== expected) {
+        failures.push(`Param '${key}' = '${actualStr}', expected '${expected}'`);
+      }
+    }
+  }
+
+  // Check forbidden params
+  if (assertions.forbiddenParams && toolCall) {
+    for (const [key, pattern] of Object.entries(assertions.forbiddenParams)) {
+      const actual = toolCall.params[key];
+      const actualStr = typeof actual === 'string' ? actual : JSON.stringify(actual);
+      if (actual !== undefined && pattern instanceof RegExp && pattern.test(actualStr || '')) {
+        failures.push(`Forbidden param pattern found: '${key}' matches ${pattern}`);
+      }
+    }
+  }
+
+  // Check response contains
+  if (assertions.responseContains) {
+    for (const expected of assertions.responseContains) {
+      if (!response.toLowerCase().includes(expected.toLowerCase())) {
+        failures.push(`Response missing expected text: '${expected}'`);
+      }
+    }
+  }
+
+  // Check response not contains
+  if (assertions.responseNotContains) {
+    for (const forbidden of assertions.responseNotContains) {
+      if (response.toLowerCase().includes(forbidden.toLowerCase())) {
+        failures.push(`Response contains forbidden text: '${forbidden}'`);
+      }
+    }
+  }
+
+  return failures;
+}
+
+async function runEval(evalCase: EvalCase, verbose: boolean): Promise<EvalResult> {
+  const tools = evalCase.availableTools
+    .map((name) => endpoints.find((e) => e.toolName === name))
+    .filter((e): e is EndpointConfig => e !== undefined);
+
+  const systemPrompt = buildSystemPrompt(tools);
+  const fullPrompt = `${systemPrompt}\n\nUser: ${evalCase.userPrompt}`;
+
+  // Write prompt to temp file to avoid shell escaping issues with backticks, quotes, JSON etc.
+  const tmpDir = path.join(__dirname, '.eval-tmp');
+  const { mkdirSync, writeFileSync: writeTmp, unlinkSync, rmSync } = await import('fs');
+  mkdirSync(tmpDir, { recursive: true });
+  const promptFile = path.join(tmpDir, `${evalCase.id}-${Date.now()}.txt`);
+  writeTmp(promptFile, fullPrompt);
+
+  let response: string;
+  try {
+    // Use absolute path to claude binary to avoid shell wrapper issues in subprocesses.
+    // --tools "" disables built-in tools so the LLM can only "pretend" to call our described tools.
+    const claudeBin = process.env.CLAUDE_BIN || `${process.env.HOME}/.local/bin/claude`;
+    response = execSync(
+      `cat "${promptFile}" | "${claudeBin}" -p --model sonnet --max-turns 1 --tools "" 2>/dev/null`,
+      {
+        encoding: 'utf8',
+        timeout: 60_000,
+      }
+    ).trim();
+  } catch (err: unknown) {
+    const error = err as { stdout?: string; stderr?: string; message?: string };
+    response = error.stdout || error.message || 'EVAL_ERROR: claude command failed';
+  } finally {
+    try { unlinkSync(promptFile); } catch {}
+    try { rmSync(tmpDir, { recursive: true }); } catch {}
+  }
+
+  const toolCall = parseToolCall(response);
+  const failures = checkAssertion(response, toolCall, evalCase.assertions);
+
+  if (verbose || failures.length > 0) {
+    console.log(`\n${'─'.repeat(60)}`);
+    console.log(`📋 ${evalCase.id}: ${evalCase.description}`);
+    console.log(`   Prompt: ${evalCase.userPrompt}`);
+    if (toolCall) {
+      console.log(`   Tool called: ${toolCall.tool}`);
+      console.log(`   Params: ${JSON.stringify(toolCall.params, null, 2)}`);
+    }
+    if (verbose) {
+      console.log(`   Full response:\n${response.split('\n').map((l) => `   > ${l}`).join('\n')}`);
+    }
+  }
+
+  return {
+    id: evalCase.id,
+    description: evalCase.description,
+    passed: failures.length === 0,
+    failures,
+    response,
+  };
+}
+
+// ── Main ──
+
+async function main() {
+  const args = process.argv.slice(2);
+  const verbose = args.includes('--verbose') || args.includes('-v');
+  const filterIdx = args.indexOf('--filter');
+  const filter = filterIdx >= 0 ? args[filterIdx + 1] : undefined;
+
+  let cases = evalCases;
+  if (filter) {
+    cases = cases.filter(
+      (c) => c.id.includes(filter) || c.description.toLowerCase().includes(filter.toLowerCase())
+    );
+  }
+
+  console.log(`\n🧪 MCP LLM Tip Evals — ${cases.length} case(s)\n`);
+
+  const results: EvalResult[] = [];
+  for (const evalCase of cases) {
+    process.stdout.write(`  ${evalCase.id} ... `);
+    const result = await runEval(evalCase, verbose);
+    results.push(result);
+    console.log(result.passed ? '✅ PASS' : `❌ FAIL (${result.failures.join('; ')})`);
+  }
+
+  const passed = results.filter((r) => r.passed).length;
+  const failed = results.filter((r) => !r.passed).length;
+
+  console.log(`\n${'═'.repeat(60)}`);
+  console.log(`Results: ${passed} passed, ${failed} failed out of ${results.length}`);
+
+  if (failed > 0) {
+    console.log('\nFailed evals:');
+    for (const r of results.filter((r) => !r.passed)) {
+      console.log(`  ❌ ${r.id}:`);
+      for (const f of r.failures) {
+        console.log(`     - ${f}`);
+      }
+    }
+  }
+
+  // Write results to JSON for CI/tracking
+  const outputPath = path.join(__dirname, 'llm-tip-eval-results.json');
+  const output = {
+    timestamp: new Date().toISOString(),
+    total: results.length,
+    passed,
+    failed,
+    results: results.map(({ response, ...rest }) => ({
+      ...rest,
+      responseLength: response.length,
+    })),
+  };
+
+  const { writeFileSync } = await import('fs');
+  writeFileSync(outputPath, JSON.stringify(output, null, 2));
+  console.log(`\nResults written to ${outputPath}`);
+
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary

- **`list-chats`**: Add `apiVersion: "beta"` so `viewpoint` (unread detection) works. Fix llmTip to use `$select` instead of `$expand` — viewpoint is a complex property, not a navigation property.
- **`list-chat-messages`**: Add llmTip guiding LLMs toward `$orderby=lastModifiedDateTime desc` with client-side date filtering for "what's new" queries.
- **`graph-client.ts` / `graph-tools.ts`**: Support `apiVersion` option to override the default v1.0 Graph API version per-request, driven by `apiVersion` in `endpoints.json`.
- **Tests**: Endpoint config invariant tests, apiVersion passthrough unit tests, and an LLM tip eval harness (`test/llm-tip-evals.ts`) that verifies llmTips actually guide Claude to correct tool calls.

## Context

`viewpoint` on `/me/chats` only works on the beta Graph API. The current code hardcodes `v1.0` in graph-client.ts, so any endpoint with `apiVersion: "beta"` in endpoints.json had no effect unless it was a beta-only endpoint registered separately at runtime. For `list-chats` (which exists in both v1.0 and beta), the v1.0 registration wins and the beta config is ignored — resulting in a 400 error when following the llmTip to expand viewpoint.

Also: `/chats/{chat-id}/messages/delta()` appears in Graph OData metadata but is not implemented (returns "Change tracking is not supported against microsoft.graph.chatMessage"). See [microsoftgraph/msgraph-metadata#607](https://github.com/microsoftgraph/msgraph-metadata/issues/607). This PR does not add that endpoint but notes it in the `list-chat-messages` llmTip as a known limitation.

## Test plan

- [x] Unit tests pass (`npm test` — 124 passing, 1 pre-existing failure in orphan check unrelated to this PR)
- [x] LLM tip evals pass (`npx tsx test/llm-tip-evals.ts` — 4/4)
- [x] Manually verified: `list-chats` with `$select=viewpoint` returns `viewpoint.lastMessageReadDateTime` on beta
- [x] Manually verified: `list-chat-messages` with `$orderby=lastModifiedDateTime desc` works for incremental chat scanning
- [ ] Reviewer: confirm `apiVersion` passthrough doesn't affect existing v1.0 endpoints (test covers this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)