### PR TITLE
feat: add OneNote transverse list and shared-link resolution endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ CLAUDE.md
 
 # Finder metadata files
 .DS_Store
+
+# LCI-internal deployment notes (kept local-only)
+DEPLOY.md

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1875,5 +1875,27 @@
     "toolName": "create-outlook-category",
     "scopes": ["MailboxSettings.ReadWrite"],
     "llmTip": "Creates a new Outlook category. Body: { displayName (unique), color (one of: none, preset0 … preset24 — maps to red, orange, yellow, green, teal, olive, blue, purple, cranberry, steel, dark-steel, gray, dark-gray, black, dark-red, dark-orange, dark-yellow, dark-green, dark-teal, dark-olive, dark-blue, dark-purple, dark-cranberry) }. Category names are case-sensitive when applied to messages/events."
+  },
+  {
+    "pathPattern": "/me/onenote/pages",
+    "method": "get",
+    "toolName": "list-onenote-pages",
+    "scopes": ["Notes.Read"],
+    "llmTip": "Lists all OneNote pages across every notebook and section the user has access to — transverse alternative to walking notebooks → sections → pages. Default returns top 20 ordered by lastModifiedTime desc. Supports $search='query' for full-text search across page titles and bodies, $filter (e.g. lastModifiedTime gt 2026-01-01), $top (max 100), $select, and $expand=parentNotebook,parentSection. Use $search before bouncing through list-onenote-notebooks / list-all-onenote-sections / list-onenote-section-pages when you only have a topic in mind."
+  },
+  {
+    "pathPattern": "/me/onenote/sectionGroups",
+    "method": "get",
+    "toolName": "list-onenote-section-groups",
+    "scopes": ["Notes.Read"],
+    "llmTip": "Lists all OneNote section groups (subfolders inside notebooks that contain their own sections and nested section groups) for the user. A section group is a folder-like container — many notebooks use them to organize sections by theme. Default sort is name asc. Supports $expand=sections,sectionGroups,parentNotebook,parentSectionGroup to traverse the full hierarchy. Pair with list-onenote-notebooks for a complete picture of the user's notebook structure."
+  },
+  {
+    "pathPattern": "/me/onenote/notebooks/getNotebookFromWebUrl",
+    "method": "post",
+    "toolName": "get-onenote-notebook-from-web-url",
+    "workScopes": ["Notes.Read"],
+    "contentType": "application/json",
+    "llmTip": "Resolves a OneNote notebook from its web URL (the link a user copies from OneNote / SharePoint / Teams). Body: { webUrl: 'https://...' }. Returns a CopyNotebookModel with the notebook's id, displayName, sectionsUrl, sectionGroupsUrl, and isShared — you can then list its sections via list-onenote-notebook-sections. Accepts user notebooks, group notebooks, and SharePoint-hosted team notebooks. Personal Microsoft accounts are not supported."
   }
 ]


### PR DESCRIPTION
## Summary

Adds 3 OneNote endpoints that complement the existing notebook/section/page coverage by addressing genuine gaps:

| Tool | Method + path | Permission |
| --- | --- | --- |
| `list-onenote-pages` | `GET /me/onenote/pages` | `Notes.Read` |
| `list-onenote-section-groups` | `GET /me/onenote/sectionGroups` | `Notes.Read` |
| `get-onenote-notebook-from-web-url` | `POST /me/onenote/notebooks/getNotebookFromWebUrl` | `Notes.Read` (workScopes only) |

## Why these three

### `list-onenote-pages` — search across all pages

The server already exposes `list-onenote-section-pages` (pages within one section). To find a page when you don't know the section, an agent must currently:

1. `list-onenote-notebooks` → pick one
2. `list-onenote-notebook-sections` for each notebook
3. `list-onenote-section-pages` for each section
4. Scan titles client-side

`GET /me/onenote/pages` collapses this to one call, supports `$search='topic'` for full-text page-body search, and returns the same `page` resource. Default is top 20 by `lastModifiedTime desc`. Critical for "find the page about Q3 plan" agentic workflows.

### `list-onenote-section-groups` — the missing structural piece

Section groups are sub-folders inside a notebook that contain their own sections (and nested section groups). Many corporate notebooks rely on them for thematic organization. None of the existing tools (`list-onenote-notebooks`, `list-all-onenote-sections`, `list-onenote-notebook-sections`) traverses or returns them, so an agent's mental model of the user's notebooks is partial. Supports `\$expand=sections,sectionGroups,parentNotebook,parentSectionGroup` for full-tree retrieval.

### `get-onenote-notebook-from-web-url` — link → notebook resolution

Common Teams workflow: a colleague pastes a OneNote / SharePoint / Teams notebook link in a chat, and an agent needs to operate on that notebook. This action takes the URL and returns a `CopyNotebookModel` with the notebook id, sectionsUrl, sectionGroupsUrl, and isShared. Mirrors the `parse-teams-url` pattern already in the codebase for Teams meeting links.

Personal Microsoft accounts are **not supported** on this action per Microsoft Graph spec — entry uses `workScopes` only.

## What I deliberately left out

- `GET /me/onenote/resources` — Microsoft docs explicitly state collection listing is not supported (only fetching a specific resource by id). Would be a misleading addition.
- `GET /me/onenote/operations` — same caveat: \"Getting an operations collection isn't supported\". Specific-id polling (`/operations/{id}`) is only useful when paired with copy actions, which aren't currently exposed in this server.

## Test plan

- [x] JSON validates (`node -e \"JSON.parse(...)\"`); 274 entries (+3)
- [x] `npm run generate` regenerates `src/generated/client.ts` cleanly
- [x] `npx vitest run test/endpoints-validation.test.ts` — 3 new entries map to generated client (no orphans)
- [x] Full vitest suite: 191/191 tests pass
- [ ] Manual smoke test against a tenant with a OneNote notebook (post-merge)