### PR TITLE
feat: add create-shared-mailbox-draft endpoint

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -101,6 +101,12 @@
     "llmTip": "CRITICAL: Do not try to guess the email address of the recipients. Use the list-users tool to find the email address of the recipients."
   },
   {
+    "pathPattern": "/users/{user-id}/messages",
+    "method": "post",
+    "toolName": "create-shared-mailbox-draft",
+    "workScopes": ["Mail.ReadWrite.Shared"]
+  },
+  {
     "pathPattern": "/users",
     "method": "get",
     "toolName": "list-users",


### PR DESCRIPTION
POST /users/{user-id}/messages creates a draft in another user's mailbox. Fixes #400 — create-draft-email is hardcoded to /me/messages which fails under app-only auth. Matches the pattern used by other shared-mailbox tools (list/get/send).