### PR TITLE
feat(logging): structured JSON audit log + auditLog() helper

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -208,6 +208,7 @@ The client automatically discovers OAuth endpoints and opens a browser for authe
 - **Read-only mode**: use `--read-only` to disable all write operations (send, delete, update, create)
 - **Tool filtering**: use `--enabled-tools <regex>` or `--preset <names>` to restrict available tools
 - **CORS**: configure `MS365_MCP_CORS_ORIGIN` to restrict allowed origins (defaults to `http://localhost:3000`); set explicitly when clients run on a different origin
+- **Structured audit log**: enabled by default. Every tool invocation emits one JSON line on stdout (captured by the container platform's log collector) and to `~/.ms-365-mcp-server/logs/audit.log` (mode `0o600`) with `{ event, request_id, user_principal_name, tool, http_method, status, duration_ms, error_type?, error_code? }`. The schema is intentionally narrow — tool parameters and Graph response bodies are NEVER recorded, and error messages are reduced to `error_type` / `error_code` so upstream library errors do not leak token fragments or query-string PII. Forms the "who accessed what, when" trail required for GDPR / HIPAA / PIPEDA / SOC 2 audit. Opt-out: `MS365_MCP_AUDIT_LOG=false`
 
 ## Exposed Endpoints
 

--- a/src/audit-log.ts
+++ b/src/audit-log.ts
@@ -1,0 +1,133 @@
+import winston from 'winston';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+/**
+ * Structured JSON audit log for tool invocations.
+ *
+ * Why a separate logger: the operational logger (`./logger.ts`) emits
+ * human-friendly text and may incidentally include large tool params for
+ * debugging. The audit log has a stricter, machine-parseable shape and a
+ * narrower allowlist of fields — it is the artifact that satisfies the
+ * "who accessed what, when" requirement of data-subject access requests
+ * (DSARs) and audit trails under common privacy regimes (GDPR, HIPAA,
+ * PIPEDA, SOC 2, etc.).
+ *
+ * PII boundaries:
+ *  - `user_principal_name` is the *identity claim* from the bearer token and
+ *    is required for the audit trail to be useful. It IS personal data.
+ *  - `target_resource.id` points at the affected Graph resource but does
+ *    not expose its contents (e.g. a message-id, not the message body).
+ *  - `error_type` / `error_code` are recorded but raw error messages are NOT,
+ *    because upstream library errors can incidentally include token fragments
+ *    or query-string PII.
+ *  - Tool parameters and Graph response bodies are NEVER written here.
+ *
+ * Opt-out: set `MS365_MCP_AUDIT_LOG=false` to disable when audit is
+ * collected through a separate sink (sidecar, OpenTelemetry, etc.).
+ */
+
+const logsDir =
+  process.env.MS365_MCP_LOG_DIR || path.join(os.homedir(), '.ms-365-mcp-server', 'logs');
+
+const FILE_MODE = 0o600;
+const auditLogPath = path.join(logsDir, 'audit.log');
+
+try {
+  if (!fs.existsSync(logsDir)) {
+    fs.mkdirSync(logsDir, { recursive: true, mode: 0o700 });
+  }
+  if (fs.existsSync(auditLogPath)) {
+    fs.chmodSync(auditLogPath, FILE_MODE);
+  }
+} catch {
+  // Best-effort — log directory may be ephemeral (e.g. in containers); the
+  // Console transport below still reaches the platform log collector.
+}
+
+const auditLogger = winston.createLogger({
+  level: 'info',
+  format: winston.format.combine(
+    winston.format.timestamp({ format: 'YYYY-MM-DDTHH:mm:ss.SSSZ' }),
+    winston.format.json()
+  ),
+  defaultMeta: {
+    service: 'ms-365-mcp-server',
+    stream: 'audit',
+  },
+  transports: [
+    new winston.transports.Console({
+      // Container Apps / App Service / Docker capture stdout and forward to
+      // Log Analytics — that is the production audit sink for HTTP mode.
+      // Vitest sets `VITEST=true`; staying silent there avoids polluting
+      // unrelated tests that exercise the real graph-tools module.
+      silent:
+        process.env.SILENT === 'true' ||
+        process.env.SILENT === '1' ||
+        process.env.VITEST === 'true',
+    }),
+    new winston.transports.File({
+      filename: auditLogPath,
+      options: { flags: 'a', mode: FILE_MODE },
+    }),
+  ],
+});
+
+export type AuditStatus = 'success' | 'error' | 'denied';
+
+export interface AuditEvent {
+  event: string;
+  request_id: string;
+  user_principal_name?: string;
+  tool: string;
+  http_method?: string;
+  status: AuditStatus;
+  duration_ms?: number;
+  target_resource?: { type: string; id?: string };
+  error_type?: string;
+  error_code?: string | number;
+}
+
+export function isAuditLogEnabled(): boolean {
+  return process.env.MS365_MCP_AUDIT_LOG !== 'false';
+}
+
+export function auditLog(evt: AuditEvent): void {
+  if (!isAuditLogEnabled()) return;
+  auditLogger.info(evt);
+}
+
+/**
+ * Decode a JWT payload (NO signature verification — that is the auth
+ * middleware's job) and return a stable identity claim suitable for the
+ * audit trail. Returns `undefined` when no usable claim is found or when
+ * the token is malformed.
+ *
+ * Preference order: `upn` → `preferred_username` → `email` → `sub`.
+ */
+export function getUserIdentityForAudit(token?: string): string | undefined {
+  if (!token) return undefined;
+  try {
+    const parts = token.split('.');
+    if (parts.length < 2) return undefined;
+    let b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padNeeded = (4 - (b64.length % 4)) % 4;
+    b64 = b64 + '='.repeat(padNeeded);
+    const payload = JSON.parse(Buffer.from(b64, 'base64').toString('utf-8')) as Record<
+      string,
+      unknown
+    >;
+    const candidate =
+      (payload.upn as string | undefined) ||
+      (payload.preferred_username as string | undefined) ||
+      (payload.email as string | undefined) ||
+      (payload.sub as string | undefined);
+    return typeof candidate === 'string' ? candidate : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Exported for tests.
+export const __testing = { auditLogger, auditLogPath };

--- a/src/audit-log.ts
+++ b/src/audit-log.ts
@@ -58,10 +58,13 @@ const auditLogger = winston.createLogger({
   },
   transports: [
     new winston.transports.Console({
-      // Container Apps / App Service / Docker capture stdout and forward to
-      // Log Analytics — that is the production audit sink for HTTP mode.
-      // Vitest sets `VITEST=true`; staying silent there avoids polluting
-      // unrelated tests that exercise the real graph-tools module.
+      // Route audit events to stderr so they don't collide with JSON-RPC on
+      // stdout when this server runs in stdio mode. Container platforms
+      // (Container Apps, App Service, Docker) capture both stdout and stderr
+      // and forward to Log Analytics, so the production audit sink is
+      // unaffected. Vitest sets `VITEST=true`; staying silent there avoids
+      // polluting unrelated tests that exercise the real graph-tools module.
+      stderrLevels: ['info'],
       silent:
         process.env.SILENT === 'true' ||
         process.env.SILENT === '1' ||

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -1,5 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { randomUUID } from 'crypto';
 import logger from './logger.js';
+import { auditLog, getUserIdentityForAudit } from './audit-log.js';
 import GraphClient from './graph-client.js';
 import AuthManager, {
   getEndpointRequiredScopes,
@@ -288,6 +290,12 @@ async function executeGraphTool(
   authManager?: AuthManager
 ): Promise<CallToolResult> {
   logger.info(`Tool ${tool.alias} called with params: ${JSON.stringify(params)}`);
+
+  const requestId = randomUUID();
+  const startTime = Date.now();
+  const upn = getUserIdentityForAudit(getRequestTokens()?.accessToken);
+  const httpMethod = tool.method.toUpperCase();
+
   try {
     // Resolve account-specific token if `account` parameter is provided (or auto-resolve for single account).
     // Skip in OAuth/HTTP mode — let the request context drive token selection via GraphClient.
@@ -638,13 +646,35 @@ async function executeGraphTool(
       text: item.text,
     }));
 
+    auditLog({
+      event: 'tool.call',
+      request_id: requestId,
+      user_principal_name: upn,
+      tool: tool.alias,
+      http_method: httpMethod,
+      status: response.isError ? 'error' : 'success',
+      duration_ms: Date.now() - startTime,
+    });
+
     return {
       content,
       _meta: response._meta,
       isError: response.isError,
     };
   } catch (error) {
+    const err = error as { name?: string; code?: string | number; status?: string | number };
     logger.error(`Error in tool ${tool.alias}: ${(error as Error).message}`);
+    auditLog({
+      event: 'tool.call',
+      request_id: requestId,
+      user_principal_name: upn,
+      tool: tool.alias,
+      http_method: httpMethod,
+      status: 'error',
+      duration_ms: Date.now() - startTime,
+      error_type: err?.name || 'Error',
+      error_code: err?.status ?? err?.code,
+    });
     return {
       content: [
         {

--- a/test/audit-log.test.ts
+++ b/test/audit-log.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  auditLog,
+  getUserIdentityForAudit,
+  isAuditLogEnabled,
+  __testing,
+} from '../src/audit-log.js';
+
+/**
+ * Tests for the structured JSON audit log.
+ *
+ * The audit log is the artefact downstream deployments rely on for
+ * DSAR / audit-trail compliance (GDPR, HIPAA, PIPEDA, SOC 2, …). It must
+ * emit machine-parseable JSON, never leak token fragments or response
+ * bodies, and be controllable via MS365_MCP_AUDIT_LOG=false for
+ * environments that route audit elsewhere.
+ */
+describe('audit-log', () => {
+  const prevAuditFlag = process.env.MS365_MCP_AUDIT_LOG;
+
+  beforeEach(() => {
+    vi.spyOn(__testing.auditLogger, 'info').mockImplementation(() => __testing.auditLogger);
+  });
+
+  afterEach(() => {
+    if (prevAuditFlag === undefined) delete process.env.MS365_MCP_AUDIT_LOG;
+    else process.env.MS365_MCP_AUDIT_LOG = prevAuditFlag;
+    vi.restoreAllMocks();
+  });
+
+  describe('isAuditLogEnabled', () => {
+    it('returns true by default', () => {
+      delete process.env.MS365_MCP_AUDIT_LOG;
+      expect(isAuditLogEnabled()).toBe(true);
+    });
+
+    it('returns false when MS365_MCP_AUDIT_LOG=false', () => {
+      process.env.MS365_MCP_AUDIT_LOG = 'false';
+      expect(isAuditLogEnabled()).toBe(false);
+    });
+
+    it('any other value keeps audit on', () => {
+      process.env.MS365_MCP_AUDIT_LOG = 'true';
+      expect(isAuditLogEnabled()).toBe(true);
+      process.env.MS365_MCP_AUDIT_LOG = '0';
+      expect(isAuditLogEnabled()).toBe(true); // strict 'false' string only
+    });
+  });
+
+  describe('auditLog', () => {
+    it('forwards the event payload to the audit logger', () => {
+      auditLog({
+        event: 'tool.call',
+        request_id: '00000000-0000-0000-0000-000000000001',
+        user_principal_name: 'alice@example.com',
+        tool: 'list-mail-messages',
+        http_method: 'GET',
+        status: 'success',
+        duration_ms: 123,
+      });
+      expect(__testing.auditLogger.info).toHaveBeenCalledTimes(1);
+      const [payload] = (__testing.auditLogger.info as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(payload).toMatchObject({
+        event: 'tool.call',
+        request_id: '00000000-0000-0000-0000-000000000001',
+        user_principal_name: 'alice@example.com',
+        tool: 'list-mail-messages',
+        http_method: 'GET',
+        status: 'success',
+        duration_ms: 123,
+      });
+    });
+
+    it('does NOT emit when MS365_MCP_AUDIT_LOG=false', () => {
+      process.env.MS365_MCP_AUDIT_LOG = 'false';
+      auditLog({
+        event: 'tool.call',
+        request_id: 'x',
+        tool: 'send-mail',
+        status: 'denied',
+      });
+      expect(__testing.auditLogger.info).not.toHaveBeenCalled();
+    });
+
+    it('accepts all three status values', () => {
+      auditLog({ event: 'tool.call', request_id: '1', tool: 't', status: 'success' });
+      auditLog({ event: 'tool.call', request_id: '2', tool: 't', status: 'error' });
+      auditLog({ event: 'tool.call', request_id: '3', tool: 't', status: 'denied' });
+      expect(__testing.auditLogger.info).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('getUserIdentityForAudit', () => {
+    /**
+     * Build an unsigned JWT-shaped string (`header.payload.signature`) for tests.
+     * Signature verification is the auth middleware's job — the audit helper
+     * intentionally decodes the payload without verifying.
+     */
+    function makeFakeJwt(claims: Record<string, unknown>): string {
+      const b64 = (obj: Record<string, unknown>) =>
+        Buffer.from(JSON.stringify(obj)).toString('base64url');
+      return `${b64({ alg: 'none' })}.${b64(claims)}.sig`;
+    }
+
+    it('returns undefined when no token is provided', () => {
+      expect(getUserIdentityForAudit(undefined)).toBeUndefined();
+      expect(getUserIdentityForAudit('')).toBeUndefined();
+    });
+
+    it('returns undefined for a malformed token', () => {
+      expect(getUserIdentityForAudit('not-a-jwt')).toBeUndefined();
+      expect(getUserIdentityForAudit('only.one')).toBeUndefined();
+      expect(getUserIdentityForAudit('a.@@invalid-base64.c')).toBeUndefined();
+    });
+
+    it('prefers upn over preferred_username, email, sub', () => {
+      const token = makeFakeJwt({
+        upn: 'alice@example.com',
+        preferred_username: 'mbourget@lci.local',
+        email: 'marc@personal.com',
+        sub: 'abcd-1234',
+      });
+      expect(getUserIdentityForAudit(token)).toBe('alice@example.com');
+    });
+
+    it('falls back to preferred_username when upn is missing', () => {
+      const token = makeFakeJwt({
+        preferred_username: 'mbourget@lci.local',
+        sub: 'abcd-1234',
+      });
+      expect(getUserIdentityForAudit(token)).toBe('mbourget@lci.local');
+    });
+
+    it('falls back to email then sub', () => {
+      expect(getUserIdentityForAudit(makeFakeJwt({ email: 'x@y.z' }))).toBe('x@y.z');
+      expect(getUserIdentityForAudit(makeFakeJwt({ sub: 'oid-123' }))).toBe('oid-123');
+    });
+
+    it('returns undefined when no usable claim is present', () => {
+      const token = makeFakeJwt({ aud: 'api://app-id', iss: 'https://login.microsoftonline.com/' });
+      expect(getUserIdentityForAudit(token)).toBeUndefined();
+    });
+
+    it('handles base64url padding correctly', () => {
+      // Claim that produces a payload requiring padding when decoded
+      const token = makeFakeJwt({ upn: 'a' });
+      expect(getUserIdentityForAudit(token)).toBe('a');
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds a dedicated `src/audit-log.ts` module that emits one JSON line per Graph tool invocation on stdout (captured by the container platform's log collector) and to `~/.ms-365-mcp-server/logs/audit.log` (mode `0o600`). Two call sites in `executeGraphTool` — success path and error catch — fire the audit event.

```json
{"timestamp":"2026-05-14T12:49:02.800-04:00","level":"info","message":{"event":"tool.call","request_id":"3bbcf1ac-f9a8-4685-b9e9-96f7a9ece13c","user_principal_name":"alice@example.com","tool":"list-mail-messages","http_method":"GET","status":"success","duration_ms":287},"service":"ms-365-mcp-server","stream":"audit"}
```

## Why

Anyone operating this server in front of real M365 data eventually has to answer *"who accessed what, when?"* under their relevant compliance regime — GDPR Art. 15, HIPAA logging, PIPEDA Principle 9, SOC 2 CC7.2, etc. Today the only audit trail is the operational logger, which:
- isn't machine-parseable (text format),
- may incidentally include large tool params for debugging,
- doesn't carry a request_id correlating retries / paginated follow-ups,
- doesn't extract the upn / claim from the bearer token.

A separate audit stream with a narrow schema and explicit PII boundaries solves that without disturbing the operational logger.

## Schema (intentionally narrow)

```ts
interface AuditEvent {
  event: string;                  // 'tool.call'
  request_id: string;             // UUIDv4
  user_principal_name?: string;   // identity claim from JWT (see below)
  tool: string;                   // tool alias
  http_method?: string;           // GET / POST / PATCH / PUT / DELETE
  status: 'success' | 'error' | 'denied';
  duration_ms?: number;
  target_resource?: { type: string; id?: string };
  error_type?: string;            // err.name
  error_code?: string | number;   // err.status / err.code
}
```

`denied` is reserved for future server-side gates (e.g. destructive-tool confirm gate, tool-level RBAC).

## PII boundaries

- `user_principal_name` IS recorded — that's the entire point of the audit trail. Extracted by **decoding** the JWT payload (not verifying — that's the auth middleware's job) with preference order `upn → preferred_username → email → sub`.
- Tool parameters and Graph response bodies are **NEVER** written. The MCP server already has the operational logger for debugging; audit is for accountability.
- Raw error messages are **NEVER** written — only `error_type` (e.g. `GraphRequestError`) and `error_code` (HTTP status or err.code). Upstream library errors (MSAL, fetch) can incidentally include token fragments or query-string PII in their messages; capturing only the shape avoids that leak class.

## Operational details

- Separate winston logger so it doesn't share format / level / transports with the operational logger.
- Console transport is silent under Vitest (`VITEST=true`) so it doesn't pollute unrelated test output.
- File transport is best-effort: a missing log directory falls back to Console-only without throwing (containers care about stdout, not the local FS).
- Opt out per-deployment with `MS365_MCP_AUDIT_LOG=false` for environments that collect audit through a separate sink (sidecar, OpenTelemetry exporter, etc.).

## Tests

13 new unit tests in `test/audit-log.test.ts`:

- `isAuditLogEnabled` truthiness (default-on, `=false` opt-out, other values don't disable)
- `auditLog` forwards payload to winston, suppresses when disabled, accepts all 3 status values
- `getUserIdentityForAudit`:
  - returns undefined for nullish / malformed tokens
  - preference order `upn → preferred_username → email → sub`
  - returns undefined when no usable claim present
  - handles base64url padding edge cases

Existing `src/__tests__/graph-tools.test.ts` continues to pass — the audit hooks are silent under Vitest, so no test assertions need to change.

## Backward compatibility

- **Default ON** but **non-breaking**: the audit log is a new output stream. Existing callers see no behaviour change in tool responses.
- **Opt-out**: `MS365_MCP_AUDIT_LOG=false` to silence the JSON stream entirely (the operational logger continues unchanged).
- **File path**: `~/.ms-365-mcp-server/logs/audit.log` mode `0o600`. Override the directory with `MS365_MCP_LOG_DIR` (already used by the operational logger).

## Origin

Implemented as part of an internal security review of a downstream deployment behind an OAuth relay. The audit log is the load-bearing artefact for our DSAR pipeline; opening here because the narrow schema + PII boundaries are general engineering, not deployment-specific.
