### PR TITLE
fix(oauth): honor preset/enabled-tools/read-only on /authorize

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -436,34 +436,29 @@ class MicrosoftGraphServer {
         // Use our Microsoft app's client_id
         microsoftAuthUrl.searchParams.set('client_id', clientId);
 
-        if (!microsoftAuthUrl.searchParams.get('scope')) {
-          const computedScopes = buildScopesFromEndpoints(
-            this.options.orgMode,
-            this.options.enabledTools,
-            this.options.readOnly
-          );
-          microsoftAuthUrl.searchParams.set(
-            'scope',
-            [...computedScopes, 'offline_access'].join(' ')
-          );
-        } else {
-          // Inject offline_access silently here (not advertised in scopes_supported)
-          // so Entra ID issues a refresh token, enabling silent token refresh after
-          // the access token expires. We deliberately do NOT add offline_access to
-          // buildScopesFromEndpoints(): advertising the scope in OAuth metadata made
-          // MCP clients request it explicitly, which triggers a "Maintain access to
-          // data" consent line that fails in tenants where user consent for
-          // applications is restricted by policy (even when admin has pre-consented
-          // every scope). Injecting silently in the forwarding path gives Entra
-          // what it needs to issue a refresh token without surfacing the scope to
-          // the client.
-          const scopeValue = microsoftAuthUrl.searchParams.get('scope')!;
-          const scopeList = scopeValue.split(/\s+/).filter(Boolean);
-          if (!scopeList.includes('offline_access')) {
-            scopeList.push('offline_access');
-            microsoftAuthUrl.searchParams.set('scope', scopeList.join(' '));
-          }
-        }
+        // Determine base scopes from the client request or from the user's
+        // configuration flags, then silently inject User.Read and offline_access.
+        // Neither is advertised in scopes_supported:
+        //   - User.Read: needed by Microsoft Graph /me access, which the
+        //     token-verification and login-test code paths rely on. Without
+        //     it, narrow presets (e.g. search-only) would produce tokens that
+        //     can't validate against /me.
+        //   - offline_access: needed so Entra ID issues a refresh token for
+        //     silent renewal. Advertising it in OAuth metadata made MCP
+        //     clients request it explicitly, which triggers a "Maintain
+        //     access to data" consent line that fails in tenants where user
+        //     consent for applications is restricted by policy (even when
+        //     admin has pre-consented every scope).
+        const clientScope = microsoftAuthUrl.searchParams.get('scope');
+        const baseScopes = clientScope
+          ? clientScope.split(/\s+/).filter(Boolean)
+          : buildScopesFromEndpoints(
+              this.options.orgMode,
+              this.options.enabledTools,
+              this.options.readOnly
+            );
+        const scopeSet = new Set([...baseScopes, 'User.Read', 'offline_access']);
+        microsoftAuthUrl.searchParams.set('scope', Array.from(scopeSet).join(' '));
 
         // Redirect to Microsoft's authorization page
         res.redirect(microsoftAuthUrl.toString());

--- a/src/server.ts
+++ b/src/server.ts
@@ -253,7 +253,11 @@ class MicrosoftGraphServer {
         const requestOrigin = `${protocol}://${req.get('host')}`;
         const browserBase = publicBase ?? requestOrigin;
 
-        const scopes = buildScopesFromEndpoints(this.options.orgMode, this.options.enabledTools);
+        const scopes = buildScopesFromEndpoints(
+          this.options.orgMode,
+          this.options.enabledTools,
+          this.options.readOnly
+        );
 
         const metadata: Record<string, unknown> = {
           issuer: browserBase,
@@ -282,7 +286,11 @@ class MicrosoftGraphServer {
 
         const scopes = this.options.obo
           ? [`api://${this.secrets!.clientId}/access_as_user`]
-          : buildScopesFromEndpoints(this.options.orgMode, this.options.enabledTools);
+          : buildScopesFromEndpoints(
+              this.options.orgMode,
+              this.options.enabledTools,
+              this.options.readOnly
+            );
 
         res.json({
           resource: `${requestOrigin}/mcp`,
@@ -428,11 +436,15 @@ class MicrosoftGraphServer {
         // Use our Microsoft app's client_id
         microsoftAuthUrl.searchParams.set('client_id', clientId);
 
-        // Ensure we have the minimal required scopes if none provided
         if (!microsoftAuthUrl.searchParams.get('scope')) {
+          const computedScopes = buildScopesFromEndpoints(
+            this.options.orgMode,
+            this.options.enabledTools,
+            this.options.readOnly
+          );
           microsoftAuthUrl.searchParams.set(
             'scope',
-            'User.Read Files.Read Mail.Read offline_access'
+            [...computedScopes, 'offline_access'].join(' ')
           );
         } else {
           // Inject offline_access silently here (not advertised in scopes_supported)

--- a/test/scope-derivation.test.ts
+++ b/test/scope-derivation.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { buildScopesFromEndpoints } from '../src/auth.js';
+
+describe('buildScopesFromEndpoints', () => {
+  it('returns a non-empty scope set with default arguments', () => {
+    const scopes = buildScopesFromEndpoints();
+    expect(scopes.length).toBeGreaterThan(0);
+    // Scope hierarchy collapses Read into ReadWrite when both endpoints exist.
+    expect(scopes).toContain('Mail.ReadWrite');
+    expect(scopes).not.toContain('Mail.Read');
+  });
+
+  describe('readOnly flag', () => {
+    it('downgrades Mail.ReadWrite to Mail.Read', () => {
+      const scopes = buildScopesFromEndpoints(false, undefined, true);
+      expect(scopes).toContain('Mail.Read');
+      expect(scopes).not.toContain('Mail.ReadWrite');
+    });
+
+    it('excludes scopes that only appear on write endpoints', () => {
+      expect(buildScopesFromEndpoints(false, undefined, false)).toContain('Mail.Send');
+      expect(buildScopesFromEndpoints(false, undefined, true)).not.toContain('Mail.Send');
+    });
+  });
+
+  describe('enabledTools filter', () => {
+    it('narrows the scope set when a pattern is provided', () => {
+      const all = buildScopesFromEndpoints(true, undefined, false);
+      const filtered = buildScopesFromEndpoints(true, 'search|query', false);
+      expect(filtered.length).toBeLessThan(all.length);
+    });
+
+    it('returns an empty array when no tools match the pattern', () => {
+      expect(buildScopesFromEndpoints(true, 'no-such-tool-xyzzy', false)).toEqual([]);
+    });
+  });
+
+  describe('orgMode flag', () => {
+    it('includes work-only scopes when orgMode is true', () => {
+      const personal = buildScopesFromEndpoints(false, undefined, false);
+      const org = buildScopesFromEndpoints(true, undefined, false);
+      expect(org.length).toBeGreaterThan(personal.length);
+      expect(org).toContain('Sites.Read.All');
+      expect(personal).not.toContain('Sites.Read.All');
+    });
+  });
+
+  describe('org-mode + read-only + "search|query" filter', () => {
+    const scopes = buildScopesFromEndpoints(true, 'search|query', true);
+
+    it('excludes Mail.Read (only the POST search-query endpoint needs it)', () => {
+      expect(scopes).not.toContain('Mail.Read');
+      expect(scopes).not.toContain('Mail.ReadWrite');
+    });
+
+    it('includes Files.Read and Sites.Read.All for read-only search tools', () => {
+      expect(scopes).toContain('Files.Read');
+      expect(scopes).toContain('Sites.Read.All');
+    });
+  });
+});


### PR DESCRIPTION
Closes #459.

The `/authorize` handler had a hardcoded `User.Read Files.Read Mail.Read offline_access` fallback whenever the MCP client didn't pass `scope`, ignoring `--preset`, `--enabled-tools`, `--org-mode`, and `--read-only`. Tenants whose app reg didn't include `Mail.Read` got blocked on consent even though `--list-permissions` showed they didn't need it.

Both `/authorize` and the two `/.well-known/*` handlers now route through the same `buildScopesFromEndpoints(orgMode, enabledTools, readOnly)` call that `--list-permissions` uses, so what we advertise and what we request match.

`User.Read` and `offline_access` are still injected silently in the forwarding path (kept out of `scopes_supported` for the same reason offline_access already was) so `/me`-based token verification and refresh-token issuance keep working regardless of preset.