### PR TITLE
feat: add OAuth 2.0 On-Behalf-Of (OBO) flow for HTTP mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "js-yaml": "^4.1.0",
         "open": "^11.0.0",
         "winston": "^3.17.0",
-        "zod": "^3.24.2"
+        "zod": "^3.24.2",
+        "zod-to-json-schema": "^3.25.1"
       },
       "bin": {
         "ms-365-mcp-server": "dist/index.js"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,6 +66,10 @@ program
     '--public-url <url>',
     'Public base URL (e.g. https://mcp.example.com) used in browser-facing OAuth redirects when running behind a reverse proxy. Server-to-server endpoints (token, register) stay on the request host.'
   )
+  .option(
+    '--obo',
+    'Enable On-Behalf-Of token exchange in HTTP mode. Exchanges the incoming bearer token for a Graph API token using the OBO flow. Requires MS365_MCP_CLIENT_SECRET.'
+  )
   .addOption(
     // DEPRECATED: kept only so existing deployments that set --base-url or
     // MS365_MCP_BASE_URL do not crash at startup. Use --public-url /
@@ -97,6 +101,7 @@ export interface CommandOptions {
   enableDynamicRegistration?: boolean;
   dynamicRegistration?: boolean;
   authBrowser?: boolean;
+  obo?: boolean;
   publicUrl?: string;
   /** @deprecated use publicUrl */
   baseUrl?: string;
@@ -180,6 +185,10 @@ export function parseArgs(): CommandOptions {
     } else {
       options.enableDynamicRegistration = true;
     }
+  }
+
+  if (process.env.MS365_MCP_OBO === 'true' || process.env.MS365_MCP_OBO === '1') {
+    options.obo = true;
   }
 
   // Handle cloud type - CLI option takes precedence over environment variable

--- a/src/obo-client.ts
+++ b/src/obo-client.ts
@@ -1,0 +1,51 @@
+import { ConfidentialClientApplication } from '@azure/msal-node';
+import logger from './logger.js';
+import type { AppSecrets } from './secrets.js';
+import { getCloudEndpoints } from './cloud-config.js';
+
+class OboClient {
+  private cca: ConfidentialClientApplication;
+  private graphScopes: string[];
+
+  constructor(secrets: AppSecrets, graphScopes: string[]) {
+    if (!secrets.clientSecret) {
+      throw new Error(
+        'On-Behalf-Of flow requires MS365_MCP_CLIENT_SECRET to be set (confidential client).'
+      );
+    }
+
+    const cloudEndpoints = getCloudEndpoints(secrets.cloudType);
+
+    this.cca = new ConfidentialClientApplication({
+      auth: {
+        clientId: secrets.clientId,
+        clientSecret: secrets.clientSecret,
+        authority: `${cloudEndpoints.authority}/${secrets.tenantId || 'common'}`,
+      },
+    });
+
+    const graphBase = cloudEndpoints.graphApi.replace(/\/$/, '');
+    this.graphScopes = [`${graphBase}/.default`];
+  }
+
+  async exchangeToken(userAssertion: string): Promise<string> {
+    try {
+      const result = await this.cca.acquireTokenOnBehalfOf({
+        oboAssertion: userAssertion,
+        scopes: this.graphScopes,
+      });
+
+      if (!result?.accessToken) {
+        throw new Error('OBO token exchange returned no access token');
+      }
+
+      logger.info('OBO token exchange successful');
+      return result.accessToken;
+    } catch (error) {
+      logger.error(`OBO token exchange failed: ${(error as Error).message}`);
+      throw error;
+    }
+  }
+}
+
+export default OboClient;

--- a/src/obo-client.ts
+++ b/src/obo-client.ts
@@ -7,7 +7,7 @@ class OboClient {
   private cca: ConfidentialClientApplication;
   private graphScopes: string[];
 
-  constructor(secrets: AppSecrets, graphScopes: string[]) {
+  constructor(secrets: AppSecrets) {
     if (!secrets.clientSecret) {
       throw new Error(
         'On-Behalf-Of flow requires MS365_MCP_CLIENT_SECRET to be set (confidential client).'

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import { getSecrets, type AppSecrets } from './secrets.js';
 import { getCloudEndpoints } from './cloud-config.js';
 import { requestContext } from './request-context.js';
 import crypto from 'node:crypto';
+import OboClient from './obo-client.js';
 
 /**
  * Parse HTTP option into host and port components.
@@ -53,6 +54,7 @@ class MicrosoftGraphServer {
   private graphClient: GraphClient | null;
   private server: McpServer | null;
   private secrets: AppSecrets | null;
+  private oboClient: OboClient | null;
   private version: string = '0.0.0';
   private multiAccount: boolean = false;
   private accountNames: string[] = [];
@@ -74,6 +76,7 @@ class MicrosoftGraphServer {
     this.graphClient = null; // Initialized in start() after secrets are loaded
     this.server = null;
     this.secrets = null;
+    this.oboClient = null;
   }
 
   private createMcpServer(): McpServer {
@@ -138,6 +141,20 @@ class MicrosoftGraphServer {
       }
     } catch (err) {
       logger.warn(`Failed to detect multi-account mode: ${(err as Error).message}`);
+    }
+
+    if (this.options.obo) {
+      if (!this.options.http) {
+        throw new Error('--obo requires --http (On-Behalf-Of flow only works in HTTP mode).');
+      }
+      if (!this.secrets.clientSecret) {
+        throw new Error(
+          '--obo requires MS365_MCP_CLIENT_SECRET to be set (confidential client required for On-Behalf-Of flow).'
+        );
+      }
+      const graphScopes = buildScopesFromEndpoints(this.options.orgMode, this.options.enabledTools);
+      this.oboClient = new OboClient(this.secrets, graphScopes);
+      logger.info('On-Behalf-Of (OBO) flow enabled');
     }
 
     const outputFormat = this.options.toon ? 'toon' : 'json';
@@ -261,7 +278,9 @@ class MicrosoftGraphServer {
         const requestOrigin = `${protocol}://${req.get('host')}`;
         const browserBase = publicBase ?? requestOrigin;
 
-        const scopes = buildScopesFromEndpoints(this.options.orgMode, this.options.enabledTools);
+        const scopes = this.options.obo
+          ? [`api://${this.secrets!.clientId}/access_as_user`]
+          : buildScopesFromEndpoints(this.options.orgMode, this.options.enabledTools);
 
         res.json({
           resource: `${requestOrigin}/mcp`,
@@ -540,7 +559,11 @@ class MicrosoftGraphServer {
 
           try {
             if (req.microsoftAuth) {
-              await requestContext.run({ accessToken: req.microsoftAuth.accessToken }, handler);
+              let accessToken = req.microsoftAuth.accessToken;
+              if (this.oboClient) {
+                accessToken = await this.oboClient.exchangeToken(accessToken);
+              }
+              await requestContext.run({ accessToken }, handler);
             } else {
               await handler();
             }
@@ -581,7 +604,11 @@ class MicrosoftGraphServer {
 
           try {
             if (req.microsoftAuth) {
-              await requestContext.run({ accessToken: req.microsoftAuth.accessToken }, handler);
+              let accessToken = req.microsoftAuth.accessToken;
+              if (this.oboClient) {
+                accessToken = await this.oboClient.exchangeToken(accessToken);
+              }
+              await requestContext.run({ accessToken }, handler);
             } else {
               await handler();
             }

--- a/src/server.ts
+++ b/src/server.ts
@@ -152,8 +152,7 @@ class MicrosoftGraphServer {
           '--obo requires MS365_MCP_CLIENT_SECRET to be set (confidential client required for On-Behalf-Of flow).'
         );
       }
-      const graphScopes = buildScopesFromEndpoints(this.options.orgMode, this.options.enabledTools);
-      this.oboClient = new OboClient(this.secrets, graphScopes);
+      this.oboClient = new OboClient(this.secrets);
       logger.info('On-Behalf-Of (OBO) flow enabled');
     }
 


### PR DESCRIPTION
## Summary

Adds support for the OAuth 2.0 On-Behalf-Of (OBO) flow, enabling the server to act as a middle-tier API in Entra ID. When `--obo` is enabled, clients authenticate to the MCP server's own app registration (via an exposed API scope), and the server exchanges the incoming user token for a downstream Microsoft Graph token on each request.

This mirrors the pattern used by Microsoft's `Microsoft.Identity.Web` library and unlocks certain scenarios such as:

User signs into LLM-enabled App A -> App A calls the MS 365 MCP Server with the user's token (scoped to the server's `access_as_user`) -> the server exchanges that token via OBO for a Graph API token and calls Graph as the user.

Each hop reuses the original user identity without prompting for reauthentication.

This makes the end-user experience much better when using apps which integrate with this project.

## Changes

- **New `--obo` CLI flag** (also `MS365_MCP_OBO=true`) — enables OBO exchange in HTTP mode
- **New `src/obo-client.ts`** — wraps MSAL Node's `ConfidentialClientApplication.acquireTokenOnBehalfOf()`
- **`src/server.ts`** — intercepts the `/mcp` GET/POST handlers, exchanges the bearer token before it reaches `requestContext`, and advertises `api://<clientId>/access_as_user` in `/.well-known/oauth-protected-resource` metadata when OBO is active
- **Startup validation** — `--obo` requires `--http` and `MS365_MCP_CLIENT_SECRET`; the server fails fast with a clear error otherwise
- **Scope strategy** — requests `https://graph.microsoft.com/.default` to receive a token containing all admin-consented Graph permissions, avoiding per-scope interactive consent requirements inherent to OBO

Non-OBO auth paths (device code, interactive browser, authorization code proxy) are unchanged.

## Test plan

### Entra ID setup (one-time)

**Server app registration** (used by MS 365 MCP Server)
- [ ] Create a confidential client app registration
- [ ] Under **Expose an API**, set the Application ID URI to `api://<server-client-id>` and add a scope named `access_as_user`
- [ ] Under **API permissions**, add the Microsoft Graph delegated permissions the server needs (e.g. `User.Read`, `Files.Read`, `Mail.Read`, etc.) and grant admin consent
- [ ] Under **Certificates & secrets**, create a client secret

**Client app registration** (used by the calling application)
- [ ] Create a separate app registration (public or confidential, depending on your client)
- [ ] Under **API permissions**, add the server app's `access_as_user` scope (via "My APIs" → select the server app) and grant admin consent
- [ ] On the **server** app registration, under **Expose an API → Authorized client applications**, add the client app's client ID and authorize it for the `access_as_user` scope (this
pre-authorizes the client so users aren't prompted to consent to the server API)

### Server environment

- [ ] Set `MS365_MCP_CLIENT_ID` to the **server** app's client ID
- [ ] Set `MS365_MCP_CLIENT_SECRET` to the server app's client secret
- [ ] Set `MS365_MCP_TENANT_ID` to your tenant ID

### Functional tests

- [ ] `npm run build` succeeds
- [ ] Start server: `npm run dev:http -- --obo -v`
- [ ] Verify startup logs `On-Behalf-Of (OBO) flow enabled`
- [ ] Acquire a user token for `api://<server-client-id>/access_as_user` using the **client** app registration (e.g. via auth code flow, MSAL, or a tool like the MCP Inspector)
- [ ] Call `POST /mcp` with that token in the `Authorization: Bearer` header and invoke a tool (e.g. `list-drives`) — verify the Graph call succeeds with the OBO-exchanged token
- [ ] Verify `GET /.well-known/oauth-protected-resource` advertises `api://<server-client-id>/access_as_user` in `scopes_supported`

### Negative tests

- [ ] Start with `--obo` but no `--http` → server fails fast with a clear error
- [ ] Start with `--obo` and `--http` but no `MS365_MCP_CLIENT_SECRET` → server fails fast with a clear error
- [ ] Start **without** `--obo` and verify the existing pass-through HTTP auth path still works (regression check)