### PR TITLE
feat: return 401 + WWW-Authenticate so MCP clients drive token refresh

### DIFF
--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -1,6 +1,5 @@
 import logger from './logger.js';
 import AuthManager from './auth.js';
-import { refreshAccessToken } from './lib/microsoft-auth.js';
 import { encode as toonEncode } from '@toon-format/toon';
 import type { AppSecrets } from './secrets.js';
 import { getCloudEndpoints } from './cloud-config.js';
@@ -50,7 +49,6 @@ interface GraphRequestOptions {
   includeHeaders?: boolean;
   excludeResponse?: boolean;
   accessToken?: string;
-  refreshToken?: string;
 
   [key: string]: unknown;
 }
@@ -87,25 +85,15 @@ class GraphClient {
 
   async makeRequest(endpoint: string, options: GraphRequestOptions = {}): Promise<unknown> {
     const contextTokens = getRequestTokens();
-    let accessToken =
+    const accessToken =
       options.accessToken ?? contextTokens?.accessToken ?? (await this.authManager.getToken());
-    const refreshToken = options.refreshToken ?? contextTokens?.refreshToken;
 
     if (!accessToken) {
       throw new Error('No access token available');
     }
 
     try {
-      let response = await this.performRequest(endpoint, accessToken, options);
-
-      if (response.status === 401 && refreshToken) {
-        // Token expired, try to refresh
-        const newTokens = await this.refreshAccessToken(refreshToken);
-        accessToken = newTokens.accessToken;
-
-        // Retry the request with new token
-        response = await this.performRequest(endpoint, accessToken, options);
-      }
+      const response = await this.performRequest(endpoint, accessToken, options);
 
       if (response.status === 403) {
         const errorText = await response.text();
@@ -175,34 +163,6 @@ class GraphClient {
       logger.error('Microsoft Graph API request failed:', error);
       throw error;
     }
-  }
-
-  private async refreshAccessToken(
-    refreshToken: string
-  ): Promise<{ accessToken: string; refreshToken?: string }> {
-    const tenantId = this.secrets.tenantId || 'common';
-    const clientId = this.secrets.clientId;
-    const clientSecret = this.secrets.clientSecret;
-
-    // Log whether using public or confidential client
-    if (clientSecret) {
-      logger.info('GraphClient: Refreshing token with confidential client');
-    } else {
-      logger.info('GraphClient: Refreshing token with public client');
-    }
-
-    const response = await refreshAccessToken(
-      refreshToken,
-      clientId,
-      clientSecret,
-      tenantId,
-      this.secrets.cloudType
-    );
-
-    return {
-      accessToken: response.access_token,
-      refreshToken: response.refresh_token,
-    };
   }
 
   private async performRequest(

--- a/src/lib/microsoft-auth.ts
+++ b/src/lib/microsoft-auth.ts
@@ -2,35 +2,68 @@ import { Request, Response, NextFunction } from 'express';
 import logger from '../logger.js';
 import { getCloudEndpoints, type CloudType } from '../cloud-config.js';
 
+function buildWwwAuthenticate(req: Request, error: string, description: string): string {
+  const protocol = req.secure ? 'https' : 'http';
+  const origin = `${protocol}://${req.get('host')}`;
+  const resourceMetadata = `${origin}/.well-known/oauth-protected-resource`;
+  return `Bearer resource_metadata="${resourceMetadata}", error="${error}", error_description="${description}"`;
+}
+
+// Returns true only for JWTs whose exp claim is in the past.
+// Opaque tokens (e.g. MSA compact tokens) and tokens without exp return false
+// and are passed through for Graph to validate.
+function isJwtExpired(token: string): boolean {
+  const parts = token.split('.');
+  if (parts.length !== 3) return false;
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf-8'));
+    if (typeof payload.exp !== 'number') return false;
+    return payload.exp * 1000 < Date.now();
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Microsoft Bearer Token Auth Middleware validates that the request has a valid Microsoft access token
- * The token is passed in the Authorization header as a Bearer token
+ * Microsoft Bearer Token Auth Middleware validates that the request has a valid Microsoft access token.
+ * Returns HTTP 401 + WWW-Authenticate on missing or expired tokens so spec-compliant MCP clients
+ * refresh via the /token endpoint. Opaque tokens fall through and are validated by Graph.
  */
 export const microsoftBearerTokenAuthMiddleware = (
-  req: Request & { microsoftAuth?: { accessToken: string; refreshToken: string } },
+  req: Request & { microsoftAuth?: { accessToken: string } },
   res: Response,
   next: NextFunction
 ): void => {
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    res.status(401).json({ error: 'Missing or invalid access token' });
+    res
+      .status(401)
+      .set(
+        'WWW-Authenticate',
+        buildWwwAuthenticate(req, 'invalid_token', 'Missing or malformed Authorization header')
+      )
+      .json({
+        error: 'invalid_token',
+        error_description: 'Missing or malformed Authorization header',
+      });
     return;
   }
 
   const accessToken = authHeader.substring(7);
 
-  // For Microsoft Graph, we don't validate the token here - we'll let the API calls fail if it's invalid
-  // and handle token refresh in the GraphClient
+  if (isJwtExpired(accessToken)) {
+    res
+      .status(401)
+      .set(
+        'WWW-Authenticate',
+        buildWwwAuthenticate(req, 'invalid_token', 'The access token has expired')
+      )
+      .json({ error: 'invalid_token', error_description: 'The access token has expired' });
+    return;
+  }
 
-  // Extract refresh token from a custom header (if provided)
-  const refreshToken = (req.headers['x-microsoft-refresh-token'] as string) || '';
-
-  // Store tokens in request for later use
-  req.microsoftAuth = {
-    accessToken,
-    refreshToken,
-  };
+  req.microsoftAuth = { accessToken };
 
   next();
 };

--- a/src/request-context.ts
+++ b/src/request-context.ts
@@ -2,7 +2,6 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 
 export interface RequestContext {
   accessToken: string;
-  refreshToken?: string;
 }
 
 export const requestContext = new AsyncLocalStorage<RequestContext>();

--- a/src/server.ts
+++ b/src/server.ts
@@ -522,10 +522,7 @@ class MicrosoftGraphServer {
       app.get(
         '/mcp',
         microsoftBearerTokenAuthMiddleware,
-        async (
-          req: Request & { microsoftAuth?: { accessToken: string; refreshToken: string } },
-          res: Response
-        ) => {
+        async (req: Request & { microsoftAuth?: { accessToken: string } }, res: Response) => {
           const handler = async () => {
             const server = this.createMcpServer();
             const transport = new StreamableHTTPServerTransport({
@@ -543,13 +540,7 @@ class MicrosoftGraphServer {
 
           try {
             if (req.microsoftAuth) {
-              await requestContext.run(
-                {
-                  accessToken: req.microsoftAuth.accessToken,
-                  refreshToken: req.microsoftAuth.refreshToken,
-                },
-                handler
-              );
+              await requestContext.run({ accessToken: req.microsoftAuth.accessToken }, handler);
             } else {
               await handler();
             }
@@ -572,10 +563,7 @@ class MicrosoftGraphServer {
       app.post(
         '/mcp',
         microsoftBearerTokenAuthMiddleware,
-        async (
-          req: Request & { microsoftAuth?: { accessToken: string; refreshToken: string } },
-          res: Response
-        ) => {
+        async (req: Request & { microsoftAuth?: { accessToken: string } }, res: Response) => {
           const handler = async () => {
             const server = this.createMcpServer();
             const transport = new StreamableHTTPServerTransport({
@@ -593,13 +581,7 @@ class MicrosoftGraphServer {
 
           try {
             if (req.microsoftAuth) {
-              await requestContext.run(
-                {
-                  accessToken: req.microsoftAuth.accessToken,
-                  refreshToken: req.microsoftAuth.refreshToken,
-                },
-                handler
-              );
+              await requestContext.run({ accessToken: req.microsoftAuth.accessToken }, handler);
             } else {
               await handler();
             }

--- a/test/http-oauth-fix.test.ts
+++ b/test/http-oauth-fix.test.ts
@@ -108,9 +108,8 @@ describe('Issue #258: HTTP/OAuth mode with empty MSAL cache', () => {
     expect(capturedHandler).toBeDefined();
 
     // Simulate HTTP/OAuth mode: token comes from request context (middleware)
-    const result = await requestContext.run(
-      { accessToken: 'OAUTH_HTTP_TOKEN', refreshToken: 'REFRESH_TOKEN' },
-      () => capturedHandler!({})
+    const result = await requestContext.run({ accessToken: 'OAUTH_HTTP_TOKEN' }, () =>
+      capturedHandler!({})
     );
 
     // Should NOT have called getTokenForAccount (the MSAL path)

--- a/test/request-context.test.ts
+++ b/test/request-context.test.ts
@@ -8,25 +8,19 @@ describe('request-context', () => {
   it('should isolate tokens between concurrent async operations', async () => {
     const results: string[] = [];
 
-    const request1 = requestContext.run(
-      { accessToken: 'token-A', refreshToken: 'refresh-A' },
-      async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        const tokens = getRequestTokens();
-        results.push(`req1: ${tokens?.accessToken}`);
-        return tokens?.accessToken;
-      }
-    );
+    const request1 = requestContext.run({ accessToken: 'token-A' }, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      const tokens = getRequestTokens();
+      results.push(`req1: ${tokens?.accessToken}`);
+      return tokens?.accessToken;
+    });
 
-    const request2 = requestContext.run(
-      { accessToken: 'token-B', refreshToken: 'refresh-B' },
-      async () => {
-        await new Promise((resolve) => setTimeout(resolve, 5));
-        const tokens = getRequestTokens();
-        results.push(`req2: ${tokens?.accessToken}`);
-        return tokens?.accessToken;
-      }
-    );
+    const request2 = requestContext.run({ accessToken: 'token-B' }, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      const tokens = getRequestTokens();
+      results.push(`req2: ${tokens?.accessToken}`);
+      return tokens?.accessToken;
+    });
 
     const [result1, result2] = await Promise.all([request1, request2]);
 


### PR DESCRIPTION
The bearer auth middleware previously skipped token validation and let Graph 401s bubble up as HTTP 200 tool-call errors. Spec-compliant MCP clients have no signal to refresh from that, so sessions silently died once the upstream access token expired.

The middleware now decodes the JWT locally and returns 401 with a WWW-Authenticate header pointing at /.well-known/oauth-protected-resource when exp is in the past, which is what the MCP Authorization spec and Anthropic's connector docs require to trigger client-side refresh. Opaque (MSA compact) tokens still pass through for Graph to validate.

With refresh now fully owned by the client, the in-band refresh-on-401 in graph-client.ts and the undocumented x-microsoft-refresh-token header are removed.