### PR TITLE
feat: add MailTips and supported time zone/language lookups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ CLAUDE.md
 
 # Finder metadata files
 .DS_Store
+
+# LCI-internal deployment notes (kept local-only)
+DEPLOY.md

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1875,5 +1875,27 @@
     "toolName": "create-outlook-category",
     "scopes": ["MailboxSettings.ReadWrite"],
     "llmTip": "Creates a new Outlook category. Body: { displayName (unique), color (one of: none, preset0 … preset24 — maps to red, orange, yellow, green, teal, olive, blue, purple, cranberry, steel, dark-steel, gray, dark-gray, black, dark-red, dark-orange, dark-yellow, dark-green, dark-teal, dark-olive, dark-blue, dark-purple, dark-cranberry) }. Category names are case-sensitive when applied to messages/events."
+  },
+  {
+    "pathPattern": "/me/getMailTips",
+    "method": "post",
+    "toolName": "get-mail-tips",
+    "scopes": ["Mail.Read"],
+    "contentType": "application/json",
+    "llmTip": "Looks up MailTips for one or more recipients before sending an email — answers 'is this person on auto-reply / OOF?', 'will my email exceed their mailbox quota?', 'are they an external recipient?', 'is this a mailbox or distribution list?'. Body: { EmailAddresses: ['user@contoso.com', ...] (max 100), MailTipsOptions: 'automaticReplies, mailboxFullStatus, customMailTip, externalMemberCount, totalMemberCount, maxMessageSize, deliveryRestriction, moderationStatus, recipientScope, recipientSuggestions' (comma-separated subset) }. Returns mailTips per recipient with the requested fields populated. Use this to short-circuit urgent emails when a recipient is OOF, or to warn before fanning out to a large DL."
+  },
+  {
+    "pathPattern": "/me/outlook/supportedTimeZones(TimeZoneStandard='{TimeZoneStandard}')",
+    "method": "get",
+    "toolName": "list-supported-time-zones",
+    "scopes": ["User.Read"],
+    "llmTip": "Lists time zones the user's mailbox server supports. TimeZoneStandard path parameter must be one of: 'windows' (default — Windows time zone names like 'Pacific Standard Time'), or 'iana' (IANA / Olson names like 'America/Los_Angeles'). Returns timeZoneInformation objects with alias and displayName. Use the result to validate or look up the value before calling update-mailbox-settings to change the user's preferred timeZone — the format must match what the server expects."
+  },
+  {
+    "pathPattern": "/me/outlook/supportedLanguages()",
+    "method": "get",
+    "toolName": "list-supported-languages",
+    "scopes": ["User.Read"],
+    "llmTip": "Lists locales and languages the user's mailbox server supports for the Outlook UI and message rendering. Returns localeInfo objects with locale (e.g. 'en-US'), displayName ('English (United States)'), and nativeName ('English (United States)'). Use this to validate the locale value before calling update-mailbox-settings to change the user's preferred language."
   }
 ]


### PR DESCRIPTION
## Summary

Adds 3 delegated endpoints that surface Outlook server-side reference data and pre-send recipient context — small but high-leverage for agentic workflows:

| Tool | Method + path | Permission |
| --- | --- | --- |
| `get-mail-tips` | `POST /me/getMailTips` | `Mail.Read` |
| `list-supported-time-zones` | `GET /me/outlook/supportedTimeZones(TimeZoneStandard='{TimeZoneStandard}')` | `User.Read` |
| `list-supported-languages` | `GET /me/outlook/supportedLanguages()` | `User.Read` |

## Why

### `get-mail-tips` — pre-send recipient context

The high-value addition. Before sending an urgent email, agents can ask Graph:

- Is this recipient on **auto-reply (OOF)**?
- Will the message exceed their **mailbox quota**?
- Are they an **external recipient**?
- Is this address a **mailbox** or a **distribution list**?
- For a DL, what's the **member count**?

The Graph API answers all of that in one POST per up-to-100 recipients via the `MailTipsOptions` flag list (`automaticReplies`, `mailboxFullStatus`, `customMailTip`, `externalMemberCount`, `totalMemberCount`, `maxMessageSize`, `deliveryRestriction`, `moderationStatus`, `recipientScope`, `recipientSuggestions`).

Use cases: short-circuit urgent emails when a recipient is OOF; warn before fanning out to a large DL; choose the right send-channel (DL vs individual escalation).

### `list-supported-time-zones` and `list-supported-languages` — reference data for `update-mailbox-settings`

These pair with the existing `update-mailbox-settings` tool. To set the user's preferred `timeZone` or `locale`, an agent must first know the values the server accepts. The time-zone endpoint takes a path parameter (`windows` | `iana`) to choose the returned format — important because the existing Outlook tooling assumes Windows time zone names (`'Pacific Standard Time'`), which can trip agents that natively work with IANA (`'America/Los_Angeles'`).

`list-supported-languages` returns `localeInfo` objects with `locale`, `displayName`, and `nativeName` — what `update-mailbox-settings.language.locale` expects.

## Permissions

- `get-mail-tips` → `Mail.Read` (recipient hints are mail-scoped data)
- both `supported*` endpoints → `User.Read` (mailbox-server reference data tied to the user resource)

All three support both work and personal Microsoft accounts.

## Notes

- The `MailTipsOptions` parameter on `get-mail-tips` is a comma-separated subset string per Graph spec, not an array. The llmTip flags this so an agent doesn't pass a JS array literal.
- The `TimeZoneStandard` path parameter is required — there's a separate (unparametrized) `/me/outlook/supportedTimeZones` endpoint that defaults to Windows, but exposing the parametrized variant lets agents request IANA without any extra plumbing.

## Test plan

- [x] JSON validates (`node -e \"JSON.parse(...)\"`); 274 entries (+3)
- [x] `npm run generate` regenerates `src/generated/client.ts` cleanly
- [x] `npx vitest run test/endpoints-validation.test.ts` — 3 new entries map to generated client (no orphans)
- [x] Full vitest suite: 191/191 tests pass
- [ ] Manual smoke test against a tenant (post-merge) — `get-mail-tips` against a known-OOF colleague should surface the auto-reply text