### PR TITLE
fix(discovery): category filter excludes valid tools whose names lack domain keywords

### DIFF
--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -904,7 +904,22 @@ export function registerDiscoveryTools(
     async ({ query, category, limit = 10 }) => {
       const maxLimit = Math.min(Math.max(limit, 1), 50);
       const categoryDef = category ? TOOL_CATEGORIES[category] : undefined;
-      const categoryFilter = (name: string) => !categoryDef || categoryDef.pattern.test(name);
+      // Match category against tool name OR its Graph path OR its llmTip. Name-only
+      // matching silently dropped tools whose names don't carry a domain keyword —
+      // e.g. get-schedule / find-meeting-times both live at calendar-ish paths
+      // (/me/calendar/getSchedule, /me/findMeetingTimes) but have "schedule" /
+      // "meeting" names, so category=calendar used to exclude them.
+      const categoryFilter = (name: string) => {
+        if (!categoryDef) return true;
+        const entry = toolsRegistry.get(name);
+        if (!entry) return false;
+        const { tool, config } = entry;
+        return (
+          categoryDef.pattern.test(name) ||
+          categoryDef.pattern.test(tool.path) ||
+          (config?.llmTip ? categoryDef.pattern.test(config.llmTip) : false)
+        );
+      };
 
       let orderedNames: string[];
       if (query && query.trim().length > 0) {


### PR DESCRIPTION
## Summary
search-tools' \`categoryFilter\` compares the category regex against the tool **name** only, which silently excludes valid tools whose names don't contain the domain keyword even though their Graph path and llmTip clearly do.

Real-world impact: when a model correctly narrows its search to \`category: \"calendar\"\` for a \"find a free slot across these users\" query, both of the tools that are literally designed for that — \`get-schedule\` (/me/calendar/getSchedule, the scheduling-assistant API) and \`find-meeting-times\` (/me/findMeetingTimes, the meeting-time suggester) — get filtered out because \"schedule\" and \"meeting\" aren't in the \`calendar: /calendar|event/i\` category regex and neither word appears in the tool names. The model then either escalates search-tools again with new phrasings or gives up and tells the user it can't do it.

## Fix
Test the category pattern against tool name OR Graph path OR llmTip. Preserves the existing narrow category regexes (which remain useful for ranking) while letting cross-domain tools surface when their path or tip signal makes them relevant.

\`\`\`ts
const categoryFilter = (name: string) => {
  if (!categoryDef) return true;
  const entry = toolsRegistry.get(name);
  if (!entry) return false;
  const { tool, config } = entry;
  return (
    categoryDef.pattern.test(name) ||
    categoryDef.pattern.test(tool.path) ||
    (config?.llmTip ? categoryDef.pattern.test(config.llmTip) : false)
  );
};
\`\`\`

## Verification on current endpoints.json
- \`category: \"calendar\"\` now surfaces \`get-schedule\` and \`find-meeting-times\` (as expected)
- \`category: \"files\"\` behavior unchanged (no tools newly included/excluded under test)
- \`category: \"mail\"\`, \`\"search\"\`, \`\"tasks\"\` unchanged

## Test plan
- [ ] Call \`search-tools\` with \`query: \"find meeting times\"\` and \`category: \"calendar\"\` — verify \`find-meeting-times\` and \`get-schedule\` appear in results
- [ ] Call \`search-tools\` with \`category: \"mail\"\` — result set unchanged
- [ ] Call \`search-tools\` without a category param — behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)