### PR TITLE
feat: --enabled-tools applies to discovery mode and utility tools

### DIFF
--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -828,4 +828,102 @@ describe('graph-tools', () => {
       expect(payload.error).toMatch(/not found/i);
     });
   });
+
+  // ---- 11. Discovery mode respects --enabled-tools ----
+  describe('discovery mode: --enabled-tools filter', () => {
+    it('search-tools only surfaces Graph tools matching the regex', async () => {
+      mockEndpoints.push(
+        {
+          alias: 'list-mail-messages',
+          method: 'get',
+          path: '/me/messages',
+          description: 'List mail',
+          parameters: [],
+        },
+        {
+          alias: 'list-calendar-events',
+          method: 'get',
+          path: '/me/events',
+          description: 'List events',
+          parameters: [],
+        }
+      );
+      mockEndpointsJson = [
+        { toolName: 'list-mail-messages', method: 'get', pathPattern: '/me/messages' },
+        { toolName: 'list-calendar-events', method: 'get', pathPattern: '/me/events' },
+      ];
+
+      const server = createMockServer();
+      const { registerDiscoveryTools } = await loadModule();
+      registerDiscoveryTools(server as any, {} as any, false, false, undefined, false, [], 'mail');
+
+      const result = await server.tools.get('search-tools')!.handler({ limit: 50 });
+      const found = JSON.parse(result.content[0].text).tools.map((t: any) => t.name);
+      expect(found).toContain('list-mail-messages');
+      expect(found).not.toContain('list-calendar-events');
+    });
+
+    it('utility tools obey the regex too', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const server = createMockServer();
+      const { registerDiscoveryTools } = await loadModule();
+      registerDiscoveryTools(
+        server as any,
+        {} as any,
+        false,
+        false,
+        undefined,
+        false,
+        [],
+        '^download-bytes$'
+      );
+
+      const result = await server.tools.get('search-tools')!.handler({ limit: 50 });
+      const found = JSON.parse(result.content[0].text).tools.map((t: any) => t.name);
+      expect(found).toContain('download-bytes');
+      expect(found).not.toContain('parse-teams-url');
+    });
+
+    it('invalid regex pattern is ignored, all tools surface', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const server = createMockServer();
+      const { registerDiscoveryTools } = await loadModule();
+      registerDiscoveryTools(
+        server as any,
+        {} as any,
+        false,
+        false,
+        undefined,
+        false,
+        [],
+        '[invalid'
+      );
+
+      const result = await server.tools.get('search-tools')!.handler({ limit: 50 });
+      const found = JSON.parse(result.content[0].text).tools.map((t: any) => t.name);
+      expect(found).toContain('download-bytes');
+      expect(found).toContain('parse-teams-url');
+    });
+  });
+
+  // ---- 12. Read-only mode filters utility tools without readOnlyHint ----
+  describe('utility tools in read-only mode', () => {
+    it('skips utility tools whose readOnlyHint is not true', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, {} as any, true);
+
+      // Both built-in utility tools (download-bytes, parse-teams-url) have
+      // readOnlyHint: true so they should be present.
+      expect(server.tools.has('download-bytes')).toBe(true);
+      expect(server.tools.has('parse-teams-url')).toBe(true);
+    });
+  });
 });

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -865,6 +865,7 @@ export function registerGraphTools(
     accountNames,
   };
   for (const utility of UTILITY_TOOLS) {
+    if (readOnly && !utility.readOnlyHint) continue;
     if (enabledToolsRegex && !enabledToolsRegex.test(utility.name)) continue;
     try {
       registerUtilityToolWithMcp(server, utility, utilityCtx);
@@ -886,7 +887,8 @@ export function registerGraphTools(
 
 export function buildToolsRegistry(
   readOnly: boolean,
-  orgMode: boolean
+  orgMode: boolean,
+  enabledToolsRegex?: RegExp
 ): Map<string, { tool: (typeof api.endpoints)[0]; config: EndpointConfig | undefined }> {
   const toolsMap = new Map<
     string,
@@ -905,6 +907,10 @@ export function buildToolsRegistry(
       if (!(method === 'POST' && endpointConfig?.readOnly)) {
         continue;
       }
+    }
+
+    if (enabledToolsRegex && !enabledToolsRegex.test(tool.alias)) {
+      continue;
     }
 
     toolsMap.set(tool.alias, { tool, config: endpointConfig });
@@ -1003,10 +1009,27 @@ export function registerDiscoveryTools(
   orgMode: boolean = false,
   authManager?: AuthManager,
   multiAccount: boolean = false,
-  accountNames: string[] = []
+  accountNames: string[] = [],
+  enabledTools?: string
 ): void {
-  const toolsRegistry = buildToolsRegistry(readOnly, orgMode);
-  const utilityTools = UTILITY_TOOLS;
+  let enabledToolsRegex: RegExp | undefined;
+  if (enabledTools) {
+    try {
+      enabledToolsRegex = new RegExp(enabledTools, 'i');
+      logger.info(`Discovery mode: filtering tools with pattern ${enabledTools}`);
+    } catch (error) {
+      logger.error(
+        `Invalid --enabled-tools regex ${JSON.stringify(enabledTools)} — ignoring filter: ${(error as Error).message}`
+      );
+    }
+  }
+
+  const toolsRegistry = buildToolsRegistry(readOnly, orgMode, enabledToolsRegex);
+  const utilityTools = UTILITY_TOOLS.filter((u) => {
+    if (readOnly && !u.readOnlyHint) return false;
+    if (enabledToolsRegex && !enabledToolsRegex.test(u.name)) return false;
+    return true;
+  });
   const searchIndex = buildDiscoverySearchIndex(toolsRegistry, utilityTools);
   const totalCount = toolsRegistry.size + utilityTools.length;
   logger.info(

--- a/src/server.ts
+++ b/src/server.ts
@@ -108,7 +108,8 @@ class MicrosoftGraphServer {
         this.options.orgMode,
         this.authManager,
         this.multiAccount,
-        this.accountNames
+        this.accountNames,
+        this.options.enabledTools
       );
     } else {
       registerGraphTools(


### PR DESCRIPTION
Discovery mode now respects --enabled-tools (previously the regex was passed to registerGraphTools but ignored by registerDiscoveryTools, so a user running --discovery --preset mail still saw every tool in search-tools). The regex filter is now threaded through buildToolsRegistry and applied to utility tools the same way it's applied in regular mode.

Read-only mode also gates utility tools by their readOnlyHint, so future write-utility additions don't slip past --read-only. Both current utilities (download-bytes, parse-teams-url) have readOnlyHint: true so behavior is unchanged today.