### PR TITLE
feat: split public and internal URLs in OAuth metadata

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -42,7 +42,7 @@ For production, use Azure Key Vault instead of environment variables for secrets
 docker run -p 3000:3000 \
   -e MS365_MCP_KEYVAULT_URL=https://your-keyvault.vault.azure.net \
   -e MS365_MCP_ORG_MODE=true \
-  -e MS365_MCP_BASE_URL=https://mcp.example.com \
+  -e MS365_MCP_PUBLIC_URL=https://mcp.example.com \
   ms-365-mcp-server \
   --http 3000 --org-mode
 ```
@@ -72,7 +72,7 @@ docker run -p 3000:3000 \
      --env-vars \
        "MS365_MCP_KEYVAULT_URL=https://your-keyvault.vault.azure.net" \
        "MS365_MCP_ORG_MODE=true" \
-       "MS365_MCP_BASE_URL=https://mcp.example.com" \
+       "MS365_MCP_PUBLIC_URL=https://mcp.example.com" \
      --command "node" "dist/index.js" "--http" "3000" "--org-mode"
    ```
 
@@ -99,7 +99,7 @@ az webapp config appsettings set --name mcp-server --resource-group your-rg \
   --settings \
     MS365_MCP_KEYVAULT_URL="https://your-keyvault.vault.azure.net" \
     MS365_MCP_ORG_MODE="true" \
-    MS365_MCP_BASE_URL="https://mcp-server.azurewebsites.net" \
+    MS365_MCP_PUBLIC_URL="https://mcp-server.azurewebsites.net" \
     WEBSITES_PORT="3000"
 
 az webapp config set --name mcp-server --resource-group your-rg \
@@ -130,17 +130,17 @@ When deploying for an organization, create a dedicated app registration instead 
 
 ## Reverse Proxy / Custom Domain
 
-When running behind a reverse proxy or custom domain, set `MS365_MCP_BASE_URL` so OAuth discovery endpoints return the correct public URL:
+When running behind a reverse proxy, set `MS365_MCP_PUBLIC_URL` so that the OAuth authorize URL handed back to the user's browser is resolvable from outside the server's network:
 
 ```bash
 # Via environment variable
-MS365_MCP_BASE_URL=https://mcp.example.com
+MS365_MCP_PUBLIC_URL=https://mcp.example.com
 
 # Or via CLI flag
---base-url https://mcp.example.com
+--public-url https://mcp.example.com
 ```
 
-Without this, `/.well-known/oauth-authorization-server` would advertise `http://localhost:3000` as the authorization endpoint.
+Only browser-facing fields (`issuer`, `authorization_endpoint`, `authorization_servers`) are pinned to this URL. Server-to-server endpoints (`token_endpoint`, `registration_endpoint`, `resource`) stay on the request origin, so clients that reach the server over an internal network (e.g. another container on the same Docker network) don't have to round-trip back through the public URL.
 
 ## Client Configuration
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -63,8 +63,14 @@ program
     'Use browser-based interactive OAuth flow instead of device code for stdio mode. Opens system browser with localhost callback for seamless sign-in.'
   )
   .option(
-    '--base-url <url>',
-    'Public base URL for OAuth metadata when running behind a reverse proxy (e.g. https://mcp.example.com)'
+    '--public-url <url>',
+    'Public base URL (e.g. https://mcp.example.com) used in browser-facing OAuth redirects when running behind a reverse proxy. Server-to-server endpoints (token, register) stay on the request host.'
+  )
+  .addOption(
+    // DEPRECATED: kept only so existing deployments that set --base-url or
+    // MS365_MCP_BASE_URL do not crash at startup. Use --public-url /
+    // MS365_MCP_PUBLIC_URL instead. Hidden from --help; undocumented.
+    new Option('--base-url <url>', 'deprecated: use --public-url').hideHelp()
   );
 
 export interface CommandOptions {
@@ -91,6 +97,8 @@ export interface CommandOptions {
   enableDynamicRegistration?: boolean;
   dynamicRegistration?: boolean;
   authBrowser?: boolean;
+  publicUrl?: string;
+  /** @deprecated use publicUrl */
   baseUrl?: string;
 
   [key: string]: unknown;

--- a/src/server.ts
+++ b/src/server.ts
@@ -200,17 +200,46 @@ class MicrosoftGraphServer {
 
       const oauthProvider = new MicrosoftOAuthProvider(this.authManager, this.secrets!);
 
+      // Public URL resolution for browser-facing OAuth endpoints.
+      //
+      // When running behind a reverse proxy, the request's Host header only
+      // reflects the public origin if the client reached the server through
+      // the proxy. If a client (e.g. Open WebUI) talks to the server over
+      // an internal Docker hostname, Host is that internal name, so the
+      // authorize URL we hand back to the user's browser would be
+      // unresolvable from outside. Setting MS365_MCP_PUBLIC_URL pins the
+      // browser-facing origin while the server-to-server endpoints
+      // (token, register, resource) stay on the request origin so clients
+      // that reach us internally don't need NAT loopback through the proxy.
+      //
+      // DEPRECATED: --base-url / MS365_MCP_BASE_URL. Use --public-url /
+      // MS365_MCP_PUBLIC_URL instead. The deprecated names are still read
+      // here so existing configurations don't crash at startup, but they
+      // will be removed in a future release. Note that the original
+      // --base-url was effectively a no-op in practice: it was plumbed
+      // through the SDK's mcpAuthRouter, whose metadata endpoint is
+      // shadowed by the custom handler below, so no deployment relied
+      // on its actual semantics.
+      const publicUrlRaw =
+        this.options.publicUrl ||
+        process.env.MS365_MCP_PUBLIC_URL ||
+        this.options.baseUrl ||
+        process.env.MS365_MCP_BASE_URL ||
+        null;
+      const publicBase = publicUrlRaw ? new URL(publicUrlRaw).href.replace(/\/$/, '') : null;
+
       // OAuth Authorization Server Discovery
       app.get('/.well-known/oauth-authorization-server', async (req, res) => {
         const protocol = req.secure ? 'https' : 'http';
-        const url = new URL(`${protocol}://${req.get('host')}`);
+        const requestOrigin = `${protocol}://${req.get('host')}`;
+        const browserBase = publicBase ?? requestOrigin;
 
         const scopes = buildScopesFromEndpoints(this.options.orgMode, this.options.enabledTools);
 
         const metadata: Record<string, unknown> = {
-          issuer: url.origin,
-          authorization_endpoint: `${url.origin}/authorize`,
-          token_endpoint: `${url.origin}/token`,
+          issuer: browserBase,
+          authorization_endpoint: `${browserBase}/authorize`,
+          token_endpoint: `${requestOrigin}/token`,
           response_types_supported: ['code'],
           response_modes_supported: ['query'],
           grant_types_supported: ['authorization_code', 'refresh_token'],
@@ -220,7 +249,7 @@ class MicrosoftGraphServer {
         };
 
         if (this.options.enableDynamicRegistration) {
-          metadata.registration_endpoint = `${url.origin}/register`;
+          metadata.registration_endpoint = `${requestOrigin}/register`;
         }
 
         res.json(metadata);
@@ -229,16 +258,17 @@ class MicrosoftGraphServer {
       // OAuth Protected Resource Discovery
       app.get('/.well-known/oauth-protected-resource', async (req, res) => {
         const protocol = req.secure ? 'https' : 'http';
-        const url = new URL(`${protocol}://${req.get('host')}`);
+        const requestOrigin = `${protocol}://${req.get('host')}`;
+        const browserBase = publicBase ?? requestOrigin;
 
         const scopes = buildScopesFromEndpoints(this.options.orgMode, this.options.enabledTools);
 
         res.json({
-          resource: `${url.origin}/mcp`,
-          authorization_servers: [url.origin],
+          resource: `${requestOrigin}/mcp`,
+          authorization_servers: [browserBase],
           scopes_supported: scopes,
           bearer_methods_supported: ['header'],
-          resource_documentation: `${url.origin}`,
+          resource_documentation: browserBase,
         });
       });
 
@@ -483,9 +513,7 @@ class MicrosoftGraphServer {
       app.use(
         mcpAuthRouter({
           provider: oauthProvider,
-          issuerUrl: new URL(
-            this.options.baseUrl || process.env.MS365_MCP_BASE_URL || `http://localhost:${port}`
-          ),
+          issuerUrl: new URL(publicBase ?? `http://localhost:${port}`),
         })
       );
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -7,12 +7,24 @@ vi.mock('commander', () => {
     description: vi.fn().mockReturnThis(),
     version: vi.fn().mockReturnThis(),
     option: vi.fn().mockReturnThis(),
+    addOption: vi.fn().mockReturnThis(),
     parse: vi.fn(),
     opts: vi.fn().mockReturnValue({ file: 'test.xlsx' }),
   };
 
+  class MockOption {
+    constructor(
+      public flags: string,
+      public description: string
+    ) {}
+    hideHelp() {
+      return this;
+    }
+  }
+
   return {
     Command: vi.fn(() => mockCommand),
+    Option: MockOption,
   };
 });
 


### PR DESCRIPTION
The custom /.well-known handlers derived every OAuth URL from the request Host header, so when a client reached the server over an internal network (e.g. Open WebUI in the same Docker network), the authorize URL handed back to the user's browser used that internal hostname and couldn't resolve from outside.

Resolve a public URL from --public-url / MS365_MCP_PUBLIC_URL and use it only for browser-facing fields (issuer, authorization_endpoint, authorization_servers). Server-to-server fields (token_endpoint, registration_endpoint, resource) stay on the request origin so internal clients don't have to round-trip through the reverse proxy.

--base-url / MS365_MCP_BASE_URL is deprecated but still read as a fallback. Its original implementation was effectively a no-op because the SDK's mcpAuthRouter it plumbed into was shadowed by the custom handlers.