### PR TITLE
chore: use npm ci and add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+dist
+.git
+.claude
+CLAUDE.md
+.github
+.vscode
+*.log
+.DS_Store
+coverage
+.env
+.env.*
+.token-cache.json
+.selected-account.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@ coverage
 .env.*
 .token-cache.json
 .selected-account.json
+.mcp.json

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ CLAUDE.md
 
 # Finder metadata files
 .DS_Store
+
+# LCI-internal deployment notes (kept local-only)
+DEPLOY.md

--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,3 @@ CLAUDE.md
 
 # Finder metadata files
 .DS_Store
-
-# LCI-internal deployment notes (kept local-only)
-DEPLOY.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:24-alpine AS builder
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm i
+RUN npm ci
 
 COPY . .
 RUN npm run generate
@@ -17,6 +17,6 @@ COPY --from=builder /app/dist /app/dist
 COPY --from=builder /app/package*.json ./
 
 ENV NODE_ENV=production
-RUN npm i --ignore-scripts --omit=dev
+RUN npm ci --ignore-scripts --omit=dev
 
 ENTRYPOINT ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary

Two small Docker build improvements:

- **`Dockerfile`** — switch `npm i` to `npm ci` in both build stages. `npm ci` reads `package-lock.json` strictly, fails fast on lockfile drift, and skips dependency resolution — deterministic and faster builds in CI/Docker contexts.
- **`.dockerignore`** (new) — keeps the build context lean and prevents developer-machine artifacts from being copied into the image:
  - `node_modules`, `dist`, `coverage` (rebuilt or unused at runtime)
  - `.git`, `.github`, `.vscode`, `.claude`, `*.log`, `.DS_Store` (metadata noise)
  - `.env`, `.env.*`, `.token-cache.json`, `.selected-account.json` (**security** — local credentials and MSAL token caches must never end up in a published image)

Without a `.dockerignore`, `COPY . .` brings the entire working tree — including local `.env` files and MSAL token caches that exist on a developer's machine — into the image layer, even when those files are gitignored. Docker doesn't honor `.gitignore`.

## Test plan

- [ ] `docker build .` succeeds (deterministic install via `npm ci`)
- [ ] Resulting image does not contain `.env`, `.git`, `node_modules` from the host
- [ ] `npm run inspector` still works against the built image