### PR TITLE
fix: rework --discovery with BM25 search and get-tool-schema - finally! Hopefully!

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "js-yaml": "^4.1.0",
     "open": "^11.0.0",
     "winston": "^3.17.0",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "zod-to-json-schema": "^3.25.1"
   },
   "optionalDependencies": {
     "@azure/identity": "^4.5.0",

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -10,6 +10,12 @@ import { fileURLToPath } from 'url';
 import { TOOL_CATEGORIES } from './tool-categories.js';
 import { getRequestTokens } from './request-context.js';
 import { parseTeamsUrl } from './lib/teams-url-parser.js';
+import { buildBM25Index, scoreQuery, tokenize, type BM25Index } from './lib/bm25.js';
+export interface DiscoverySearchIndex {
+  bm25: BM25Index;
+  nameTokens: Map<string, Set<string>>;
+}
+import { describeToolSchema } from './lib/tool-schema.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -747,7 +753,7 @@ export function registerGraphTools(
   return registeredCount;
 }
 
-function buildToolsRegistry(
+export function buildToolsRegistry(
   readOnly: boolean,
   orgMode: boolean
 ): Map<string, { tool: (typeof api.endpoints)[0]; config: EndpointConfig | undefined }> {
@@ -776,6 +782,80 @@ function buildToolsRegistry(
   return toolsMap;
 }
 
+/**
+ * Builds a BM25 index over the tool registry. Name tokens are weighted 3x and llmTip
+ * tokens 2x via repetition, so a tool whose name matches the query outranks one that
+ * merely mentions the query term in its Microsoft-supplied description.
+ */
+export function buildDiscoverySearchIndex(
+  toolsRegistry: ReturnType<typeof buildToolsRegistry>
+): DiscoverySearchIndex {
+  // Cap contribution from the `description` and `llmTip` fields so a verbose llmTip
+  // (e.g. the KQL search-syntax guide on list-mail-messages, ~300 tokens) doesn't
+  // inflate a tool's doc length and crush BM25's length normalization. Names and
+  // paths are short and reliable, so they stay uncapped and are repeated to carry
+  // the bulk of the ranking signal. Tip excerpt (12 tokens) is enough to capture
+  // the first "what this tool does" phrase without swamping the doc.
+  const TIP_EXCERPT_TOKENS = 12;
+  const DESC_CAP_TOKENS = 40;
+  const docs: Array<{ id: string; tokens: string[] }> = [];
+  const nameTokens = new Map<string, Set<string>>();
+  for (const [name, { tool, config }] of toolsRegistry) {
+    const nt = tokenize(name);
+    nameTokens.set(name, new Set(nt));
+    const pathTokens = tokenize(tool.path);
+    const descTokens = tokenize(tool.description).slice(0, DESC_CAP_TOKENS);
+    const tipTokens = tokenize(config?.llmTip).slice(0, TIP_EXCERPT_TOKENS);
+    const tokens = [
+      ...nt,
+      ...nt,
+      ...nt,
+      ...nt,
+      ...nt,
+      ...pathTokens,
+      ...pathTokens,
+      ...tipTokens,
+      ...descTokens,
+    ];
+    docs.push({ id: name, tokens });
+  }
+  return { bm25: buildBM25Index(docs), nameTokens };
+}
+
+/**
+ * BM25 + a "name precision" bonus: reward tools whose names contain a high fraction
+ * of the query tokens (and consist mostly of query-matching tokens). This counteracts
+ * cases where a tool with a longer or more off-topic description outranks a tool
+ * whose name directly matches — a common problem because many endpoint descriptions
+ * are the wrong Graph prose pasted in.
+ */
+export function scoreDiscoveryQuery(
+  query: string,
+  index: DiscoverySearchIndex
+): Array<{ id: string; score: number }> {
+  const queryTokenSet = new Set(tokenize(query));
+  if (queryTokenSet.size === 0) return [];
+  const ranked = scoreQuery(query, index.bm25);
+  const NAME_BONUS_WEIGHT = 2;
+  for (const r of ranked) {
+    const nt = index.nameTokens.get(r.id);
+    if (!nt || nt.size === 0) continue;
+    let matchedIdf = 0;
+    let matchedCount = 0;
+    for (const qt of queryTokenSet) {
+      if (nt.has(qt)) {
+        matchedCount++;
+        matchedIdf += index.bm25.idf.get(qt) ?? 0;
+      }
+    }
+    if (matchedCount === 0) continue;
+    const precision = matchedCount / nt.size;
+    r.score += precision * matchedIdf * NAME_BONUS_WEIGHT;
+  }
+  ranked.sort((a, b) => b.score - a.score);
+  return ranked;
+}
+
 export function registerDiscoveryTools(
   server: McpServer,
   graphClient: GraphClient,
@@ -785,63 +865,56 @@ export function registerDiscoveryTools(
   _multiAccount: boolean = false
 ): void {
   const toolsRegistry = buildToolsRegistry(readOnly, orgMode);
+  const searchIndex = buildDiscoverySearchIndex(toolsRegistry);
   logger.info(`Discovery mode: ${toolsRegistry.size} tools available in registry`);
+
+  const categoryNames = Object.keys(TOOL_CATEGORIES).join(', ');
+
+  const toResultEntry = (name: string) => {
+    const entry = toolsRegistry.get(name);
+    if (!entry) return null;
+    const { tool, config } = entry;
+    return {
+      name,
+      method: tool.method.toUpperCase(),
+      path: tool.path,
+      description: tool.description || `${tool.method.toUpperCase()} ${tool.path}`,
+      ...(config?.llmTip ? { llmTip: config.llmTip } : {}),
+    };
+  };
 
   server.tool(
     'search-tools',
-    `Search through ${toolsRegistry.size} available Microsoft Graph API tools. Use this to find tools by name, path, or description before executing them.`,
+    `Search through ${toolsRegistry.size} Microsoft Graph API tools. Ranks results by BM25 over tool name, llmTip, description, and path (tokenized on hyphens, camelCase, and whitespace). After picking a tool, call get-tool-schema to see its parameters, then execute-tool to invoke it.`,
     {
       query: z
         .string()
-        .describe('Search query to filter tools (searches name, path, and description)')
-        .optional(),
-      category: z
-        .string()
         .describe(
-          'Filter by category: mail, calendar, files, contacts, tasks, onenote, search, users, excel'
+          'Natural-language query. Tokenized and BM25-ranked. E.g. "send email", "create calendar event", "list unread messages".'
         )
         .optional(),
-      limit: z.number().describe('Maximum results to return (default: 20, max: 50)').optional(),
+      category: z.string().describe(`Optional pre-filter by category: ${categoryNames}`).optional(),
+      limit: z.number().describe('Maximum results (default: 10, max: 50)').optional(),
     },
     {
       title: 'search-tools',
       readOnlyHint: true,
-      openWorldHint: true, // Searches Microsoft Graph API tools
+      openWorldHint: true,
     },
-    async ({ query, category, limit = 20 }) => {
-      const maxLimit = Math.min(limit, 50);
-      const results: Array<{
-        name: string;
-        method: string;
-        path: string;
-        description: string;
-      }> = [];
-
-      const queryLower = query?.toLowerCase();
+    async ({ query, category, limit = 10 }) => {
+      const maxLimit = Math.min(Math.max(limit, 1), 50);
       const categoryDef = category ? TOOL_CATEGORIES[category] : undefined;
+      const categoryFilter = (name: string) => !categoryDef || categoryDef.pattern.test(name);
 
-      for (const [name, { tool, config }] of toolsRegistry) {
-        if (categoryDef && !categoryDef.pattern.test(name)) {
-          continue;
-        }
-
-        if (queryLower) {
-          const searchText =
-            `${name} ${tool.path} ${tool.description || ''} ${config?.llmTip || ''}`.toLowerCase();
-          if (!searchText.includes(queryLower)) {
-            continue;
-          }
-        }
-
-        results.push({
-          name,
-          method: tool.method.toUpperCase(),
-          path: tool.path,
-          description: tool.description || `${tool.method.toUpperCase()} ${tool.path}`,
-        });
-
-        if (results.length >= maxLimit) break;
+      let orderedNames: string[];
+      if (query && query.trim().length > 0) {
+        const ranked = scoreDiscoveryQuery(query, searchIndex);
+        orderedNames = ranked.map((r) => r.id).filter(categoryFilter);
+      } else {
+        orderedNames = [...toolsRegistry.keys()].filter(categoryFilter);
       }
+
+      const tools = orderedNames.slice(0, maxLimit).map(toResultEntry).filter(Boolean);
 
       return {
         content: [
@@ -849,10 +922,10 @@ export function registerDiscoveryTools(
             type: 'text',
             text: JSON.stringify(
               {
-                found: results.length,
+                found: tools.length,
                 total: toolsRegistry.size,
-                tools: results,
-                tip: 'Use execute-tool with the tool name and required parameters to call any of these tools.',
+                tools,
+                tip: 'Call get-tool-schema(tool_name) to see parameters before invoking execute-tool.',
               },
               null,
               2
@@ -864,21 +937,56 @@ export function registerDiscoveryTools(
   );
 
   server.tool(
+    'get-tool-schema',
+    'Returns the full parameter schema (name, placement, required, JSON Schema) for a tool discovered via search-tools. Call this before execute-tool so you know what parameters to pass and what enum values are valid.',
+    {
+      tool_name: z.string().describe('Exact tool name from search-tools (e.g. "send-mail")'),
+    },
+    {
+      title: 'get-tool-schema',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    async ({ tool_name }) => {
+      const entry = toolsRegistry.get(tool_name);
+      if (!entry) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                error: `Tool not found: ${tool_name}`,
+                tip: 'Use search-tools to find available tools.',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+      const schema = describeToolSchema(entry.tool, entry.config?.llmTip);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(schema, null, 2) }],
+      };
+    }
+  );
+
+  server.tool(
     'execute-tool',
-    'Execute a Microsoft Graph API tool by name. Use search-tools first to find available tools and their parameters. ' +
-      'For list endpoints, pass a small $top (or top) first and use $select to limit fields—avoid large page sizes unless the user needs them.',
+    'Execute a Microsoft Graph API tool by name. Workflow: search-tools → get-tool-schema → execute-tool. Call get-tool-schema first for any tool you have not seen before — passing the wrong shape to parameters will fail validation or return a Graph 400. For list endpoints, prefer modest $top plus $select.',
     {
       tool_name: z.string().describe('Name of the tool to execute (e.g., "list-mail-messages")'),
       parameters: z
         .record(z.any())
-        .describe('Parameters to pass to the tool as key-value pairs')
+        .describe(
+          'Parameters shaped per get-tool-schema. Path/query/header params go at the top level; request bodies go under "body".'
+        )
         .optional(),
     },
     {
       title: 'execute-tool',
       readOnlyHint: false,
-      destructiveHint: true, // Can execute any tool, including write operations
-      openWorldHint: true, // Executes against Microsoft Graph API
+      destructiveHint: true,
+      openWorldHint: true,
     },
     async ({ tool_name, parameters = {} }) => {
       const toolData = toolsRegistry.get(tool_name);

--- a/src/lib/bm25.ts
+++ b/src/lib/bm25.ts
@@ -1,0 +1,91 @@
+/**
+ * Tokenizes text for search indexing: splits on whitespace, hyphens, underscores,
+ * camelCase boundaries, and common punctuation in tool paths. Lowercases everything.
+ * Splitting on these boundaries means "send-mail" indexes as ["send", "mail"] and
+ * matches a query like "send email" via the shared "send" token.
+ */
+export function tokenize(text: string | undefined | null): string[] {
+  if (!text) return [];
+  return text
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .toLowerCase()
+    .split(/[\s\-_/.,;:(){}[\]'"!?@#$]+/)
+    .filter((t) => t.length > 0);
+}
+
+export interface BM25Doc {
+  id: string;
+  length: number;
+  termFreq: Map<string, number>;
+}
+
+export interface BM25Index {
+  docs: Map<string, BM25Doc>;
+  idf: Map<string, number>;
+  avgdl: number;
+  k1: number;
+  b: number;
+}
+
+/**
+ * Builds a BM25 index from a set of pre-tokenized documents.
+ * Defaults k1=1.2, b=0.75 — standard values that work well for short technical text.
+ */
+export function buildBM25Index(
+  documents: Array<{ id: string; tokens: string[] }>,
+  k1 = 1.2,
+  b = 0.75
+): BM25Index {
+  const docs = new Map<string, BM25Doc>();
+  const df = new Map<string, number>();
+  let totalLen = 0;
+
+  for (const { id, tokens } of documents) {
+    const termFreq = new Map<string, number>();
+    for (const tok of tokens) {
+      termFreq.set(tok, (termFreq.get(tok) ?? 0) + 1);
+    }
+    for (const tok of termFreq.keys()) {
+      df.set(tok, (df.get(tok) ?? 0) + 1);
+    }
+    docs.set(id, { id, length: tokens.length, termFreq });
+    totalLen += tokens.length;
+  }
+
+  const N = docs.size;
+  const avgdl = N > 0 ? totalLen / N : 0;
+  const idf = new Map<string, number>();
+  for (const [term, n] of df) {
+    idf.set(term, Math.log((N - n + 0.5) / (n + 0.5) + 1));
+  }
+
+  return { docs, idf, avgdl, k1, b };
+}
+
+/**
+ * Scores every document against the query tokens and returns matches sorted by score.
+ * Documents that share no tokens with the query are excluded — a query of "xyz" against
+ * a tool catalog must return empty rather than an arbitrary top-N.
+ */
+export function scoreQuery(query: string, index: BM25Index): Array<{ id: string; score: number }> {
+  const queryTokens = [...new Set(tokenize(query))];
+  if (queryTokens.length === 0) return [];
+
+  const results: Array<{ id: string; score: number }> = [];
+  for (const [id, doc] of index.docs) {
+    let score = 0;
+    let matched = false;
+    for (const qt of queryTokens) {
+      const tf = doc.termFreq.get(qt);
+      if (!tf) continue;
+      matched = true;
+      const idf = index.idf.get(qt) ?? 0;
+      const num = tf * (index.k1 + 1);
+      const den = tf + index.k1 * (1 - index.b + (index.b * doc.length) / (index.avgdl || 1));
+      score += idf * (num / den);
+    }
+    if (matched) results.push({ id, score });
+  }
+  results.sort((a, b) => b.score - a.score);
+  return results;
+}

--- a/src/lib/tool-schema.ts
+++ b/src/lib/tool-schema.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import type { api } from '../generated/client.js';
+
+type ToolEndpoint = (typeof api.endpoints)[number];
+
+function unwrapOptional(schema: z.ZodTypeAny): { inner: z.ZodTypeAny; optional: boolean } {
+  const def = (schema as { _def?: { typeName?: string; innerType?: z.ZodTypeAny } })._def;
+  const typeName = def?.typeName;
+  if (typeName === 'ZodOptional' || typeName === 'ZodDefault' || typeName === 'ZodNullable') {
+    return { inner: def!.innerType!, optional: true };
+  }
+  return { inner: schema, optional: false };
+}
+
+/**
+ * Returns a JSON Schema describing every parameter a discovery tool accepts,
+ * so an agent can construct a correctly-shaped `parameters` object for execute-tool.
+ */
+export function describeToolSchema(
+  tool: ToolEndpoint,
+  llmTip: string | undefined
+): {
+  name: string;
+  method: string;
+  path: string;
+  description: string;
+  llmTip?: string;
+  parameters: Array<{
+    name: string;
+    in: 'Path' | 'Query' | 'Body' | 'Header';
+    required: boolean;
+    description?: string;
+    schema: unknown;
+  }>;
+} {
+  const params = (tool.parameters ?? []).map((p) => {
+    const { inner, optional } = unwrapOptional(p.schema as z.ZodTypeAny);
+    const isPath = p.type === 'Path';
+    const jsonSchema = zodToJsonSchema(inner, { target: 'jsonSchema7', $refStrategy: 'none' });
+    const { $schema: _s, ...schema } = jsonSchema as Record<string, unknown>;
+    return {
+      name: p.name,
+      in: p.type as 'Path' | 'Query' | 'Body' | 'Header',
+      required: isPath || !optional,
+      description: p.description,
+      schema,
+    };
+  });
+
+  return {
+    name: tool.alias,
+    method: tool.method.toUpperCase(),
+    path: tool.path,
+    description: tool.description ?? '',
+    ...(llmTip ? { llmTip } : {}),
+    parameters: params,
+  };
+}

--- a/src/mcp-instructions.ts
+++ b/src/mcp-instructions.ts
@@ -23,8 +23,11 @@ function buildGeneralMcpInstructions(opts: McpInstructionsContext): string {
 }
 
 const DISCOVERY_MODE_INSTRUCTIONS_ADDON =
-  'DISCOVERY MODE ADD-ON: Graph is reached via search-tools then execute-tool (plus auth helpers). ' +
-  'Call search-tools with short keywords, then execute-tool with tool_name exactly as returned; put Graph parameters in the parameters object. ' +
+  'DISCOVERY MODE ADD-ON: Graph is reached via search-tools → get-tool-schema → execute-tool (plus auth helpers). ' +
+  'Workflow: (1) call search-tools with short natural-language keywords (BM25-ranked); ' +
+  '(2) call get-tool-schema(tool_name) to see the parameters, required fields, and enum values; ' +
+  '(3) call execute-tool with tool_name exactly as returned and parameters shaped per the schema. ' +
+  'Skipping get-tool-schema is the leading cause of Graph 400 errors here. ' +
   'If search-tools returns no matches, retry with shorter or different keywords.';
 
 /**

--- a/test/bm25.test.ts
+++ b/test/bm25.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { buildBM25Index, scoreQuery, tokenize } from '../src/lib/bm25.js';
+
+describe('tokenize', () => {
+  it('splits on hyphens', () => {
+    expect(tokenize('send-mail')).toEqual(['send', 'mail']);
+  });
+
+  it('splits on camelCase boundaries', () => {
+    expect(tokenize('listMailMessages')).toEqual(['list', 'mail', 'messages']);
+  });
+
+  it('splits on underscores and whitespace', () => {
+    expect(tokenize('create_calendar event')).toEqual(['create', 'calendar', 'event']);
+  });
+
+  it('splits on path separators and function-call punctuation', () => {
+    expect(tokenize('/me/events/delta()')).toEqual(['me', 'events', 'delta']);
+  });
+
+  it('lowercases everything', () => {
+    expect(tokenize('SendMail')).toEqual(['send', 'mail']);
+  });
+
+  it('returns empty array for empty/missing input', () => {
+    expect(tokenize('')).toEqual([]);
+    expect(tokenize(undefined)).toEqual([]);
+    expect(tokenize(null)).toEqual([]);
+  });
+});
+
+describe('BM25 scoring', () => {
+  const docs = [
+    { id: 'send-mail', tokens: tokenize('send-mail /me/sendMail Send the message') },
+    { id: 'list-mail-messages', tokens: tokenize('list-mail-messages /me/messages List messages') },
+    {
+      id: 'create-event',
+      tokens: tokenize('create-event /me/events Create a calendar event'),
+    },
+    {
+      id: 'share-drive-item',
+      tokens: tokenize('share-drive-item /drives/items/invite Send a sharing invitation email'),
+    },
+  ];
+  const index = buildBM25Index(docs);
+
+  it('finds hyphenated tools via natural-language query', () => {
+    const ranked = scoreQuery('send email', index);
+    const top = ranked.map((r) => r.id);
+    expect(top).toContain('send-mail');
+    expect(top).toContain('share-drive-item');
+  });
+
+  it('ranks the tool whose name matches the query ahead of incidental mentions', () => {
+    const ranked = scoreQuery('send mail', index);
+    expect(ranked[0].id).toBe('send-mail');
+  });
+
+  it('finds calendar-event tool via multi-word query', () => {
+    const ranked = scoreQuery('create calendar event', index);
+    expect(ranked[0].id).toBe('create-event');
+  });
+
+  it('returns empty when no query token matches any document', () => {
+    expect(scoreQuery('xyzzyfoobar', index)).toEqual([]);
+  });
+
+  it('returns empty when the query tokenizes to nothing', () => {
+    expect(scoreQuery('   ', index)).toEqual([]);
+  });
+});

--- a/test/discovery-search.test.ts
+++ b/test/discovery-search.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildToolsRegistry,
+  buildDiscoverySearchIndex,
+  scoreDiscoveryQuery,
+} from '../src/graph-tools.js';
+
+/**
+ * Golden-query eval for discovery search. Each case asserts that the expected tool
+ * appears in the top-N results for a natural-language query a user is likely
+ * to phrase. The live tool registry is used (no mocks) so regressions in endpoint
+ * descriptions, llmTips, or the ranking weights surface here.
+ */
+const registry = buildToolsRegistry(false, true);
+const index = buildDiscoverySearchIndex(registry);
+
+function topN(query: string, n: number): string[] {
+  return scoreDiscoveryQuery(query, index)
+    .slice(0, n)
+    .map((r) => r.id);
+}
+
+type Case = { query: string; expect: string; inTop?: number };
+
+const cases: Case[] = [
+  // Mail
+  { query: 'send email', expect: 'send-mail', inTop: 5 },
+  { query: 'send mail', expect: 'send-mail', inTop: 3 },
+  { query: 'list unread mail', expect: 'list-mail-messages', inTop: 5 },
+  { query: 'list messages', expect: 'list-mail-messages', inTop: 5 },
+  { query: 'read mail message', expect: 'get-mail-message', inTop: 5 },
+  { query: 'delete mail', expect: 'delete-mail-message', inTop: 5 },
+  { query: 'list mail folders', expect: 'list-mail-folders', inTop: 3 },
+  // Calendar
+  { query: 'create calendar event', expect: 'create-calendar-event', inTop: 5 },
+  { query: 'create event', expect: 'create-calendar-event', inTop: 5 },
+  { query: 'list calendars', expect: 'list-calendars', inTop: 3 },
+  { query: 'list calendar events', expect: 'list-calendar-events', inTop: 5 },
+  { query: 'accept event', expect: 'accept-calendar-event', inTop: 5 },
+  // Teams
+  { query: 'list chats', expect: 'list-chats', inTop: 5 },
+  { query: 'chat messages', expect: 'list-chat-messages', inTop: 5 },
+  { query: 'send chat message', expect: 'send-chat-message', inTop: 5 },
+  // Excel
+  { query: 'list excel worksheets', expect: 'list-excel-worksheets', inTop: 3 },
+  { query: 'excel range', expect: 'get-excel-range', inTop: 10 },
+  // Files
+  { query: 'list folders', expect: 'list-mail-folders', inTop: 10 },
+  { query: 'onedrive folder', expect: 'create-onedrive-folder', inTop: 10 },
+  { query: 'download file', expect: 'download-onedrive-file-content', inTop: 5 },
+  { query: 'upload file', expect: 'upload-file-content', inTop: 5 },
+  // Users
+  { query: 'search users', expect: 'list-users', inTop: 10 },
+  { query: 'user manager', expect: 'get-user-manager', inTop: 10 },
+  // Contacts
+  { query: 'list contacts', expect: 'list-outlook-contacts', inTop: 5 },
+  { query: 'create contact', expect: 'create-outlook-contact', inTop: 5 },
+];
+
+describe('discovery search (golden queries)', () => {
+  for (const c of cases) {
+    const n = c.inTop ?? 5;
+    it(`"${c.query}" → ${c.expect} in top ${n}`, () => {
+      if (!registry.has(c.expect)) {
+        throw new Error(
+          `Test fixture error: expected tool "${c.expect}" is not in the registry. ` +
+            `Update the golden-query case or add the endpoint.`
+        );
+      }
+      const top = topN(c.query, n);
+      expect(top, `top ${n} for "${c.query}"`).toContain(c.expect);
+    });
+  }
+
+  it('returns empty for gibberish queries', () => {
+    expect(scoreDiscoveryQuery('zzzqqqxxxfoobarbaz', index)).toEqual([]);
+  });
+
+  it('covers at least 80% of golden queries in top 5', () => {
+    let hits = 0;
+    for (const c of cases) {
+      if (topN(c.query, 5).includes(c.expect)) hits++;
+    }
+    const ratio = hits / cases.length;
+    expect(ratio, `hit ratio ${(ratio * 100).toFixed(1)}%`).toBeGreaterThanOrEqual(0.8);
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,7 @@
+// Node 18 lacks the Web `File` global that Node 20+ and browsers provide.
+// The generated Graph client uses `z.instanceof(File)` for multipart upload
+// endpoints, so importing it under Node 18 throws ReferenceError at module load.
+// Provide a minimal stand-in so tests that load the real client can run on 18.
+if (typeof (globalThis as { File?: unknown }).File === 'undefined') {
+  (globalThis as { File?: unknown }).File = class File {};
+}

--- a/test/tool-schema.test.ts
+++ b/test/tool-schema.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { buildToolsRegistry } from '../src/graph-tools.js';
+import { describeToolSchema } from '../src/lib/tool-schema.js';
+
+const registry = buildToolsRegistry(false, true);
+
+function schemaFor(name: string) {
+  const entry = registry.get(name);
+  if (!entry) throw new Error(`Registry missing ${name}`);
+  return describeToolSchema(entry.tool, entry.config?.llmTip);
+}
+
+describe('describeToolSchema', () => {
+  it('returns name, method, path, and parameters for a common tool', () => {
+    const s = schemaFor('list-mail-messages');
+    expect(s.name).toBe('list-mail-messages');
+    expect(s.method).toBe('GET');
+    expect(s.path).toContain('/me/messages');
+    expect(Array.isArray(s.parameters)).toBe(true);
+  });
+
+  it('marks path parameters as required', () => {
+    const s = schemaFor('get-mail-message');
+    const pathParams = s.parameters.filter((p) => p.in === 'Path');
+    expect(pathParams.length).toBeGreaterThan(0);
+    for (const p of pathParams) expect(p.required).toBe(true);
+  });
+
+  it('emits JSON Schema objects (not Zod) for every parameter', () => {
+    const s = schemaFor('send-mail');
+    for (const p of s.parameters) {
+      expect(p.schema).toBeDefined();
+      expect(typeof p.schema).toBe('object');
+      // zod-to-json-schema always produces a typed node at the root for our schemas
+      expect(p.schema).toHaveProperty('type');
+    }
+  });
+
+  it('includes llmTip when the endpoint has one', () => {
+    // Walk the registry for any tool with an llmTip — guard against registries without one
+    const entry = [...registry.entries()].find(([, v]) => v.config?.llmTip)?.[1];
+    if (!entry) return;
+    const s = describeToolSchema(entry.tool, entry.config?.llmTip);
+    expect(s.llmTip).toBeTruthy();
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    setupFiles: ['./test/setup.ts'],
   },
 });


### PR DESCRIPTION
search-tools previously did naive substring matching that returned zero results for natural-language queries like "send email" or "create calendar event". It now tokenizes (hyphen, underscore, camelCase) and ranks via BM25 with a name-precision bonus, and includes llmTip in the result payload.

Adds get-tool-schema(tool_name) so agents can inspect parameters and enum values before calling execute-tool instead of guessing and relying on Graph 400s to self-correct.