### PR TITLE
fix: preserve query params in fetchAllPages pagination

### DIFF
--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -400,15 +400,14 @@ async function executeGraphTool(
         while (nextLink && pageCount < maxPages && allItems.length < maxItems) {
           logger.info(`Fetching page ${pageCount + 1} from: ${nextLink}`);
 
+          // Extract path + query string from the nextLink URL.
+          // Pass the full path (with query string) as the endpoint so that
+          // $skiptoken and other pagination params are preserved.
+          // Previously, query params were extracted into nextOptions.queryParams
+          // but graphRequest/performRequest never read that field — they were lost.
           const url = new URL(nextLink);
-          const nextPath = url.pathname.replace('/v1.0', '');
+          const nextPath = url.pathname.replace('/v1.0', '') + url.search;
           const nextOptions = { ...options };
-
-          const nextQueryParams: Record<string, string> = {};
-          for (const [key, value] of url.searchParams.entries()) {
-            nextQueryParams[key] = value;
-          }
-          nextOptions.queryParams = nextQueryParams;
 
           const nextResponse = await graphClient.graphRequest(nextPath, nextOptions);
           if (nextResponse?.content?.[0]?.text) {


### PR DESCRIPTION
## Summary
- `fetchAllPages` pagination returns duplicate first page on every iteration because `$skiptoken` and other query params from `@odata.nextLink` are silently dropped
- The pagination loop extracted query params into `nextOptions.queryParams`, but `graphRequest` → `makeRequest` → `performRequest` never reads `options.queryParams` — only the endpoint path is used
- Fix: append `url.search` to the path so query params reach the final URL

## Context
We encountered this on a personal Microsoft account (`consumers` tenant). Personal accounts don't support `$skip` on `/me/messages`, so `fetchAllPages` (following `@odata.nextLink`) is the only way to paginate. With `$skip` unsupported, the bug is immediately visible — every page returns the same 10 results.

Organizational accounts likely aren't affected in practice because `$skip` works as an alternative pagination method, so most users never need `fetchAllPages` for basic pagination.

## Reproduction
1. Use a personal Microsoft account (`consumers` tenant)
2. Call `list-mail-messages` with `fetchAllPages: true`
3. Result: all pages return the same 10 emails (1000 duplicates across 100 pages)

## Test
After fix: 1000 unique emails returned, spanning from current day back 2+ weeks.

## Note
The relevant commit is `fix: preserve query params in fetchAllPages pagination`. The `chore: set version` commit is fork-specific and can be ignored — cherry-pick just the fix.