### PR TITLE
feat: add create-chat endpoint for Teams chats

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1540,5 +1540,12 @@
     "toolName": "remove-group-owner",
     "workScopes": ["Group.ReadWrite.All"],
     "llmTip": "Removes an owner from a group. A group must have at least one owner — this call fails if you try to remove the last owner. Use list-group-owners to find the owner's ID."
+  },
+  {
+    "pathPattern": "/chats",
+    "method": "post",
+    "toolName": "create-chat",
+    "workScopes": ["Chat.Create", "Chat.ReadWrite"],
+    "llmTip": "Creates a new 1:1 or group Teams chat. Body: { chatType ('oneOnOne' or 'group'), topic (optional, group only), members: [{ '@odata.type': '#microsoft.graph.aadUserConversationMember', roles: ['owner' | 'guest'], 'user@odata.bind': 'https://graph.microsoft.com/v1.0/users({id})' }] }. A oneOnOne chat requires exactly 2 members (self + other), both with role 'owner'. For group chats, include all participants. The signed-in user must be one of the members. Returns the created chat with its id — use that id with send-chat-message, list-chat-members, etc."
   }
 ]


### PR DESCRIPTION
## Summary
- Adds POST `/chats` as `create-chat` to create a new 1:1 or group Teams chat.
- Closes a gap in Teams chat coverage: the server currently supports `list-chats`, `get-chat`, `list-chat-members`, `send-chat-message` etc., but had no way to *start* a new chat.
- Uses `workScopes: ["Chat.Create", "Chat.ReadWrite"]`.

## Rationale
Without this, an MCP client can only interact with existing chats. Creating a new 1:1 or group conversation required falling back to the Teams UI.

## Test plan
- [x] `npm run generate` — client regenerated with `create-chat` alias
- [x] `npm run build` — builds clean
- [x] `npm test` — 131 tests pass (incl. `endpoints-validation.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)