### PR TITLE
feat: add contact folder CRUD and folder-scoped contact endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ CLAUDE.md
 
 # Finder metadata files
 .DS_Store
+
+# LCI-internal deployment notes (kept local-only)
+DEPLOY.md

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1875,5 +1875,47 @@
     "toolName": "create-outlook-category",
     "scopes": ["MailboxSettings.ReadWrite"],
     "llmTip": "Creates a new Outlook category. Body: { displayName (unique), color (one of: none, preset0 … preset24 — maps to red, orange, yellow, green, teal, olive, blue, purple, cranberry, steel, dark-steel, gray, dark-gray, black, dark-red, dark-orange, dark-yellow, dark-green, dark-teal, dark-olive, dark-blue, dark-purple, dark-cranberry) }. Category names are case-sensitive when applied to messages/events."
+  },
+  {
+    "pathPattern": "/me/contactFolders",
+    "method": "get",
+    "toolName": "list-contact-folders",
+    "scopes": ["Contacts.Read"],
+    "llmTip": "Lists the user's Outlook contact folders (the named buckets that organize contacts). Always includes the built-in 'Contacts' folder; user-created folders also appear. Returns id, displayName, parentFolderId, and wellKnownName ('contacts' for the default). Use this before list-contact-folder-contacts or create-contact-in-folder to discover folder ids. Supports $filter, $top, $orderby."
+  },
+  {
+    "pathPattern": "/me/contactFolders",
+    "method": "post",
+    "toolName": "create-contact-folder",
+    "scopes": ["Contacts.ReadWrite"],
+    "llmTip": "Creates a new contact folder under the user's mailbox root. Body: { displayName: 'Family' }. Returns the created contactFolder with its id. Folder names must be unique among siblings. To create a sub-folder, POST to /me/contactFolders/{parent-id}/childFolders instead — not currently exposed."
+  },
+  {
+    "pathPattern": "/me/contactFolders/{contactFolder-id}",
+    "method": "patch",
+    "toolName": "update-contact-folder",
+    "scopes": ["Contacts.ReadWrite"],
+    "llmTip": "Renames a contact folder. Body: { displayName: 'New name' }. Only displayName is writable. The default 'Contacts' folder cannot be renamed — Graph returns an error. Get the folder id via list-contact-folders."
+  },
+  {
+    "pathPattern": "/me/contactFolders/{contactFolder-id}",
+    "method": "delete",
+    "toolName": "delete-contact-folder",
+    "scopes": ["Contacts.ReadWrite"],
+    "llmTip": "Deletes a contact folder and ALL contacts in it (cascades). The default 'Contacts' folder cannot be deleted — Graph returns an error. Get the folder id via list-contact-folders. Operation is irreversible."
+  },
+  {
+    "pathPattern": "/me/contactFolders/{contactFolder-id}/contacts",
+    "method": "get",
+    "toolName": "list-contact-folder-contacts",
+    "scopes": ["Contacts.Read"],
+    "llmTip": "Lists contacts inside a specific folder. Pair with list-contact-folders to discover the folder id. Note: the existing list-outlook-contacts (GET /me/contacts) only returns contacts from the default folder — use this tool to read contacts from any folder. Supports $filter, $search='query', $orderby, $top, $select."
+  },
+  {
+    "pathPattern": "/me/contactFolders/{contactFolder-id}/contacts",
+    "method": "post",
+    "toolName": "create-contact-in-folder",
+    "scopes": ["Contacts.ReadWrite"],
+    "llmTip": "Creates a contact inside a specific folder (instead of the default Contacts folder). Body is a contact resource: { givenName, surname, displayName, emailAddresses: [{ address, name }], businessPhones: [], mobilePhone, jobTitle, companyName, ... }. The existing create-outlook-contact (POST /me/contacts) writes to the default folder only; use this when organizing contacts into named folders. Get the folder id via list-contact-folders."
   }
 ]


### PR DESCRIPTION
## Summary

Adds 6 delegated endpoints that complete the contact-organization story for Outlook contacts:

| Tool | Method + path | Permission |
| --- | --- | --- |
| `list-contact-folders` | `GET /me/contactFolders` | `Contacts.Read` |
| `create-contact-folder` | `POST /me/contactFolders` | `Contacts.ReadWrite` |
| `update-contact-folder` | `PATCH /me/contactFolders/{contactFolder-id}` | `Contacts.ReadWrite` |
| `delete-contact-folder` | `DELETE /me/contactFolders/{contactFolder-id}` | `Contacts.ReadWrite` |
| `list-contact-folder-contacts` | `GET /me/contactFolders/{contactFolder-id}/contacts` | `Contacts.Read` |
| `create-contact-in-folder` | `POST /me/contactFolders/{contactFolder-id}/contacts` | `Contacts.ReadWrite` |

## Why these six

The server already exposes full CRUD on `/me/contacts` (the default Contacts folder):

- `list-outlook-contacts`, `get-outlook-contact`
- `create-outlook-contact`, `update-outlook-contact`, `delete-outlook-contact`

But **contact folders themselves were entirely inaccessible** — agents could neither discover, create, rename, nor delete the named buckets that organize contacts. They also could not read or write contacts in any folder other than the default one, since `/me/contacts` is hard-scoped to the default folder by Microsoft Graph convention (no `?folderId=` query parameter exists).

This split delivers two complementary clusters:

1. **Folder CRUD (4 tools)** — full lifecycle for the named buckets (\"Family\", \"Suppliers\", \"Q3 prospects\").
2. **Folder-scoped contact ops (2 tools)** — `list-contact-folder-contacts` to read contacts from any folder, `create-contact-in-folder` to add contacts directly to a non-default folder.

Combined, this enables a complete \"organize my contacts by group\" workflow from MCP — discover folders, create new ones, move contacts in by addressing the right path, rename or delete folders as needed.

## Permissions

Match the existing Outlook contact convention in this file:

- Reads → `Contacts.Read` (least privileged)
- Writes → `Contacts.ReadWrite`

Both work and personal Microsoft accounts are supported on all six.

## Edge cases the llmTips warn about

- Default folder restrictions: the built-in `Contacts` folder cannot be renamed or deleted — Graph returns an error.
- `delete-contact-folder` cascades: deleting a folder also deletes ALL contacts in it. The llmTip flags this so an agent doesn't trigger irreversible data loss inadvertently.
- `create-contact-in-folder` distinguishes itself from the existing `create-outlook-contact` (default-folder-only).

## Out of scope

- Sub-folder creation (`POST /me/contactFolders/{id}/childFolders`) — happy to add as a follow-up; left out here to keep this PR focused on the top-level workflow.
- `GET /me/contactFolders/{id}` (single-folder fetch) — low value when `list-contact-folders` returns the same data for all folders in one call.

## Test plan

- [x] JSON validates; 277 entries (+6)
- [x] `npm run generate` regenerates `src/generated/client.ts` cleanly
- [x] `npx vitest run test/endpoints-validation.test.ts` — 6 new entries map to generated client (no orphans)
- [x] Full vitest suite: 191/191 tests pass
- [ ] Manual smoke test against a tenant (post-merge)