### PR TITLE
fix: scope outlook.body-content-type Prefer header to GET requests

### DIFF
--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -525,4 +525,61 @@ describe('graph-tools', () => {
       expect(tool!.schema['timezone']).toBeUndefined();
     });
   });
+
+  // ---- 7. outlook.body-content-type Prefer header ----
+  describe('outlook.body-content-type Prefer header', () => {
+    it('should set Prefer: outlook.body-content-type="text" on GET requests', async () => {
+      const endpoint = makeEndpoint({ method: 'get' });
+      const config = makeConfig({ method: 'get' });
+      mockEndpoints.push(endpoint);
+      mockEndpointsJson = [config];
+
+      const graphClient = createMockGraphClient([
+        { content: [{ type: 'text', text: JSON.stringify({ value: [] }) }] },
+      ]);
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      await server.tools.get('test-tool')!.handler({});
+
+      const [, options] = graphClient.graphRequest.mock.calls[0];
+      expect(options.headers['Prefer']).toContain('outlook.body-content-type="text"');
+    });
+
+    it('should NOT set Prefer: outlook.body-content-type on POST requests', async () => {
+      const endpoint = makeEndpoint({
+        alias: 'create-reply-draft',
+        method: 'post',
+        path: '/me/messages/:messageId/createReply',
+        parameters: [
+          { name: 'messageId', type: 'Path', schema: z.string() },
+          { name: 'body', type: 'Body', schema: z.any() },
+        ],
+      });
+      const config = makeConfig({
+        toolName: 'create-reply-draft',
+        method: 'post',
+        pathPattern: '/me/messages/{message-id}/createReply',
+      });
+      mockEndpoints.push(endpoint);
+      mockEndpointsJson = [config];
+
+      const graphClient = createMockGraphClient([{ content: [{ type: 'text', text: '{}' }] }]);
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      await server.tools.get('create-reply-draft')!.handler({
+        messageId: 'AAMk123',
+        body: { Message: { body: { contentType: 'html', content: '<p>hi</p>' } } },
+      });
+
+      const [, options] = graphClient.graphRequest.mock.calls[0];
+      const prefer = options.headers['Prefer'];
+      expect(prefer === undefined || !prefer.includes('outlook.body-content-type')).toBe(true);
+    });
+  });
 });

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -190,13 +190,15 @@
     "pathPattern": "/me/messages/{message-id}/createReply",
     "method": "post",
     "toolName": "create-reply-draft",
-    "scopes": ["Mail.ReadWrite"]
+    "scopes": ["Mail.ReadWrite"],
+    "llmTip": "For HTML replies pass Message.body.contentType: 'html' with Message.body.content as HTML. Note: supplying Message.body replaces the whole draft body, so the original quoted history is not included. Specifying both 'comment' and Message.body returns 400. Signatures are added by the Outlook client only, not via Graph."
   },
   {
     "pathPattern": "/me/messages/{message-id}/createReplyAll",
     "method": "post",
     "toolName": "create-reply-all-draft",
-    "scopes": ["Mail.ReadWrite"]
+    "scopes": ["Mail.ReadWrite"],
+    "llmTip": "For HTML replies pass Message.body.contentType: 'html' with Message.body.content as HTML. Note: supplying Message.body replaces the whole draft body, so the original quoted history is not included. Specifying both 'comment' and Message.body returns 400. Signatures are added by the Outlook client only, not via Graph."
   },
   {
     "pathPattern": "/me/messages/{message-id}/send",

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -287,7 +287,7 @@ async function executeGraphTool(
     }
 
     const bodyFormat = process.env.MS365_MCP_BODY_FORMAT || 'text';
-    if (bodyFormat !== 'html') {
+    if (bodyFormat !== 'html' && tool.method.toUpperCase() === 'GET') {
       preferValues.push(`outlook.body-content-type="${bodyFormat}"`);
     }
 


### PR DESCRIPTION
The header was added in #255 to shrink mail GET responses (#254), but it was applied to every method. On POST createReply/createReplyAll this made the response echo body content as text even when the draft was stored as HTML, leading users to think HTML replies weren't supported. Restrict to GET and add an llmTip on the two reply-draft endpoints documenting HTML usage. Refs #408.