### PR TITLE
feat: add calendar sharing and delegate permission endpoints

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1897,5 +1897,33 @@
     "toolName": "list-supported-languages",
     "scopes": ["User.Read"],
     "llmTip": "Lists locales and languages the user's mailbox server supports for the Outlook UI and message rendering. Returns localeInfo objects with locale (e.g. 'en-US'), displayName ('English (United States)'), and nativeName ('English (United States)'). Use this to validate the locale value before calling update-mailbox-settings to change the user's preferred language."
+  },
+  {
+    "pathPattern": "/me/calendar/calendarPermissions",
+    "method": "get",
+    "toolName": "list-my-calendar-permissions",
+    "scopes": ["Calendars.Read"],
+    "llmTip": "Lists share recipients and delegates on the user's primary calendar. Returns calendarPermission objects with id, role ('none' | 'freeBusyRead' | 'limitedRead' | 'read' | 'write' | 'delegateWithoutPrivateEventAccess' | 'delegateWithPrivateEventAccess' | 'custom'), emailAddress { name, address }, isInsideOrganization, isRemovable, allowedRoles. Returns an empty collection when called by a delegate or share recipient (only the calendar owner sees the full list). For a non-primary calendar, use /me/calendars/{calendar-id}/calendarPermissions — not currently exposed."
+  },
+  {
+    "pathPattern": "/me/calendar/calendarPermissions",
+    "method": "post",
+    "toolName": "create-my-calendar-permission",
+    "scopes": ["Calendars.ReadWrite"],
+    "llmTip": "Shares the user's primary calendar with another user (or sets up a delegate). Body: { emailAddress: { name: 'Adele Vance', address: 'adele@contoso.com' }, role: 'read' | 'write' | 'delegateWithoutPrivateEventAccess' | 'delegateWithPrivateEventAccess', isInsideOrganization: true, isRemovable: true }. Use list-users to resolve the recipient SMTP. Returns the created calendarPermission with its id (used by update-my-calendar-permission and delete-my-calendar-permission)."
+  },
+  {
+    "pathPattern": "/me/calendar/calendarPermissions/{calendarPermission-id}",
+    "method": "patch",
+    "toolName": "update-my-calendar-permission",
+    "scopes": ["Calendars.ReadWrite"],
+    "llmTip": "Changes the role (permission level) granted to an existing share recipient or delegate. Body: { role: 'read' | 'write' | 'delegateWithoutPrivateEventAccess' | 'delegateWithPrivateEventAccess' }. Only the role property is writable — to change the recipient's email or other properties, delete and recreate via delete-my-calendar-permission + create-my-calendar-permission. Get the permission id via list-my-calendar-permissions."
+  },
+  {
+    "pathPattern": "/me/calendar/calendarPermissions/{calendarPermission-id}",
+    "method": "delete",
+    "toolName": "delete-my-calendar-permission",
+    "scopes": ["Calendars.ReadWrite"],
+    "llmTip": "Revokes a calendar share or delegate access. Get the permission id via list-my-calendar-permissions. Permissions where isRemovable=false (e.g. the implicit 'My Organization' default) cannot be deleted — Graph returns an error."
   }
 ]


### PR DESCRIPTION
## Summary

Adds 4 delegated endpoints that enable agents to drive the Outlook calendar-sharing surface:

| Tool | Method + path | Permission |
| --- | --- | --- |
| `list-my-calendar-permissions` | `GET /me/calendar/calendarPermissions` | `Calendars.Read` |
| `create-my-calendar-permission` | `POST /me/calendar/calendarPermissions` | `Calendars.ReadWrite` |
| `update-my-calendar-permission` | `PATCH /me/calendar/calendarPermissions/{calendarPermission-id}` | `Calendars.ReadWrite` |
| `delete-my-calendar-permission` | `DELETE /me/calendar/calendarPermissions/{calendarPermission-id}` | `Calendars.ReadWrite` |

## Why

The server already covers calendar CRUD (`list-calendars`, `create-calendar`, `update-calendar`, `delete-calendar`), event CRUD, and free/busy lookups (`get-schedule`, `find-meeting-times`) — but had no surface for the *people* dimension of a calendar: who has been granted access, at what level, and how to grant or revoke that access.

This fills the gap end to end:

- **list** returns share recipients and delegates with their `role` (`freeBusyRead`, `limitedRead`, `read`, `write`, `delegateWithoutPrivateEventAccess`, `delegateWithPrivateEventAccess`, etc.), `emailAddress`, `isInsideOrganization`, `isRemovable`, `allowedRoles`.
- **create** grants access by email + role — the API equivalent of \"Share this calendar with…\" in Outlook.
- **update** changes the `role` for an existing share or delegate.
- **delete** revokes access.

## Microsoft Graph quirks the llmTips flag

- **Update is `role`-only.** Per Microsoft Graph spec, only the `role` property of a `calendarPermission` is writable. Changing the recipient's `emailAddress`, `allowedRoles`, `isInsideOrganization`, or `isRemovable` requires deleting and recreating the permission. The `update-my-calendar-permission` llmTip names this explicitly so agents don't waste a turn attempting an unsupported PATCH.
- **Default `My Organization` permission cannot be deleted.** Graph implicitly creates a permission with `isRemovable=false` for the user's organization; deleting it fails with an error. The `delete-my-calendar-permission` llmTip warns about this.
- **List behavior is owner-only.** Calling `list-my-calendar-permissions` from a delegate or share recipient's account returns an empty collection — only the calendar owner sees the full list. Documented on the Microsoft Learn page; the llmTip surfaces it.
- **Scope is the primary calendar.** This PR covers `/me/calendar/calendarPermissions` only. For non-primary calendars (`/me/calendars/{calendar-id}/calendarPermissions`), happy to add as a follow-up if useful.

## Permissions

Match the existing calendar convention:
- Reads → `Calendars.Read`
- Writes → `Calendars.ReadWrite`

Both work and personal Microsoft accounts are supported.

## Test plan

- [x] JSON validates (`node -e \"JSON.parse(...)\"`); 275 entries (+4)
- [x] `npm run generate` regenerates `src/generated/client.ts` cleanly
- [x] `npx vitest run test/endpoints-validation.test.ts` — 4 new entries map to generated client (no orphans)
- [x] Full vitest suite: 191/191 tests pass
- [ ] Manual smoke test against a tenant (post-merge)