### PR TITLE
feat: add reply/replyAll/forward tools for shared mailboxes

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -107,6 +107,27 @@
     "workScopes": ["Mail.ReadWrite.Shared"]
   },
   {
+    "pathPattern": "/users/{user-id}/messages/{message-id}/reply",
+    "method": "post",
+    "toolName": "reply-shared-mailbox-mail",
+    "workScopes": ["Mail.Send.Shared"],
+    "llmTip": "Reply to a message from a shared mailbox preserving full HTML formatting and conversation thread. The 'user-id' is the shared mailbox email address (e.g. support@contoso.com). The 'comment' field is your reply text. Do NOT reconstruct the email manually. Requires Send As permission on the shared mailbox in Exchange."
+  },
+  {
+    "pathPattern": "/users/{user-id}/messages/{message-id}/replyAll",
+    "method": "post",
+    "toolName": "reply-all-shared-mailbox-mail",
+    "workScopes": ["Mail.Send.Shared"],
+    "llmTip": "Reply-all to a message from a shared mailbox preserving full HTML formatting and conversation thread. The 'user-id' is the shared mailbox email address. The 'comment' field is your reply text. Requires Send As permission on the shared mailbox in Exchange."
+  },
+  {
+    "pathPattern": "/users/{user-id}/messages/{message-id}/forward",
+    "method": "post",
+    "toolName": "forward-shared-mailbox-mail",
+    "workScopes": ["Mail.Send.Shared"],
+    "llmTip": "Forward a message from a shared mailbox preserving full HTML formatting and attachments. The 'user-id' is the shared mailbox email address. 'toRecipients' is required. The 'comment' field adds text above the forwarded content. Requires Send As permission on the shared mailbox in Exchange."
+  },
+  {
     "pathPattern": "/users",
     "method": "get",
     "toolName": "list-users",


### PR DESCRIPTION
## Summary

Adds three endpoints to expose the dedicated reply, reply-all and forward Graph operations for shared mailboxes:

- `POST /users/{user-id}/messages/{message-id}/reply` → `reply-shared-mailbox-mail`
- `POST /users/{user-id}/messages/{message-id}/replyAll` → `reply-all-shared-mailbox-mail`
- `POST /users/{user-id}/messages/{message-id}/forward` → `forward-shared-mailbox-mail`

All three use `Mail.Send.Shared`, consistent with the existing `send-shared-mailbox-mail`.

## Motivation

The server already exposes:

- `reply-mail-message`, `reply-all-mail-message`, `forward-mail-message` for personal mailboxes (`/me/messages/{id}/{action}`)
- `send-shared-mailbox-mail` and `create-shared-mailbox-draft` for shared mailboxes

The matching reply/replyAll/forward operations on shared mailboxes were missing. Without them, an agent answering a message in a shared support inbox has to fall back to `send-shared-mailbox-mail` and reconstruct the email manually, which loses the conversation thread, headers and HTML formatting in Outlook.

Routing through the dedicated Graph actions lets the server preserve all of that automatically.

## References

- https://learn.microsoft.com/en-us/graph/api/message-reply
- https://learn.microsoft.com/en-us/graph/api/message-replyall
- https://learn.microsoft.com/en-us/graph/api/message-forward

## Test plan

- `npm run verify` passes locally (generate + lint + format + build + 192 tests)
- Diff is limited to `src/endpoints.json` (21 lines added)

## Note

A previous attempt at adding these endpoints was opened as #190 by an external contributor and closed without review. This PR implements only the three shared-mailbox actions, leaves the existing `*-mail-message` tools untouched, and does not change any `llmTip` on existing endpoints.