### PR TITLE
feat: add list-drive-item-thumbnails endpoint

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -522,6 +522,13 @@
     "llmTip": "Generate a short-lived embeddable preview URL for a file (Office docs, PDFs, images). Body: { page?: number | string, zoom?: number, viewer?: 'onedrive' | 'office' }. Returns getUrl (interactive) and postUrl (form-post). Useful for surfacing inline previews in summary emails or chat messages without needing the recipient to open the file."
   },
   {
+    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/thumbnails",
+    "method": "get",
+    "toolName": "list-drive-item-thumbnails",
+    "scopes": ["Files.Read"],
+    "llmTip": "Lists thumbnail sets for a file. Each set contains small (96px), medium (176px), large (800px) thumbnails with url and dimensions. Returns empty for unsupported types (text docs). Use $select=small,medium,large or $expand=small($select=url) to fetch specific sizes. The returned URLs are short-lived — fetch the bytes immediately."
+  },
+  {
     "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/permissions",
     "method": "get",
     "toolName": "list-drive-item-permissions",


### PR DESCRIPTION
## Summary
- Adds `GET /drives/{id}/items/{id}/thumbnails` to retrieve thumbnail sets (small/medium/large) for files
- Returns short-lived image URLs ideal for inline previews, file pickers, or thumbnail grids
- Complements the recently merged `create-drive-item-preview` (#425): preview returns an embeddable iframe URL for the full doc; thumbnails return plain image URLs for lightweight UIs

## Context
This PR replaces my earlier #395 (drive copy/preview/thumbnails), which had two endpoints (`copy-drive-item`, `get-drive-item-preview`) that became redundant when #425 was merged. I'm closing #395 in favor of this scoped-down version. The third endpoint (`list-drive-item-thumbnails`) remains unique and is what's submitted here.

## Permission
`Files.Read` (already used across drive endpoints).

## Verification
- `endpoints-validation.test.ts`: passing
- JSON valid, endpoint surfaces in `client.js` build