### PR TITLE
feat: replace per-entity file downloads with generic download-bytes

### DIFF
--- a/bin/modules/generate-mcp-tools.mjs
+++ b/bin/modules/generate-mcp-tools.mjs
@@ -51,6 +51,13 @@ export function generateMcpTools(openApiSpec, outputDir) {
     // Replace with: path: `/...range(param=':value')...`,
     clientCode = clientCode.replace(/(path:\s*)'(\/[^']*\([^)]*=':[\w]+'\)[^']*)'/g, '$1`$2`');
 
+    // openapi-zod-client emits z.instanceof(File) for `format: binary` bodies; MCP
+    // transports JSON so no caller produces File. Body marshaller decodes the string.
+    clientCode = clientCode.replace(
+      /z\.instanceof\(File\)/g,
+      "z.string().describe('Base64-encoded file content. The server decodes it and PUTs the raw bytes to Microsoft Graph.')"
+    );
+
     fs.writeFileSync(clientFilePath, clientCode);
 
     return true;

--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -582,4 +582,250 @@ describe('graph-tools', () => {
       expect(prefer === undefined || !prefer.includes('outlook.body-content-type')).toBe(true);
     });
   });
+
+  // ---- 8. Binary upload (requestFormat: 'binary') ----
+  describe('binary upload bodies', () => {
+    it('decodes base64 body to bytes and sets octet-stream Content-Type', async () => {
+      const endpoint = makeEndpoint({
+        alias: 'upload-file-content',
+        method: 'put',
+        path: '/drives/:driveId/items/:driveItemId/content',
+        requestFormat: 'binary' as const,
+        parameters: [
+          { name: 'driveId', type: 'Path', schema: z.string() },
+          { name: 'driveItemId', type: 'Path', schema: z.string() },
+          {
+            name: 'body',
+            type: 'Body',
+            schema: z.string().describe('Base64-encoded file content'),
+          },
+        ],
+      });
+      const config = makeConfig({
+        toolName: 'upload-file-content',
+        method: 'put',
+        pathPattern: '/drives/{drive-id}/items/{driveItem-id}/content',
+        scopes: ['Files.ReadWrite'],
+      });
+      mockEndpoints.push(endpoint);
+      mockEndpointsJson = [config];
+
+      const graphClient = createMockGraphClient([{ content: [{ type: 'text', text: '{}' }] }]);
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const original = 'Hello, world!';
+      const base64 = Buffer.from(original, 'utf-8').toString('base64');
+
+      await server.tools.get('upload-file-content')!.handler({
+        driveId: 'drive123',
+        driveItemId: 'item456',
+        body: base64,
+      });
+
+      const [path, options] = graphClient.graphRequest.mock.calls[0];
+      expect(path).toBe('/drives/drive123/items/item456/content');
+      expect(options.headers['Content-Type']).toBe('application/octet-stream');
+      expect(Buffer.isBuffer(options.body) || options.body instanceof Uint8Array).toBe(true);
+      expect(Buffer.from(options.body).toString('utf-8')).toBe(original);
+    });
+
+    it('honors endpoints.json contentType override on binary uploads', async () => {
+      const endpoint = makeEndpoint({
+        alias: 'upload-file-content',
+        method: 'put',
+        path: '/drives/:driveId/items/:driveItemId/content',
+        requestFormat: 'binary' as const,
+        parameters: [
+          { name: 'driveId', type: 'Path', schema: z.string() },
+          { name: 'driveItemId', type: 'Path', schema: z.string() },
+          { name: 'body', type: 'Body', schema: z.string() },
+        ],
+      });
+      const config = makeConfig({
+        toolName: 'upload-file-content',
+        method: 'put',
+        pathPattern: '/drives/{drive-id}/items/{driveItem-id}/content',
+        scopes: ['Files.ReadWrite'],
+        contentType: 'application/pdf',
+      });
+      mockEndpoints.push(endpoint);
+      mockEndpointsJson = [config];
+
+      const graphClient = createMockGraphClient([{ content: [{ type: 'text', text: '{}' }] }]);
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      await server.tools.get('upload-file-content')!.handler({
+        driveId: 'd',
+        driveItemId: 'i',
+        body: Buffer.from('%PDF-1.4').toString('base64'),
+      });
+
+      const [, options] = graphClient.graphRequest.mock.calls[0];
+      expect(options.headers['Content-Type']).toBe('application/pdf');
+    });
+  });
+
+  // ---- 9. download-bytes utility tool ----
+  describe('download-bytes', () => {
+    it('routes a relative Graph path through graphRequest', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = {
+        graphRequest: vi.fn().mockResolvedValue({
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                contentType: 'image/jpeg',
+                encoding: 'base64',
+                contentBytes: 'aGk=',
+              }),
+            },
+          ],
+        }),
+      };
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('download-bytes');
+      expect(tool).toBeDefined();
+
+      await tool!.handler({ target: '/me/photo/$value' });
+
+      expect(graphClient.graphRequest).toHaveBeenCalledTimes(1);
+      const [path, options] = graphClient.graphRequest.mock.calls[0];
+      expect(path).toBe('/me/photo/$value');
+      expect(options.accessToken).toBeUndefined();
+    });
+
+    it('rejects absolute URLs (Graph paths only)', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, {} as any);
+
+      const tool = server.tools.get('download-bytes');
+      const result = await tool!.handler({
+        target: 'https://example.sharepoint.com/d/abc?temp=signed',
+      });
+
+      expect(result.isError).toBe(true);
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toMatch(/relative Microsoft Graph path/);
+    });
+
+    it('rejects targets that do not start with /', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, {} as any);
+
+      const tool = server.tools.get('download-bytes');
+      const result = await tool!.handler({ target: 'ftp://example.com/x' });
+
+      expect(result.isError).toBe(true);
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toMatch(/relative Microsoft Graph path/);
+    });
+  });
+
+  // ---- 10. Utility tools surface in --discovery mode ----
+  describe('discovery mode: utility tools', () => {
+    it('search-tools surfaces download-bytes for "download" queries', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const server = createMockServer();
+      const { registerDiscoveryTools } = await loadModule();
+      registerDiscoveryTools(server as any, {} as any);
+
+      const result = await server.tools.get('search-tools')!.handler({ query: 'download' });
+      const payload = JSON.parse(result.content[0].text);
+      const names = payload.tools.map((t: any) => t.name);
+      expect(names).toContain('download-bytes');
+    });
+
+    it('get-tool-schema returns the download-bytes parameter schema', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const server = createMockServer();
+      const { registerDiscoveryTools } = await loadModule();
+      registerDiscoveryTools(server as any, {} as any);
+
+      const result = await server.tools
+        .get('get-tool-schema')!
+        .handler({ tool_name: 'download-bytes' });
+      const schema = JSON.parse(result.content[0].text);
+      expect(schema.name).toBe('download-bytes');
+      expect(schema.path).toBe('tool:download-bytes');
+      const targetParam = schema.parameters.find((p: any) => p.name === 'target');
+      expect(targetParam).toBeDefined();
+      expect(targetParam.required).toBe(true);
+    });
+
+    it('execute-tool dispatches to download-bytes for a Graph path', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = {
+        graphRequest: vi.fn().mockResolvedValue({
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                contentType: 'image/png',
+                encoding: 'base64',
+                contentBytes: 'iVBORw0K',
+              }),
+            },
+          ],
+        }),
+      };
+
+      const server = createMockServer();
+      const { registerDiscoveryTools } = await loadModule();
+      registerDiscoveryTools(server as any, graphClient as any);
+
+      const result = await server.tools.get('execute-tool')!.handler({
+        tool_name: 'download-bytes',
+        parameters: { target: '/me/photo/$value' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(graphClient.graphRequest).toHaveBeenCalledTimes(1);
+      const [path] = graphClient.graphRequest.mock.calls[0];
+      expect(path).toBe('/me/photo/$value');
+    });
+
+    it('execute-tool reports unknown tool when name matches neither registry', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const server = createMockServer();
+      const { registerDiscoveryTools } = await loadModule();
+      registerDiscoveryTools(server as any, {} as any);
+
+      const result = await server.tools.get('execute-tool')!.handler({
+        tool_name: 'no-such-tool',
+        parameters: {},
+      });
+      expect(result.isError).toBe(true);
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toMatch(/not found/i);
+    });
+  });
 });

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -151,13 +151,8 @@
     "pathPattern": "/me/messages/{message-id}/attachments",
     "method": "get",
     "toolName": "list-mail-attachments",
-    "scopes": ["Mail.Read"]
-  },
-  {
-    "pathPattern": "/me/messages/{message-id}/attachments/{attachment-id}",
-    "method": "get",
-    "toolName": "get-mail-attachment",
-    "scopes": ["Mail.Read"]
+    "scopes": ["Mail.Read"],
+    "llmTip": "Lists attachments on a message: id, name, contentType, size, isInline. To download the bytes, call download-bytes with target=/me/messages/{message-id}/attachments/{attachment-id}/$value (the /$value suffix returns raw bytes; the bare attachment URL embeds contentBytes in JSON which can truncate large files)."
   },
   {
     "pathPattern": "/me/messages/{message-id}/attachments/{attachment-id}",
@@ -480,14 +475,6 @@
     "scopes": ["Files.Read"]
   },
   {
-    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/content",
-    "method": "get",
-    "toolName": "download-onedrive-file-content",
-    "scopes": ["Files.Read"],
-    "returnDownloadUrl": true,
-    "llmTip": "Returns a temporary download URL, NOT the file content directly."
-  },
-  {
     "pathPattern": "/drives/{drive-id}/items/{driveItem-id}",
     "method": "delete",
     "toolName": "delete-onedrive-file",
@@ -498,7 +485,7 @@
     "method": "put",
     "toolName": "upload-file-content",
     "scopes": ["Files.ReadWrite"],
-    "llmTip": "Max 4MB. For new files use path format: /items/root:/path/to/file.txt:/content. Overwrites existing files without warning."
+    "llmTip": "Body is a base64-encoded string of the file bytes; the server decodes it before PUT. Max 4MB inline (use create-upload-session above 4MB). For new files use path format: /items/root:/path/to/file.txt:/content. Overwrites existing files without warning."
   },
   {
     "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/createUploadSession",
@@ -512,7 +499,7 @@
     "method": "get",
     "toolName": "get-drive-item",
     "scopes": ["Files.Read"],
-    "llmTip": "Gets metadata for a file or folder: name, size, lastModifiedDateTime, createdBy, webUrl, file (mimeType, hashes), folder (childCount), parentReference. Does not return content — use download-onedrive-file-content for that."
+    "llmTip": "Gets metadata for a file or folder: name, size, lastModifiedDateTime, createdBy, webUrl, file (mimeType, hashes), folder (childCount), parentReference, and @microsoft.graph.downloadUrl. For the bytes, call download-bytes with target=/drives/{drive-id}/items/{driveItem-id}/content (Graph redirects to the same downloadUrl)."
   },
   {
     "pathPattern": "/drives/{drive-id}/items/{driveItem-id}",
@@ -1078,22 +1065,6 @@
     "llmTip": "Lists users who report directly to a specific user. Use with get-user-manager to traverse the org hierarchy."
   },
   {
-    "pathPattern": "/me/photo/$value",
-    "method": "get",
-    "toolName": "get-my-profile-photo",
-    "scopes": ["User.Read"],
-    "returnDownloadUrl": true,
-    "llmTip": "Returns the current user's profile photo as binary image data. The photo is typically in JPEG format."
-  },
-  {
-    "pathPattern": "/users/{user-id}/photo/$value",
-    "method": "get",
-    "toolName": "get-user-profile-photo",
-    "workScopes": ["User.Read.All"],
-    "returnDownloadUrl": true,
-    "llmTip": "Returns a specific user's profile photo as binary image data. Use the user ID or UPN (email)."
-  },
-  {
     "pathPattern": "/me/people",
     "method": "get",
     "toolName": "list-relevant-people",
@@ -1185,15 +1156,7 @@
     "method": "get",
     "toolName": "list-chat-message-hosted-contents",
     "workScopes": ["ChatMessage.Read"],
-    "llmTip": "Lists hosted-content references (inline images, code snippets) attached to a Teams chat message. Returns an array of { id, contentType }. Use get-chat-message-hosted-content with the id to download the bytes. Hosted content IDs can also be parsed from the <img src> URL in the message body between /hostedContents/ and /$value."
-  },
-  {
-    "pathPattern": "/chats/{chat-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}/$value",
-    "method": "get",
-    "toolName": "get-chat-message-hosted-content",
-    "workScopes": ["ChatMessage.Read"],
-    "returnDownloadUrl": true,
-    "llmTip": "Returns raw bytes of a hosted content item (typically image/png or image/jpeg) attached to a Teams 1:1 or group chat message. Use list-chat-message-hosted-contents to discover IDs, or extract the ID from the <img src> URL in the message body."
+    "llmTip": "Lists hosted-content references (inline images, code snippets) attached to a Teams chat message. Returns { id, contentType } per item. To download bytes, call download-bytes with target=/chats/{chat-id}/messages/{chatMessage-id}/hostedContents/{id}/$value. IDs can also be extracted from the <img src> URL in the message body between /hostedContents/ and /$value."
   },
   {
     "pathPattern": "/chats/{chat-id}/messages",
@@ -1261,15 +1224,7 @@
     "method": "get",
     "toolName": "list-channel-message-hosted-contents",
     "workScopes": ["ChannelMessage.Read.All"],
-    "llmTip": "Lists hosted-content references (inline images, code snippets) attached to a Teams channel message. Returns an array of { id, contentType }. Use get-channel-message-hosted-content with the id to download bytes."
-  },
-  {
-    "pathPattern": "/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}/$value",
-    "method": "get",
-    "toolName": "get-channel-message-hosted-content",
-    "workScopes": ["ChannelMessage.Read.All"],
-    "returnDownloadUrl": true,
-    "llmTip": "Returns raw bytes of a hosted content item attached to a Teams channel message. Use list-channel-message-hosted-contents to discover IDs."
+    "llmTip": "Lists hosted-content references (inline images, code snippets) attached to a Teams channel message. Returns { id, contentType } per item. To download bytes, call download-bytes with target=/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents/{id}/$value."
   },
   {
     "pathPattern": "/teams/{team-id}/channels/{channel-id}/messages",

--- a/src/generated/endpoint-types.ts
+++ b/src/generated/endpoint-types.ts
@@ -14,7 +14,7 @@ export type Endpoint = {
   path: string;
   alias: string;
   description?: string;
-  requestFormat: 'json';
+  requestFormat: 'json' | 'binary' | 'form-data' | 'form-url' | 'text';
   parameters?: Parameter[];
   response: z.ZodType<any>;
   errors?: Array<{

--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -44,7 +44,7 @@ export function isBinaryContentType(contentType: string): boolean {
 interface GraphRequestOptions {
   headers?: Record<string, string>;
   method?: string;
-  body?: string;
+  body?: string | Buffer | Uint8Array;
   rawResponse?: boolean;
   includeHeaders?: boolean;
   excludeResponse?: boolean;
@@ -184,7 +184,8 @@ class GraphClient {
     return fetch(url, {
       method: options.method || 'GET',
       headers,
-      body: options.body,
+      // Node's fetch accepts Buffer/Uint8Array; TS BodyInit doesn't.
+      body: options.body as unknown as string,
     });
   }
 

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -15,7 +15,7 @@ export interface DiscoverySearchIndex {
   bm25: BM25Index;
   nameTokens: Map<string, Set<string>>;
 }
-import { describeToolSchema } from './lib/tool-schema.js';
+import { describeToolSchema, describeUtilityToolSchema } from './lib/tool-schema.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -115,6 +115,151 @@ interface CallToolResult {
   isError?: boolean;
 
   [key: string]: unknown;
+}
+
+interface UtilityToolContext {
+  graphClient: GraphClient;
+  authManager?: AuthManager;
+  multiAccount: boolean;
+  accountNames: string[];
+}
+
+interface UtilityTool {
+  name: string;
+  // Synthetic for display in search-tools / get-tool-schema. The `tool:` prefix
+  // marks these as non-Graph so an LLM doesn't try to construct a Graph URL from them.
+  method: string;
+  path: string;
+  description: string;
+  buildSchema: (ctx: UtilityToolContext) => Record<string, z.ZodTypeAny>;
+  execute: (params: Record<string, unknown>, ctx: UtilityToolContext) => Promise<CallToolResult>;
+  readOnlyHint?: boolean;
+  openWorldHint?: boolean;
+}
+
+export const UTILITY_TOOLS: readonly UtilityTool[] = [
+  {
+    name: 'parse-teams-url',
+    method: 'POST',
+    path: 'tool:parse-teams-url',
+    description:
+      'Converts any Teams meeting URL format (short /meet/, full /meetup-join/, or recap ?threadId=) into a standard joinWebUrl. Use this before list-online-meetings when the user provides a recap or short URL.',
+    readOnlyHint: true,
+    openWorldHint: false,
+    buildSchema: () => ({
+      url: z.string().describe('Teams meeting URL in any format'),
+    }),
+    execute: async (params) => {
+      const url = params.url;
+      if (typeof url !== 'string') {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: 'url is required.' }) }],
+          isError: true,
+        };
+      }
+      try {
+        const joinWebUrl = parseTeamsUrl(url);
+        return { content: [{ type: 'text', text: joinWebUrl }] };
+      } catch (error) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: (error as Error).message }) }],
+          isError: true,
+        };
+      }
+    },
+  },
+  {
+    name: 'download-bytes',
+    method: 'GET',
+    path: 'tool:download-bytes',
+    description:
+      'Download binary content from Microsoft Graph and return it as base64. Single tool for any binary read: drive file content, mail attachment, profile photo, Teams hosted content, meeting recording. Returns { contentType, encoding: "base64", contentLength, contentBytes }.',
+    readOnlyHint: true,
+    openWorldHint: true,
+    buildSchema: (ctx) => {
+      const schema: Record<string, z.ZodTypeAny> = {
+        target: z
+          .string()
+          .describe(
+            'Relative Microsoft Graph path starting with "/". Common paths: ' +
+              '/drives/{drive-id}/items/{driveItem-id}/content (drive file content); ' +
+              '/me/messages/{message-id}/attachments/{attachment-id}/$value (mail attachment, list-mail-attachments returns the IDs); ' +
+              '/me/photo/$value or /users/{user-id}/photo/$value (profile photo); ' +
+              '/chats/{chat-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}/$value (Teams chat hosted content, list-chat-message-hosted-contents returns the IDs); ' +
+              '/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}/$value (Teams channel hosted content). ' +
+              'For meeting recordings (often large), use get-meeting-recording-content which returns a URL for out-of-band download by the client.'
+          ),
+      };
+      if (ctx.multiAccount) {
+        schema['account'] = z
+          .string()
+          .optional()
+          .describe(
+            'Account to use when multiple Microsoft accounts are configured. Required when multiple accounts exist (see list-accounts).'
+          );
+      }
+      return schema;
+    },
+    execute: async (params, { graphClient, authManager }) => {
+      const target = params.target;
+      const accountParam = params.account as string | undefined;
+      if (typeof target !== 'string' || target.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ error: 'target is required and must be a non-empty string.' }),
+            },
+          ],
+          isError: true,
+        };
+      }
+      if (!target.startsWith('/')) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                error:
+                  'target must be a relative Microsoft Graph path starting with "/", e.g. /me/photo/$value or /drives/{drive-id}/items/{driveItem-id}/content. Absolute URLs are not accepted; if you have an @microsoft.graph.downloadUrl, use the equivalent /content or /$value path instead (Graph 302-redirects to the same bytes).',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+      try {
+        let accountAccessToken: string | undefined;
+        if (authManager && !authManager.isOAuthModeEnabled() && !getRequestTokens()) {
+          accountAccessToken = await authManager.getTokenForAccount(accountParam);
+        }
+        return await graphClient.graphRequest(target, { accessToken: accountAccessToken });
+      } catch (error) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: (error as Error).message }) }],
+          isError: true,
+        };
+      }
+    },
+  },
+];
+
+function registerUtilityToolWithMcp(
+  server: McpServer,
+  utility: UtilityTool,
+  ctx: UtilityToolContext
+): void {
+  server.tool(
+    utility.name,
+    utility.description,
+    utility.buildSchema(ctx),
+    {
+      title: utility.name,
+      readOnlyHint: utility.readOnlyHint ?? true,
+      openWorldHint: utility.openWorldHint ?? true,
+    },
+    async (params) => utility.execute(params, ctx)
+  );
 }
 
 async function executeGraphTool(
@@ -326,7 +471,7 @@ async function executeGraphTool(
     const options: {
       method: string;
       headers: Record<string, string>;
-      body?: string;
+      body?: string | Buffer | Uint8Array;
       rawResponse?: boolean;
       includeHeaders?: boolean;
       excludeResponse?: boolean;
@@ -338,7 +483,12 @@ async function executeGraphTool(
     };
 
     if (options.method !== 'GET' && body) {
-      if (config?.contentType === 'text/html') {
+      if (tool.requestFormat === 'binary' && typeof body === 'string') {
+        options.body = Buffer.from(body, 'base64');
+        if (!config?.contentType) {
+          headers['Content-Type'] = 'application/octet-stream';
+        }
+      } else if (config?.contentType === 'text/html') {
         if (typeof body === 'string') {
           options.body = body;
         } else if (typeof body === 'object' && 'content' in body) {
@@ -708,37 +858,19 @@ export function registerGraphTools(
     logger.info('Multi-account mode: "account" parameter injected into all tool schemas');
   }
 
-  // Register parse-teams-url utility tool (no Graph API call)
-  if (!enabledToolsRegex || enabledToolsRegex.test('parse-teams-url')) {
+  const utilityCtx: UtilityToolContext = {
+    graphClient,
+    authManager,
+    multiAccount,
+    accountNames,
+  };
+  for (const utility of UTILITY_TOOLS) {
+    if (enabledToolsRegex && !enabledToolsRegex.test(utility.name)) continue;
     try {
-      server.tool(
-        'parse-teams-url',
-        'Converts any Teams meeting URL format (short /meet/, full /meetup-join/, or recap ?threadId=) into a standard joinWebUrl. Use this before list-online-meetings when the user provides a recap or short URL.',
-        {
-          url: z.string().describe('Teams meeting URL in any format'),
-        },
-        {
-          title: 'parse-teams-url',
-          readOnlyHint: true,
-          openWorldHint: false,
-        },
-        async ({ url }) => {
-          try {
-            const joinWebUrl = parseTeamsUrl(url);
-            return { content: [{ type: 'text', text: joinWebUrl }] };
-          } catch (error) {
-            return {
-              content: [
-                { type: 'text', text: JSON.stringify({ error: (error as Error).message }) },
-              ],
-              isError: true,
-            };
-          }
-        }
-      );
+      registerUtilityToolWithMcp(server, utility, utilityCtx);
       registeredCount++;
     } catch (error) {
-      logger.error(`Failed to register tool parse-teams-url: ${(error as Error).message}`);
+      logger.error(`Failed to register tool ${utility.name}: ${(error as Error).message}`);
       failedCount++;
     }
   }
@@ -787,7 +919,8 @@ export function buildToolsRegistry(
  * merely mentions the query term in its Microsoft-supplied description.
  */
 export function buildDiscoverySearchIndex(
-  toolsRegistry: ReturnType<typeof buildToolsRegistry>
+  toolsRegistry: ReturnType<typeof buildToolsRegistry>,
+  utilityTools: readonly UtilityTool[] = []
 ): DiscoverySearchIndex {
   // Cap contribution from the `description` and `llmTip` fields so a verbose llmTip
   // (e.g. the KQL search-syntax guide on list-mail-messages, ~300 tokens) doesn't
@@ -817,6 +950,14 @@ export function buildDiscoverySearchIndex(
       ...descTokens,
     ];
     docs.push({ id: name, tokens });
+  }
+  for (const utility of utilityTools) {
+    const nt = tokenize(utility.name);
+    nameTokens.set(utility.name, new Set(nt));
+    const pathTokens = tokenize(utility.path);
+    const descTokens = tokenize(utility.description).slice(0, DESC_CAP_TOKENS);
+    const tokens = [...nt, ...nt, ...nt, ...nt, ...nt, ...pathTokens, ...pathTokens, ...descTokens];
+    docs.push({ id: utility.name, tokens });
   }
   return { bm25: buildBM25Index(docs), nameTokens };
 }
@@ -861,35 +1002,59 @@ export function registerDiscoveryTools(
   readOnly: boolean = false,
   orgMode: boolean = false,
   authManager?: AuthManager,
-  _multiAccount: boolean = false
+  multiAccount: boolean = false,
+  accountNames: string[] = []
 ): void {
   const toolsRegistry = buildToolsRegistry(readOnly, orgMode);
-  const searchIndex = buildDiscoverySearchIndex(toolsRegistry);
-  logger.info(`Discovery mode: ${toolsRegistry.size} tools available in registry`);
+  const utilityTools = UTILITY_TOOLS;
+  const searchIndex = buildDiscoverySearchIndex(toolsRegistry, utilityTools);
+  const totalCount = toolsRegistry.size + utilityTools.length;
+  logger.info(
+    `Discovery mode: ${totalCount} tools (${toolsRegistry.size} Graph + ${utilityTools.length} utility)`
+  );
+
+  const utilityCtx: UtilityToolContext = {
+    graphClient,
+    authManager,
+    multiAccount,
+    accountNames,
+  };
+  const utilityByName = new Map(utilityTools.map((u) => [u.name, u]));
 
   const categoryNames = Object.keys(TOOL_CATEGORIES).join(', ');
 
   const toResultEntry = (name: string) => {
     const entry = toolsRegistry.get(name);
-    if (!entry) return null;
-    const { tool, config } = entry;
-    return {
-      name,
-      method: tool.method.toUpperCase(),
-      path: tool.path,
-      description: tool.description || `${tool.method.toUpperCase()} ${tool.path}`,
-      ...(config?.llmTip ? { llmTip: config.llmTip } : {}),
-    };
+    if (entry) {
+      const { tool, config } = entry;
+      return {
+        name,
+        method: tool.method.toUpperCase(),
+        path: tool.path,
+        description: tool.description || `${tool.method.toUpperCase()} ${tool.path}`,
+        ...(config?.llmTip ? { llmTip: config.llmTip } : {}),
+      };
+    }
+    const utility = utilityByName.get(name);
+    if (utility) {
+      return {
+        name: utility.name,
+        method: utility.method,
+        path: utility.path,
+        description: utility.description,
+      };
+    }
+    return null;
   };
 
   server.tool(
     'search-tools',
-    `Search through ${toolsRegistry.size} Microsoft Graph API tools. Ranks results by BM25 over tool name, llmTip, description, and path (tokenized on hyphens, camelCase, and whitespace). After picking a tool, call get-tool-schema to see its parameters, then execute-tool to invoke it.`,
+    `Search through ${totalCount} tools (${toolsRegistry.size} Microsoft Graph API operations + ${utilityTools.length} server utilities like download-bytes). Ranks results by BM25 over tool name, llmTip, description, and path. After picking a tool, call get-tool-schema for parameters, then execute-tool.`,
     {
       query: z
         .string()
         .describe(
-          'Natural-language query. Tokenized and BM25-ranked. E.g. "send email", "create calendar event", "list unread messages".'
+          'Natural-language query. Tokenized and BM25-ranked. E.g. "send email", "download photo", "list unread messages".'
         )
         .optional(),
       category: z.string().describe(`Optional pre-filter by category: ${categoryNames}`).optional(),
@@ -910,7 +1075,9 @@ export function registerDiscoveryTools(
         const ranked = scoreDiscoveryQuery(query, searchIndex);
         orderedNames = ranked.map((r) => r.id).filter(categoryFilter);
       } else {
-        orderedNames = [...toolsRegistry.keys()].filter(categoryFilter);
+        orderedNames = [...toolsRegistry.keys(), ...utilityTools.map((u) => u.name)].filter(
+          categoryFilter
+        );
       }
 
       const tools = orderedNames.slice(0, maxLimit).map(toResultEntry).filter(Boolean);
@@ -922,7 +1089,7 @@ export function registerDiscoveryTools(
             text: JSON.stringify(
               {
                 found: tools.length,
-                total: toolsRegistry.size,
+                total: totalCount,
                 tools,
                 tip: 'Call get-tool-schema(tool_name) to see parameters before invoking execute-tool.',
               },
@@ -948,23 +1115,30 @@ export function registerDiscoveryTools(
     },
     async ({ tool_name }) => {
       const entry = toolsRegistry.get(tool_name);
-      if (!entry) {
+      if (entry) {
+        const schema = describeToolSchema(entry.tool, entry.config?.llmTip);
         return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                error: `Tool not found: ${tool_name}`,
-                tip: 'Use search-tools to find available tools.',
-              }),
-            },
-          ],
-          isError: true,
+          content: [{ type: 'text', text: JSON.stringify(schema, null, 2) }],
         };
       }
-      const schema = describeToolSchema(entry.tool, entry.config?.llmTip);
+      const utility = utilityByName.get(tool_name);
+      if (utility) {
+        const schema = describeUtilityToolSchema(utility, utilityCtx);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(schema, null, 2) }],
+        };
+      }
       return {
-        content: [{ type: 'text', text: JSON.stringify(schema, null, 2) }],
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              error: `Tool not found: ${tool_name}`,
+              tip: 'Use search-tools to find available tools.',
+            }),
+          },
+        ],
+        isError: true,
       };
     }
   );
@@ -989,22 +1163,31 @@ export function registerDiscoveryTools(
     },
     async ({ tool_name, parameters = {} }) => {
       const toolData = toolsRegistry.get(tool_name);
-      if (!toolData) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                error: `Tool not found: ${tool_name}`,
-                tip: 'Use search-tools to find available tools.',
-              }),
-            },
-          ],
-          isError: true,
-        };
+      if (toolData) {
+        return executeGraphTool(
+          toolData.tool,
+          toolData.config,
+          graphClient,
+          parameters,
+          authManager
+        );
       }
-
-      return executeGraphTool(toolData.tool, toolData.config, graphClient, parameters, authManager);
+      const utility = utilityByName.get(tool_name);
+      if (utility) {
+        return utility.execute(parameters, utilityCtx);
+      }
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              error: `Tool not found: ${tool_name}`,
+              tip: 'Use search-tools to find available tools.',
+            }),
+          },
+        ],
+        isError: true,
+      };
     }
   );
 

--- a/src/lib/tool-schema.ts
+++ b/src/lib/tool-schema.ts
@@ -57,3 +57,51 @@ export function describeToolSchema(
     parameters: params,
   };
 }
+
+interface UtilityDescriptor {
+  name: string;
+  method: string;
+  path: string;
+  description: string;
+  buildSchema: (ctx: never) => Record<string, z.ZodTypeAny>;
+}
+
+// Params reported as `Query` (top-level): execute-tool passes `parameters`
+// straight to utility.execute(); `Body` would mislead LLMs into nesting under `body`.
+export function describeUtilityToolSchema<C>(
+  utility: UtilityDescriptor & { buildSchema: (ctx: C) => Record<string, z.ZodTypeAny> },
+  ctx: C
+): {
+  name: string;
+  method: string;
+  path: string;
+  description: string;
+  parameters: Array<{
+    name: string;
+    in: 'Query';
+    required: boolean;
+    description?: string;
+    schema: unknown;
+  }>;
+} {
+  const schemaMap = utility.buildSchema(ctx);
+  const params = Object.entries(schemaMap).map(([name, zodSchema]) => {
+    const { inner, optional } = unwrapOptional(zodSchema);
+    const jsonSchema = zodToJsonSchema(inner, { target: 'jsonSchema7', $refStrategy: 'none' });
+    const { $schema: _s, ...schema } = jsonSchema as Record<string, unknown>;
+    return {
+      name,
+      in: 'Query' as const,
+      required: !optional,
+      description: zodSchema.description,
+      schema,
+    };
+  });
+  return {
+    name: utility.name,
+    method: utility.method,
+    path: utility.path,
+    description: utility.description,
+    parameters: params,
+  };
+}

--- a/src/mcp-instructions.ts
+++ b/src/mcp-instructions.ts
@@ -13,6 +13,7 @@ function buildGeneralMcpInstructions(opts: McpInstructionsContext): string {
     'When you need an organizational user or recipient address, resolve it with list-users (or another directory tool); do not invent SMTP addresses.',
     'Directory $search on collections such as /users or /groups requires ConsistencyLevel: eventual when the tool exposes that header.',
     'Teams chat and channel messages: prefer HTML contentType in the body; plain text is often mangled by Graph.',
+    'Files / binary content: use download-bytes for any binary read (drive file content, mail attachments, profile photos, Teams hosted content, meeting recordings); pass it a Graph path or an absolute @microsoft.graph.downloadUrl from a metadata response. For uploads, upload-file-content takes a base64 string body up to 4MB; use create-upload-session above that.',
   ];
   if (opts.readOnly) parts.push('This server is read-only; write operations are disabled.');
   if (opts.multiAccount)

--- a/src/server.ts
+++ b/src/server.ts
@@ -107,7 +107,8 @@ class MicrosoftGraphServer {
         this.options.readOnly,
         this.options.orgMode,
         this.authManager,
-        this.multiAccount
+        this.multiAccount,
+        this.accountNames
       );
     } else {
       registerGraphTools(

--- a/src/tool-categories.ts
+++ b/src/tool-categories.ts
@@ -8,7 +8,7 @@ export interface ToolCategory {
 export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   mail: {
     name: 'mail',
-    pattern: /mail|attachment|draft/i,
+    pattern: /mail|attachment|draft|download-bytes/i,
     description: 'Email operations (read, send, manage folders, attachments)',
   },
   calendar: {
@@ -24,13 +24,13 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   personal: {
     name: 'personal',
     pattern:
-      /mail|calendar|drive|contact|todo|onenote|attachment|draft|event|file|folder|search|query/i,
+      /mail|calendar|drive|contact|todo|onenote|attachment|draft|event|file|folder|search|query|download-bytes|parse-teams-url/i,
     description:
       'Personal productivity tools (mail, calendar, files, contacts, tasks, notes, search)',
   },
   work: {
     name: 'work',
-    pattern: /team|channel|chat|sharepoint|planner|site|list|shared|search|query/i,
+    pattern: /team|channel|chat|sharepoint|planner|site|list|shared|search|query|download-bytes/i,
     description: 'Organization/work tools (Teams, SharePoint, shared mailboxes, search)',
     requiresOrgMode: true,
   },
@@ -61,7 +61,7 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   },
   users: {
     name: 'users',
-    pattern: /user|list-users/i,
+    pattern: /user|list-users|download-bytes/i,
     description: 'User directory access',
     requiresOrgMode: true,
   },

--- a/test/calendar-view.test.ts
+++ b/test/calendar-view.test.ts
@@ -138,7 +138,7 @@ describe('Calendar View Tools', () => {
       for (const call of mockServer.tool.mock.calls) {
         const toolName = call[0] as string;
         // Skip utility tools that are not Graph API endpoints
-        if (toolName === 'parse-teams-url') continue;
+        if (toolName === 'parse-teams-url' || toolName === 'download-bytes') continue;
         const paramSchema = call[2] as Record<string, z.ZodTypeAny>;
         expect(paramSchema).toHaveProperty('fetchAllPages');
       }

--- a/test/discovery-search.test.ts
+++ b/test/discovery-search.test.ts
@@ -3,6 +3,7 @@ import {
   buildToolsRegistry,
   buildDiscoverySearchIndex,
   scoreDiscoveryQuery,
+  UTILITY_TOOLS,
 } from '../src/graph-tools.js';
 
 /**
@@ -12,7 +13,8 @@ import {
  * descriptions, llmTips, or the ranking weights surface here.
  */
 const registry = buildToolsRegistry(false, true);
-const index = buildDiscoverySearchIndex(registry);
+const utilityNames = new Set(UTILITY_TOOLS.map((u) => u.name));
+const index = buildDiscoverySearchIndex(registry, UTILITY_TOOLS);
 
 function topN(query: string, n: number): string[] {
   return scoreDiscoveryQuery(query, index)
@@ -47,8 +49,11 @@ const cases: Case[] = [
   // Files
   { query: 'list folders', expect: 'list-mail-folders', inTop: 10 },
   { query: 'onedrive folder', expect: 'create-onedrive-folder', inTop: 10 },
-  { query: 'download file', expect: 'download-onedrive-file-content', inTop: 5 },
   { query: 'upload file', expect: 'upload-file-content', inTop: 5 },
+  { query: 'download file', expect: 'download-bytes', inTop: 5 },
+  { query: 'download bytes', expect: 'download-bytes', inTop: 5 },
+  { query: 'profile photo', expect: 'download-bytes', inTop: 10 },
+  { query: 'parse teams url', expect: 'parse-teams-url', inTop: 5 },
   // Users
   { query: 'search users', expect: 'list-users', inTop: 10 },
   { query: 'user manager', expect: 'get-user-manager', inTop: 10 },
@@ -61,7 +66,7 @@ describe('discovery search (golden queries)', () => {
   for (const c of cases) {
     const n = c.inTop ?? 5;
     it(`"${c.query}" → ${c.expect} in top ${n}`, () => {
-      if (!registry.has(c.expect)) {
+      if (!registry.has(c.expect) && !utilityNames.has(c.expect)) {
         throw new Error(
           `Test fixture error: expected tool "${c.expect}" is not in the registry. ` +
             `Update the golden-query case or add the endpoint.`

--- a/test/read-only.test.ts
+++ b/test/read-only.test.ts
@@ -83,8 +83,8 @@ describe('Read-Only Mode', () => {
 
     registerGraphTools(mockServer, {} as GraphClient, options.readOnly);
 
-    // 1 GET endpoint + 1 parse-teams-url utility tool
-    expect(mockServer.tool).toHaveBeenCalledTimes(2);
+    // 1 GET endpoint + parse-teams-url + download-bytes utility tools
+    expect(mockServer.tool).toHaveBeenCalledTimes(3);
 
     const toolCalls = mockServer.tool.mock.calls.map((call: unknown[]) => call[0]);
     expect(toolCalls).toContain('list-mail-messages');
@@ -100,8 +100,8 @@ describe('Read-Only Mode', () => {
 
     registerGraphTools(mockServer, {} as GraphClient, options.readOnly);
 
-    // 4 mocked endpoints (get-schedule skipped: workScopes only, no orgMode) + 1 parse-teams-url utility tool
-    expect(mockServer.tool).toHaveBeenCalledTimes(5);
+    // 4 mocked endpoints (get-schedule skipped: workScopes only, no orgMode) + parse-teams-url + download-bytes
+    expect(mockServer.tool).toHaveBeenCalledTimes(6);
 
     const toolCalls = mockServer.tool.mock.calls.map((call: unknown[]) => call[0]);
     expect(toolCalls).toContain('list-mail-messages');
@@ -132,8 +132,8 @@ describe('Read-Only Mode', () => {
     // PATCH endpoint should still be skipped (readOnly bypass is POST-only)
     expect(toolCalls).not.toContain('update-mail-folder');
 
-    // 2 graph tools (list-mail-messages + get-schedule) + 1 parse-teams-url
-    expect(mockServer.tool).toHaveBeenCalledTimes(3);
+    // 2 graph tools (list-mail-messages + get-schedule) + parse-teams-url + download-bytes
+    expect(mockServer.tool).toHaveBeenCalledTimes(4);
   });
 
   it('should block PATCH and DELETE endpoints in read-only mode regardless of readOnly flag', () => {

--- a/test/tool-filtering.test.ts
+++ b/test/tool-filtering.test.ts
@@ -51,8 +51,8 @@ describe('Tool Filtering', () => {
   it('should register all tools when no filter is provided', () => {
     registerGraphTools(server, graphClient, false);
 
-    // 5 mocked endpoints + 1 parse-teams-url utility tool
-    expect(toolSpy).toHaveBeenCalledTimes(6);
+    // 5 mocked endpoints + parse-teams-url + download-bytes utility tools
+    expect(toolSpy).toHaveBeenCalledTimes(7);
     expect(toolSpy).toHaveBeenCalledWith(
       'list-mail-messages',
       expect.any(String),
@@ -133,8 +133,8 @@ describe('Tool Filtering', () => {
   it('should handle invalid regex patterns gracefully', () => {
     registerGraphTools(server, graphClient, false, '[invalid regex');
 
-    // 5 mocked endpoints + 1 parse-teams-url utility tool (no filter applied on invalid regex)
-    expect(toolSpy).toHaveBeenCalledTimes(6);
+    // 5 mocked endpoints + parse-teams-url + download-bytes (no filter applied on invalid regex)
+    expect(toolSpy).toHaveBeenCalledTimes(7);
   });
 
   it('should combine read-only and filtering correctly', () => {


### PR DESCRIPTION
Closes #414. Upload body now accepts a base64 string (was z.instanceof(File), unusable from JSON-RPC clients). Generator post-processes the openapi-zod-client output to swap the schema; runtime decodes to bytes before PUT.

Replaces 6 per-entity download tools (download-onedrive-file-content, get-mail-attachment, get-my-profile-photo, get-user-profile-photo, get-chat-message-hosted-content, get-channel-message-hosted-content) with a single download-bytes(target) accepting any relative Microsoft Graph path (e.g. /me/photo/$value, /drives/{id}/items/{id}/content). Discovery mode surfaces it through a UTILITY_TOOLS registry shared with regular mode; parse-teams-url moves into the same registry. Listing-tool llmTips updated to direct LLMs at the new path.