### PR TITLE
fix(logger): restrict log file permissions to owner-only (CWE-532)

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -10,7 +10,37 @@ const logsDir =
 
 if (!fs.existsSync(logsDir)) {
   fs.mkdirSync(logsDir, { recursive: true, mode: 0o700 });
+} else {
+  // Tighten permissions on a pre-existing log directory in case it was created
+  // with a more permissive umask.
+  try {
+    fs.chmodSync(logsDir, 0o700);
+  } catch {
+    // Best-effort — on platforms that don't support chmod (e.g. Windows) this
+    // is a no-op.
+  }
 }
+
+// Restrict log file mode to owner-only (0o600). Log files may contain error
+// messages from upstream libraries (MSAL, fetch, etc.) which can incidentally
+// include token fragments or other sensitive material; on shared/multi-user
+// systems the default umask may otherwise leave them world-readable.
+const FILE_MODE = 0o600;
+
+function ensureFileMode(filePath: string): void {
+  try {
+    if (fs.existsSync(filePath)) {
+      fs.chmodSync(filePath, FILE_MODE);
+    }
+  } catch {
+    // Best-effort — chmod is unsupported on some platforms (e.g. Windows).
+  }
+}
+
+const errorLogPath = path.join(logsDir, 'error.log');
+const serverLogPath = path.join(logsDir, 'mcp-server.log');
+ensureFileMode(errorLogPath);
+ensureFileMode(serverLogPath);
 
 const logger = winston.createLogger({
   level: process.env.LOG_LEVEL || 'info',
@@ -24,11 +54,13 @@ const logger = winston.createLogger({
   ),
   transports: [
     new winston.transports.File({
-      filename: path.join(logsDir, 'error.log'),
+      filename: errorLogPath,
       level: 'error',
+      options: { flags: 'a', mode: FILE_MODE },
     }),
     new winston.transports.File({
-      filename: path.join(logsDir, 'mcp-server.log'),
+      filename: serverLogPath,
+      options: { flags: 'a', mode: FILE_MODE },
     }),
   ],
 });

--- a/test/logger-permissions.test.ts
+++ b/test/logger-permissions.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+describe('logger file permissions (CWE-532)', () => {
+  let tmpDir: string;
+  let prevLogDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms365-mcp-log-perm-'));
+    prevLogDir = process.env.MS365_MCP_LOG_DIR;
+    process.env.MS365_MCP_LOG_DIR = tmpDir;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (prevLogDir === undefined) {
+      delete process.env.MS365_MCP_LOG_DIR;
+    } else {
+      process.env.MS365_MCP_LOG_DIR = prevLogDir;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates log files with owner-only (0o600) permissions', async () => {
+    // Skip on Windows where POSIX modes are not honored
+    if (process.platform === 'win32') return;
+
+    const mod = await import('../src/logger.ts');
+    const logger = mod.default;
+
+    logger.info('permission test message');
+    logger.error('permission test error');
+
+    // Wait for winston to flush.
+    await new Promise((r) => setTimeout(r, 400));
+
+    const serverLog = path.join(tmpDir, 'mcp-server.log');
+    const errorLog = path.join(tmpDir, 'error.log');
+
+    expect(fs.existsSync(serverLog)).toBe(true);
+    expect(fs.existsSync(errorLog)).toBe(true);
+
+    const serverMode = fs.statSync(serverLog).mode & 0o777;
+    const errorMode = fs.statSync(errorLog).mode & 0o777;
+
+    // Group/other bits must be cleared — file must not be readable by other users.
+    expect(serverMode & 0o077).toBe(0);
+    expect(errorMode & 0o077).toBe(0);
+
+    // Directory should also be owner-only.
+    const dirMode = fs.statSync(tmpDir).mode & 0o777;
+    expect(dirMode & 0o077).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Harden file permissions on the winston log files written under `~/.ms-365-mcp-server/logs/` (or `MS365_MCP_LOG_DIR`). Today the `error.log` and `mcp-server.log` files are created using the process default umask, which on most Linux systems means `0644` — i.e. world-readable. Log lines can incidentally include error strings from MSAL or `fetch` (token endpoint diagnostics, refresh failures, etc.) that contain token fragments or other sensitive material, so on shared/multi-user hosts a local unprivileged user could read them.

This is **CWE-532: Insertion of Sensitive Information into Log File** — low/defense-in-depth severity, but a clean and narrow fix.

- Affected file: `src/logger.ts`
- Affected sinks: both `winston.transports.File` instances (`error.log`, `mcp-server.log`)
- Data flow: `logger.error(err)` / `logger.info(...)` from `src/server.ts` and `src/lib/microsoft-auth.ts` → winston File transport → world-readable file on disk

## Fix

`src/logger.ts`:
1. Pass `options: { flags: 'a', mode: 0o600 }` to both `winston.transports.File` constructors so newly created log files are owner-only.
2. On startup, `chmod` the log directory to `0o700` if it already exists, and `chmod` any pre-existing `error.log` / `mcp-server.log` to `0o600`. This retrofits installations that already have permissive log files from earlier runs.
3. All `chmod` calls are wrapped in try/catch so behavior on Windows (where POSIX modes aren't honored) is unchanged.

The directory creation path already used `mode: 0o700` — this PR makes the file mode consistent with that intent and covers the upgrade path.

No other file transports exist in the codebase, so there are no parallel log paths that would re-introduce the issue.

## Test results

Added `test/logger-permissions.test.ts`, which:
- points `MS365_MCP_LOG_DIR` at a fresh tmp dir,
- imports the logger and writes one `info` and one `error` line,
- waits for winston to flush, then asserts that `mcp-server.log`, `error.log`, and the directory all have group/other bits cleared (`mode & 0o077 === 0`).
- skips on `win32` since POSIX modes don't apply.

Local run:

```
✓ test/logger-permissions.test.ts (1 test) 458ms
  ✓ logger file permissions (CWE-532) > creates log files with owner-only (0o600) permissions
Test Files  1 passed (1)
```

## Security analysis

Preconditions for exploitation:
- A local unprivileged user on the same host as the MCP server process.
- A permissive umask (typically `022` on Linux servers) so that log files default to `0644`.
- Sensitive material reaching the log — most plausibly through `logger.error(err)` calls where the error message comes from MSAL or a `fetch` failure against the token endpoint and includes token fragments, refresh-token error context, or PKCE/code material.

After the fix, even with a permissive umask the log files are created `0o600` and the directory `0o700`, so only the owning user (and root) can read them. Pre-existing files are tightened on next startup.

## Adversarial review

Before submitting, we tried to disprove this. The log directory was already created with `0o700`, which suggests the intent was already owner-only — but that does not constrain the *file* mode, and on Linux the file inside a `0o700` directory is still created `0o644`, meaning anyone who can stat a path inside the dir (e.g. via a hard link, or because the dir mode gets loosened, or because a backup tool runs as another user) can read its contents. We also checked whether there are framework-level mitigations (there aren't — winston respects whatever mode you pass, and defaults to none) and whether macOS home directory perms (`0o750`) make this moot (they help, but Linux servers are the realistic deployment target). The fix is small, behavior-preserving on Windows, and improves defense-in-depth on the platforms where the issue is real.

cc @lewiswigmore
