### PR TITLE
fix: request offline_access so Entra ID issues a refresh token

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -195,6 +195,10 @@ function buildScopesFromEndpoints(
     }
   });
 
+  // Always request offline_access so Entra ID issues a refresh token,
+  // enabling silent token refresh after the access token expires (~60–90 min).
+  scopesSet.add('offline_access');
+
   const scopes = Array.from(scopesSet);
   if (enabledToolsPattern) {
     logger.info(`Built ${scopes.length} scopes for filtered tools: ${scopes.join(', ')}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -385,7 +385,19 @@ class MicrosoftGraphServer {
 
         // Ensure we have the minimal required scopes if none provided
         if (!microsoftAuthUrl.searchParams.get('scope')) {
-          microsoftAuthUrl.searchParams.set('scope', 'User.Read Files.Read Mail.Read');
+          microsoftAuthUrl.searchParams.set(
+            'scope',
+            'User.Read Files.Read Mail.Read offline_access'
+          );
+        } else {
+          // Always include offline_access so Entra ID issues a refresh token,
+          // enabling silent token refresh once the access token expires.
+          const scopeValue = microsoftAuthUrl.searchParams.get('scope')!;
+          const scopeList = scopeValue.split(/\s+/).filter(Boolean);
+          if (!scopeList.includes('offline_access')) {
+            scopeList.push('offline_access');
+            microsoftAuthUrl.searchParams.set('scope', scopeList.join(' '));
+          }
         }
 
         // Redirect to Microsoft's authorization page


### PR DESCRIPTION
## Summary

- Add `offline_access` to the scopes built by `buildScopesFromEndpoints()` so the OAuth metadata (`scopes_supported`) advertises it
- In the `/authorize` HTTP endpoint, always append `offline_access` to the scope forwarded to Microsoft (fallback path and augmentation when the client supplies its own scope list)

## Motivation

Without `offline_access`, Microsoft Entra ID does not issue a refresh token. The recent #406 change correctly returns `401 + WWW-Authenticate` so MCP clients drive token refresh — but clients have no refresh token to use, so the session still dies ~60–90 min after sign-in and the user is forced to re-authenticate.

Requesting `offline_access` is the missing piece: Entra ID returns a refresh token valid for ~90 days (rolling), and `acquireTokenSilent` / the client-driven refresh flow can then renew the access token transparently.

## Test plan

- [x] Existing test suite passes (`npx vitest run` — 173/173)
- [ ] Manual: sign in via HTTP OAuth, confirm `offline_access` appears in the Microsoft authorize URL
- [ ] Manual: wait >60 min, confirm next tool call refreshes silently instead of returning 401 without recovery

Note: users authenticated before this change must sign in once more to receive a refresh token with the new scope; subsequent sessions are silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)