### PR TITLE
fix(dispatch): honor $-prefixed OData param names in execute-tool

### DIFF
--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -192,12 +192,17 @@ async function executeGraphTool(
       const camelCaseParamName = paramName.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
 
       // Look up param definition using normalized name (without $) for OData params,
-      // or camelCase equivalent for kebab-case path params
+      // or camelCase equivalent for kebab-case path params.
+      // The generated Zod client declares OData params with the `$`-prefix (e.g. `$select`);
+      // models often send the bare form (`select`) because some clients strip `$`. Without
+      // the fixedParamName fallback, the bare form silently falls out of the switch below
+      // and the query param is dropped — producing malformed Graph calls.
       const paramDef = parameterDefinitions.find(
         (p) =>
           p.name === paramName ||
           p.name === camelCaseParamName ||
-          (isOdataParam && p.name === normalizedParamName)
+          (isOdataParam && p.name === normalizedParamName) ||
+          (isOdataParam && p.name === fixedParamName)
       );
 
       if (paramDef) {


### PR DESCRIPTION
## Summary
`executeGraphTool` silently drops OData query params (`$select`, `$orderby`, `$top`, `$filter`, `$skip`, `$count`, `$search`, `$expand`) when an LLM sends them as the bare form (`select`, `orderby`, etc.). The resulting Graph call goes out without the query, so responses are unfiltered/unsorted or fail with 400.

## Root cause
The generated Zod client declares these params with the `\$` prefix. The dispatcher's param-def lookup tries three matches, none of which connect `select` → `\$select`:

\`\`\`ts
p.name === paramName                               // 'select' === '\$select' → false
p.name === camelCaseParamName                      // same     → false
(isOdataParam && p.name === normalizedParamName)   // '\$select' === 'select' → false
\`\`\`

All three fail → \`paramDef\` is undefined → the param falls out of the Path/Query/Body/Header switch → silently dropped.

## Fix
Add a fourth branch that compares against the already-computed \`fixedParamName\` (the normalized \`\$\`-prefixed form):

\`\`\`ts
(isOdataParam && p.name === fixedParamName)
\`\`\`

7-line net change. No new behavior for non-OData params. No change to existing matchers — this is purely additive.

## Repro
With discovery mode enabled:
\`\`\`json
{ \"name\": \"execute-read\", \"arguments\": { \"tool_name\": \"get-shared-calendar-view\",
  \"parameters\": { \"userId\": \"target@contoso.com\",
    \"startDateTime\": \"2026-04-25T00:00:00Z\", \"endDateTime\": \"2026-04-25T23:59:59Z\",
    \"select\": [\"subject\",\"start\",\"end\"] } } }
\`\`\`

Before: \`\$select\` stripped → full event payload returned.
After:  \`\$select\` forwarded → Graph honors projection.

## Test plan
- [ ] Call an OData-heavy tool (e.g. \`list-mail-messages\`, \`get-calendar-view\`) with \`select: [...]\` at the top level of \`parameters\` — verify the URL sent to Graph contains \`\$select=...\`
- [ ] Same call with \`\$select: [...]\` — behavior unchanged (existing path)
- [ ] Non-OData param dispatch unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)