### PR TITLE
fix: inject offline_access silently in /authorize forwarding

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -385,7 +385,27 @@ class MicrosoftGraphServer {
 
         // Ensure we have the minimal required scopes if none provided
         if (!microsoftAuthUrl.searchParams.get('scope')) {
-          microsoftAuthUrl.searchParams.set('scope', 'User.Read Files.Read Mail.Read');
+          microsoftAuthUrl.searchParams.set(
+            'scope',
+            'User.Read Files.Read Mail.Read offline_access'
+          );
+        } else {
+          // Inject offline_access silently here (not advertised in scopes_supported)
+          // so Entra ID issues a refresh token, enabling silent token refresh after
+          // the access token expires. We deliberately do NOT add offline_access to
+          // buildScopesFromEndpoints(): advertising the scope in OAuth metadata made
+          // MCP clients request it explicitly, which triggers a "Maintain access to
+          // data" consent line that fails in tenants where user consent for
+          // applications is restricted by policy (even when admin has pre-consented
+          // every scope). Injecting silently in the forwarding path gives Entra
+          // what it needs to issue a refresh token without surfacing the scope to
+          // the client.
+          const scopeValue = microsoftAuthUrl.searchParams.get('scope')!;
+          const scopeList = scopeValue.split(/\s+/).filter(Boolean);
+          if (!scopeList.includes('offline_access')) {
+            scopeList.push('offline_access');
+            microsoftAuthUrl.searchParams.set('scope', scopeList.join(' '));
+          }
         }
 
         // Redirect to Microsoft's authorization page


### PR DESCRIPTION
## Summary

Injects `offline_access` into the scope parameter that is forwarded to Microsoft in the `/authorize` endpoint, so Entra ID issues a refresh token. Does **not** advertise the scope in `/.well-known/oauth-authorization-server.scopes_supported`.

Replaces #407 with a corrected approach after testing revealed the metadata-advertising path caused sign-in failures in tenants with restrictive user-consent policies.

## Motivation

The recent #406 change correctly returns `401 + WWW-Authenticate` so MCP clients drive token refresh, but without `offline_access` in the Microsoft authorize request there is no refresh token to use — sessions silently die ~60–90 min after sign-in.

#407 tried to fix this by adding `offline_access` to `buildScopesFromEndpoints()`, making it appear in `scopes_supported`. **This broke sign-in in tenants with restricted user consent**:

1. Claude reads `scopes_supported`, builds the list, and passes it back in `/authorize`.
2. With `offline_access` explicitly requested by the client, Entra surfaces a **"Maintain access to data"** consent line in addition to the regular scope consent.
3. In tenants where the "user consent for applications" policy is set to "Do not allow user consent" or "Allow for verified publishers" — **even when admin has pre-consented every other scope tenant-wide** — Entra routes to an "Admin approval required" page instead of the normal consent screen.
4. The user can only *request* approval; they cannot accept. Sign-in dead-ends.

The surface area of this bug is wider than LCI's specific policy: any Microsoft 365 tenant that tightens user consent (increasingly common for security/compliance) will trip on the same path once this MCP server is deployed against an app registration with admin-only scopes.

## Fix

Inject `offline_access` **silently** in the `/authorize` forwarding handler:

```ts
// src/server.ts
if (!microsoftAuthUrl.searchParams.get('scope')) {
  microsoftAuthUrl.searchParams.set('scope', 'User.Read Files.Read Mail.Read offline_access');
} else {
  const scopeList = scopeValue.split(/\s+/).filter(Boolean);
  if (!scopeList.includes('offline_access')) {
    scopeList.push('offline_access');
    microsoftAuthUrl.searchParams.set('scope', scopeList.join(' '));
  }
}
```

The server appends the scope to the request Entra sees, but it never appears in the OAuth metadata Claude reads. Entra emits a refresh token as usual; Claude never triggers the "Maintain access to data" consent line.

## Trade-offs

- **Pro**: No behavior change visible to Claude clients — they keep requesting the tool-driven scope list. No new consent prompts. Refresh works.
- **Pro**: Tenants with lenient consent see zero regression.
- **Con**: Slight divergence from the pure-proxy ideal where the server forwards client scopes verbatim. The alternative (leaving this to the client) breaks refresh in every restrictive-consent tenant; the silent injection is the lesser evil.
- **Note**: Since `offline_access` is not in `scopes_supported`, admins pre-consenting the app in Entra must still check the `offline_access` box manually once tenant-wide (or it is granted at first user sign-in per normal OAuth flow).

## Test plan

- [x] `npm run verify` passes (lint + format + build + tests, 173/173)
- [x] Manual: `/authorize` response `Location` header contains `offline_access` in the forwarded scope
- [x] Manual: `/.well-known/oauth-authorization-server.scopes_supported` does NOT contain `offline_access`
- [x] Manual: end-to-end sign-in succeeds in a tenant with restricted user consent where #407 previously failed (validated on deployed image `lci-de8b6b5`)
- [ ] Reviewer to confirm: sign-in in a lenient-consent tenant is unchanged (no extra prompts, tokens include refresh_token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)