### PR TITLE
feat: OneDrive sharing-link, copy, and preview action endpoints

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -499,6 +499,27 @@
     "llmTip": "Shares a file or folder with specific users. Body: { recipients: [{ email: 'user@example.com' }], roles: ['read'], sendInvitation: true, message: 'Please review this file.' }. Roles: 'read', 'write', 'owner'. Set requireSignIn to true to require authentication."
   },
   {
+    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/createLink",
+    "method": "post",
+    "toolName": "create-drive-item-share-link",
+    "scopes": ["Files.ReadWrite"],
+    "llmTip": "Create a shareable link for a file or folder WITHOUT sending an email invitation. Body: { type: 'view' | 'edit' | 'embed', scope: 'anonymous' | 'organization' | 'users', password?: string, expirationDateTime?: ISO-8601, retainInheritedPermissions?: boolean }. Returns a permission with link.webUrl. Pair with share-drive-item when you want to grant explicit access; use this when you only need a URL to paste into a doc/email/chat without triggering OneDrive notifications."
+  },
+  {
+    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/copy",
+    "method": "post",
+    "toolName": "copy-drive-item",
+    "scopes": ["Files.ReadWrite"],
+    "llmTip": "Asynchronously copy a file or folder to a new location and/or name. Body: { parentReference: { driveId: '...', id: '...' }, name?: 'New Name.xlsx' }. Returns 202 Accepted with a Location header pointing at a monitor URL for the async job. Ideal for duplicating templates (e.g. clone an Armhr Census Template per prospect), bulk file provisioning, or preserving an immutable snapshot of a working file."
+  },
+  {
+    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/preview",
+    "method": "post",
+    "toolName": "create-drive-item-preview",
+    "scopes": ["Files.Read"],
+    "llmTip": "Generate a short-lived embeddable preview URL for a file (Office docs, PDFs, images). Body: { page?: number | string, zoom?: number, viewer?: 'onedrive' | 'office' }. Returns getUrl (interactive) and postUrl (form-post). Useful for surfacing inline previews in summary emails or chat messages without needing the recipient to open the file."
+  },
+  {
     "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/permissions",
     "method": "get",
     "toolName": "list-drive-item-permissions",


### PR DESCRIPTION
## Summary

Follow-up to #423 in the same vein — adding Graph drive-item *action* endpoints that round out the OneDrive surface for programmatic workflows. Each fills a real gap that previously required workarounds (download-and-reupload for copies, share-with-invite for link generation, etc.).

### What's in this PR

- **`create-drive-item-share-link`** — POST `/drives/{id}/items/{id}/createLink`. Generates a shareable link (`view` / `edit` / `embed`; `anonymous` / `organization` / `users` scope) **without** sending an email invitation. Complements the existing `share-drive-item` (which uses `/invite` and triggers a OneDrive notification email). Use this when you only need a URL to paste into a doc, email, or chat — common for programmatic flows where the caller controls the messaging.

- **`copy-drive-item`** — POST `/drives/{id}/items/{id}/copy`. Asynchronously copy a file or folder to a new location and/or name via Graph's server-side copy. Returns `202 Accepted` + `Location` header pointing at a monitor URL for the async job. Ideal for duplicating templates (e.g. clone a master census xlsx per prospect), bulk provisioning, or capturing an immutable snapshot of a working file. Avoids the download-then-reupload workaround.

- **`create-drive-item-preview`** — POST `/drives/{id}/items/{id}/preview`. Generates a short-lived embeddable preview URL for Office docs, PDFs, and images. Body `{ page?, zoom?, viewer? }`. Returns `getUrl` (interactive) and `postUrl` (form-post). Useful for inline file previews in summary emails or chat messages without forcing the recipient to open the file.

### How they combine

- **Templated provisioning**: `copy-drive-item` to clone a master Excel template into a per-client folder, then `update-excel-range` (#423) and `format-excel-range` (#424) to populate it.
- **Notification-free sharing**: `create-drive-item-share-link` to mint a URL, then attach it to a separately-composed email via the existing `send-mail` tool — useful when the OneDrive default invite email is too noisy or the caller wants full control over recipients and messaging.
- **Inline previews**: `create-drive-item-preview` to embed a quick visual in a status report without forcing recipients to download.

## Test plan

- [x] `npm run generate` — clean regeneration
- [x] `npm run build` — success; all 3 new endpoints surface in `dist/generated/client.js`
- [x] `npm test` — 173/173 passing
- [ ] Manual smoke test against a live drive (covered locally)