### PR TITLE
fix: normalize keytar ESM/CJS interop so token persistence works on Node 24+

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -16,7 +16,14 @@ async function getKeytar() {
   }
   if (keytar === null) {
     try {
-      keytar = await import('keytar');
+      // Normalize ESM/CJS interop: under Node 24+ `await import('keytar')` returns a
+      // namespace object whose top-level `setPassword` is undefined (functions live on
+      // `.default`). On older Node and pure CJS, methods live on the namespace itself.
+      // Falling back to the namespace keeps backward compatibility. See issue #418.
+      const mod = (await import('keytar')) as typeof import('keytar') & {
+        default?: typeof import('keytar');
+      };
+      keytar = mod.default ?? mod;
       return keytar;
     } catch (error) {
       logger.info('keytar not available, using file-based credential storage');


### PR DESCRIPTION
## Summary

Closes #418.

`dist/auth.js` (and its source in `src/auth.ts:19`) imports keytar with
`keytar = await import('keytar')` and then calls `kt.setPassword(...)` directly.
Under Node 24+ that namespace object's top-level `setPassword` is `undefined` —
the actual functions live on `.default`. As a result every save throws
\`kt.setPassword is not a function\`, silently falls back to file storage, and
on systems where the keychain *is* reachable tokens never get persisted there.
For users running through `npx` on Node 24+ this manifests as **having to re-login
every session** even though logging in succeeds and the file fallback may or may
not survive depending on environment.

This PR normalizes the import so we always pick the real module shape:

\`\`\`ts
const mod = (await import('keytar')) as typeof import('keytar') & {
  default?: typeof import('keytar');
};
keytar = mod.default ?? mod;
\`\`\`

`mod.default ?? mod` keeps backward compatibility with older Node versions
and pure-CJS bundlers where methods sit on the namespace itself.

## Reproduction (independent confirmation of #418 on macOS / Node 25)

The original report (#418) was on Linux Node 24.15.0. I hit the same bug on
**macOS 15 / Node v25.8.1** with `@softeria/ms-365-mcp-server@0.87.0` —
confirming it is not Linux- or libsecret-specific.

\`\`\`bash
$ node --version
v25.8.1

$ cd node_modules/@softeria/ms-365-mcp-server
$ node --input-type=module -e "
const m = await import('keytar');
console.log('top setPassword:', typeof m.setPassword);
console.log('top getPassword:', typeof m.getPassword);
console.log('m.default:', typeof m.default);
console.log('m.default.setPassword:', typeof m.default?.setPassword);
console.log('keys:', Object.keys(m));
"
top setPassword: undefined          ← what the current code calls (throws)
top getPassword: function           ← partial-export, misleadingly works
m.default: object
m.default.setPassword: function     ← the real function
keys: [ 'default', 'getPassword', 'module.exports' ]
\`\`\`

After the patch, the same module exposes \`setPassword\`/\`getPassword\`/\`deletePassword\`
as functions and a real round-trip write/read/delete against the macOS Keychain
succeeds.

## Behavior change

- ✅ Node 24+ (and Node 25): keychain persistence now works as intended; users
  no longer hit \"Keychain save failed, falling back to file storage\" on every
  login.
- ✅ Older Node / CJS contexts: unchanged — \`mod.default\` is undefined there
  so the \`?? mod\` branch keeps the previous behavior.
- ✅ Environments without keytar installed (alpine etc.): unchanged — the
  outer \`try/catch\` still routes to file-only storage.

## Tests

- \`npm run generate && npm test\` → **173 passed (25 files)** locally on Node v25.8.1.
- \`npm run lint\` → no new warnings; only pre-existing ones.
- \`npx prettier --check src/auth.ts\` → clean.

## Related

- Fixes #418 (\"keytar ESM import breaks token persistence on Node 24\")
- Likely root cause for repeated-login symptom in #287, #298 (closed but
  similar shape)