### PR TITLE
feat: add Excel range write endpoints (PATCH range, insert/delete, table-row update/delete, create-table)

### DIFF
--- a/bin/modules/simplified-openapi.mjs
+++ b/bin/modules/simplified-openapi.mjs
@@ -14,6 +14,46 @@ export function createAndSaveSimplifiedOpenAPI(endpointsFile, openapiFile, opena
     }
   }
 
+  // Synthesize operations that the Graph REST API supports but are missing from
+  // Microsoft's published OpenAPI metadata (e.g. PATCH on range(address='{address}')
+  // for cell-value writes — documented in Excel API but not in the OpenAPI spec).
+  for (const endpoint of endpoints) {
+    const pathSpec = openApiSpec.paths[endpoint.pathPattern];
+    const methodLower = endpoint.method.toLowerCase();
+    if (pathSpec && !pathSpec[methodLower]) {
+      pathSpec[methodLower] = {
+        tags: ['drives.driveItem'],
+        summary: endpoint.llmTip || `${endpoint.toolName} (synthesized)`,
+        description: endpoint.llmTip || `${endpoint.toolName} (synthesized)`,
+        operationId: endpoint.toolName,
+        requestBody:
+          methodLower === 'get' || methodLower === 'delete'
+            ? undefined
+            : {
+                description: 'Operation payload',
+                required: true,
+                content: {
+                  'application/json': {
+                    schema: { type: 'object', additionalProperties: true },
+                  },
+                },
+              },
+        responses: {
+          '2XX': {
+            description: 'Success',
+            content: {
+              'application/json': {
+                schema: { type: 'object', additionalProperties: true },
+              },
+            },
+          },
+          '4XX': { $ref: '#/components/responses/error' },
+          '5XX': { $ref: '#/components/responses/error' },
+        },
+      };
+    }
+  }
+
   for (const [key, value] of Object.entries(openApiSpec.paths)) {
     const e = endpoints.filter((ep) => ep.pathPattern === key);
     if (e.length === 0) {

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -557,6 +557,59 @@
     "skipEncoding": ["address"]
   },
   {
+    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/workbook/worksheets/{workbookWorksheet-id}/range(address='{address}')",
+    "method": "patch",
+    "toolName": "update-excel-range",
+    "isExcelOp": true,
+    "scopes": ["Files.ReadWrite"],
+    "skipEncoding": ["address"],
+    "llmTip": "Set cell values, formulas, or number format on any range — does NOT require the worksheet to be a formal Excel table. Body: { values: [['v1','v2','v3']] } for a single row, or [['a','b'],['c','d']] for multi-row. Use this for append (target the next empty row's address, e.g. 'A172:H172'), update (target a single cell like 'H42'), or prepend-style edits (read existing, concatenate, write back). Number of inner-array values must match the column count of the address."
+  },
+  {
+    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/workbook/worksheets/{workbookWorksheet-id}/range(address='{address}')/insert",
+    "method": "post",
+    "toolName": "insert-excel-range",
+    "isExcelOp": true,
+    "scopes": ["Files.ReadWrite"],
+    "skipEncoding": ["address"],
+    "llmTip": "Insert blank cells at the given range, shifting existing content. Body: { shift: 'Down' } or { shift: 'Right' }. Use 'Down' to insert blank rows above existing data."
+  },
+  {
+    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/workbook/worksheets/{workbookWorksheet-id}/range(address='{address}')/delete",
+    "method": "post",
+    "toolName": "delete-excel-range",
+    "isExcelOp": true,
+    "scopes": ["Files.ReadWrite"],
+    "skipEncoding": ["address"],
+    "llmTip": "Delete cells at the given range, shifting remaining content. Body: { shift: 'Up' } or { shift: 'Left' }. Use 'Up' to delete entire rows."
+  },
+  {
+    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/workbook/tables/{workbookTable-id}/rows/itemAt(index={index})",
+    "method": "patch",
+    "toolName": "update-excel-table-row",
+    "isExcelOp": true,
+    "scopes": ["Files.ReadWrite"],
+    "skipEncoding": ["index"],
+    "llmTip": "Update a single row in a formal Excel table by zero-based row index. Body: { values: [[...]] } with one inner array matching the column count."
+  },
+  {
+    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/workbook/tables/{workbookTable-id}/rows/itemAt(index={index})",
+    "method": "delete",
+    "toolName": "delete-excel-table-row",
+    "isExcelOp": true,
+    "scopes": ["Files.ReadWrite"],
+    "skipEncoding": ["index"],
+    "llmTip": "Delete a single row from a formal Excel table by zero-based row index."
+  },
+  {
+    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/workbook/worksheets/{workbookWorksheet-id}/tables/add",
+    "method": "post",
+    "toolName": "create-excel-table",
+    "isExcelOp": true,
+    "scopes": ["Files.ReadWrite"],
+    "llmTip": "Convert a worksheet range into a formal Excel table. Body: { address: 'A1:H171', hasHeaders: true }. Required before using add-excel-table-rows / update-excel-table-row / delete-excel-table-row on a plain-cells sheet."
+  },
+  {
     "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/workbook/worksheets",
     "method": "get",
     "toolName": "list-excel-worksheets",


### PR DESCRIPTION
## Summary

Adds six Excel write tools that the underlying Microsoft Graph REST API supports but were not exposed by the MCP. The most useful is **`update-excel-range`** — `PATCH /workbook/worksheets/{id}/range(address='X')` — which lets the model write cell values to any worksheet **without first converting it to a formal Excel table**. Currently a hard limitation: the only existing write path (`add-excel-table-rows`) requires a `workbookTableId`, so any plain-cells worksheet is effectively read-only through the MCP.

## New tools

| Tool | Method + Path | Purpose |
|---|---|---|
| `update-excel-range` | `PATCH .../range(address='{address}')` | Set cell values/formulas/format on any range. Body: `{ "values": [["v1","v2"]] }`. Covers append, update, and prepend-style edits. |
| `insert-excel-range` | `POST .../range(address='{address}')/insert` | Insert blank cells, shifting existing content. Body: `{ "shift": "Down" }`. |
| `delete-excel-range` | `POST .../range(address='{address}')/delete` | Delete cells, shifting remaining content. Body: `{ "shift": "Up" }`. |
| `update-excel-table-row` | `PATCH /workbook/tables/{id}/rows/itemAt(index={index})` | Update a single row in a formal table by zero-based index. |
| `delete-excel-table-row` | `DELETE /workbook/tables/{id}/rows/itemAt(index={index})` | Delete a single row from a formal table. |
| `create-excel-table` | `POST /workbook/worksheets/{id}/tables/add` | Convert a worksheet range into a formal table. Body: `{ "address": "A1:H171", "hasHeaders": true }`. |

## Why a synthesizer was needed

Microsoft's published OpenAPI metadata only declares **GET** on `range(address='{address}')`, even though the Graph REST API accepts **PATCH** there ([range: update](https://learn.microsoft.com/en-us/graph/api/range-update)). The trim step in `simplified-openapi.mjs` silently drops `endpoints.json` entries whose method isn't present in the upstream spec at the same path.

To unblock these (and future cases where the Graph spec lags the actual REST surface), `simplified-openapi.mjs` now synthesizes a minimal OpenAPI operation block — generic `application/json` body with `additionalProperties: true`, generic `2XX` response — for any endpoint listed in `endpoints.json` whose method is missing from the upstream spec at its declared path. Existing operations are untouched.

## Verification

Smoke-tested against a real OneDrive workbook:
- `update-excel-range` writes values to arbitrary cells, including appending a new row past the existing data range, on a plain-cells worksheet (no table). Round-trip read confirms the write.
- `insert-excel-range` and `delete-excel-range` shift content as expected.
- `create-excel-table` registers a new table that subsequent `add-excel-table-rows` calls can target.

## Test plan

- [ ] CI build passes (regenerate client + lint + test)
- [ ] `update-excel-range` writes values to a plain-cells worksheet
- [ ] `insert-excel-range` / `delete-excel-range` shift content correctly
- [ ] `create-excel-table` followed by `add-excel-table-rows` works on a previously-plain sheet
- [ ] `update-excel-table-row` / `delete-excel-table-row` modify the correct rows by index
