### PR TITLE
feat(auth): filter tools by allowed scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,31 @@ npx @softeria/ms-365-mcp-server --preset mail --list-permissions
 
 This is useful for enterprise environments where Graph API permissions must be pre-approved and admin-consented before deploying a new version.
 
+The `--list-permissions` JSON includes:
+
+- `permissions`: legacy alias for `toolPermissions`, kept for compatibility with existing scripts
+- `toolPermissions`: permissions implied by the currently enabled tool surface
+- `authScopes`: scopes the server will request during MSAL authentication
+- `missingAuthScopesForEnabledTools`: enabled tool permissions not covered by configured auth scopes
+- `extraAuthScopesNotImpliedByTools`: configured auth scopes that are not implied by the enabled tools
+
+### Explicit Auth Scopes
+
+By default, MSAL requests the same scopes implied by the enabled tools. Enterprise and headless deployments can override that authentication surface with `--auth-scopes` or `MS365_MCP_AUTH_SCOPES`:
+
+```bash
+npx @softeria/ms-365-mcp-server \
+  --org-mode \
+  --enabled-tools '^(list-mail-messages|get-mail-message|list-drives|get-drive-item|download-bytes)$' \
+  --auth-scopes 'User.Read Mail.Read Files.Read'
+```
+
+CLI value takes precedence over `MS365_MCP_AUTH_SCOPES`; if neither is set, the default tool-derived scope behavior is unchanged. Supplying an empty value fails at startup so deployments do not accidentally fall back to a wider scope set.
+
+`--auth-scopes` only changes the scopes requested from Microsoft. It does not hide tools. Use `--enabled-tools`, `--preset`, and `--read-only` to control which tools are exposed.
+
+In HTTP mode, OAuth discovery advertises the configured `authScopes` when `--auth-scopes` is set so clients request the same narrower consent surface. On-Behalf-Of mode (`--obo`) still advertises `api://<clientId>/access_as_user` for protected-resource metadata; `--auth-scopes` does not override OBO.
+
 ## Organization/Work Mode
 
 To access work/school features (Teams, SharePoint, etc.), enable organization mode using any of these flags:
@@ -474,6 +499,7 @@ The following options can be used when running ms-365-mcp-server directly from t
 --work-mode       Alias for --org-mode
 --force-work-scopes Backwards compatibility alias for --org-mode (deprecated)
 --cloud <type>    Microsoft cloud environment: global (default) or china (21Vianet)
+--auth-scopes <scopes> Override auth scopes requested from Microsoft (whitespace-separated)
 ```
 
 ### Server Options

--- a/README.md
+++ b/README.md
@@ -150,8 +150,6 @@ Scope coverage is hierarchy-aware: for example, `Mail.ReadWrite` covers tools th
 
 In HTTP mode, OAuth discovery advertises the effective filtered permissions so clients request the same consent surface. On-Behalf-Of mode (`--obo`) still advertises `api://<clientId>/access_as_user` for protected-resource metadata; `--allowed-scopes` does not override OBO.
 
-Durable headless token-cache storage and account pinning are separate concerns from tool-surface scope filtering and can be addressed independently.
-
 ## Organization/Work Mode
 
 To access work/school features (Teams, SharePoint, etc.), enable organization mode using any of these flags:

--- a/README.md
+++ b/README.md
@@ -123,28 +123,34 @@ This is useful for enterprise environments where Graph API permissions must be p
 
 The `--list-permissions` JSON includes:
 
-- `permissions`: legacy alias for `toolPermissions`, kept for compatibility with existing scripts
-- `toolPermissions`: permissions implied by the currently enabled tool surface
-- `authScopes`: scopes the server will request during MSAL authentication
-- `missingAuthScopesForEnabledTools`: enabled tool permissions not covered by configured auth scopes
-- `extraAuthScopesNotImpliedByTools`: configured auth scopes that are not implied by the enabled tools
+- `toolPermissions`: permissions implied by the tool surface before `--allowed-scopes` filtering
+- `effectivePermissions`: permissions implied by the tools that remain enabled after `--allowed-scopes`
+- `permissions`: legacy alias for `effectivePermissions`, kept for compatibility with existing scripts
+- `allowedScopes`: the configured scope allowlist, when provided
+- `disabledTools`: tools hidden because their required Graph scopes are not covered by `allowedScopes`
+- `missingAllowedScopesForTools`: unique missing scopes across disabled tools
+- `extraAllowedScopesNotUsedByTools`: allowed scopes that are not used by the current tool surface
 
-### Explicit Auth Scopes
+### Allowed Scopes
 
-By default, MSAL requests the same scopes implied by the enabled tools. Enterprise and headless deployments can override that authentication surface with `--auth-scopes` or `MS365_MCP_AUTH_SCOPES`:
+By default, MSAL requests the scopes implied by the enabled tools, and the tool surface is controlled by `--enabled-tools`, `--preset`, `--org-mode`, and `--read-only`.
+
+Enterprise and headless deployments can add a scope boundary with `--allowed-scopes` or `MS365_MCP_ALLOWED_SCOPES`. When configured, the server first computes the normal tool surface, then hides Graph tools whose required scopes are not covered by the allowlist. OAuth metadata and login flows request only the effective permissions for the tools that remain enabled.
 
 ```bash
 npx @softeria/ms-365-mcp-server \
   --org-mode \
   --enabled-tools '^(list-mail-messages|get-mail-message|list-drives|get-drive-item|download-bytes)$' \
-  --auth-scopes 'User.Read Mail.Read Files.Read'
+  --allowed-scopes 'User.Read Mail.Read Files.Read'
 ```
 
-CLI value takes precedence over `MS365_MCP_AUTH_SCOPES`; if neither is set, the default tool-derived scope behavior is unchanged. Supplying an empty value fails at startup so deployments do not accidentally fall back to a wider scope set.
+CLI value takes precedence over `MS365_MCP_ALLOWED_SCOPES`; if neither is set, the default tool-derived scope behavior is unchanged. Supplying an empty value fails at startup so deployments do not accidentally fall back to a wider tool surface.
 
-`--auth-scopes` only changes the scopes requested from Microsoft. It does not hide tools. Use `--enabled-tools`, `--preset`, and `--read-only` to control which tools are exposed.
+Scope coverage is hierarchy-aware: for example, `Mail.ReadWrite` covers tools that require `Mail.Read`, and `Files.ReadWrite.All` covers tools that require `Files.Read`.
 
-In HTTP mode, OAuth discovery advertises the configured `authScopes` when `--auth-scopes` is set so clients request the same narrower consent surface. On-Behalf-Of mode (`--obo`) still advertises `api://<clientId>/access_as_user` for protected-resource metadata; `--auth-scopes` does not override OBO.
+In HTTP mode, OAuth discovery advertises the effective filtered permissions so clients request the same consent surface. On-Behalf-Of mode (`--obo`) still advertises `api://<clientId>/access_as_user` for protected-resource metadata; `--allowed-scopes` does not override OBO.
+
+Durable headless token-cache storage and account pinning are separate concerns from tool-surface scope filtering and can be addressed independently.
 
 ## Organization/Work Mode
 
@@ -494,12 +500,12 @@ The following options can be used when running ms-365-mcp-server directly from t
 --login           Login using device code flow
 --logout          Log out and clear saved credentials
 --verify-login    Verify login without starting the server
---list-permissions List all required Graph API permissions and exit (respects --org-mode, --preset, --enabled-tools)
+--list-permissions List required Graph API permissions and exit (respects --org-mode, --preset, --enabled-tools, --allowed-scopes)
 --org-mode        Enable organization/work mode from start (includes Teams, SharePoint, etc.)
 --work-mode       Alias for --org-mode
 --force-work-scopes Backwards compatibility alias for --org-mode (deprecated)
 --cloud <type>    Microsoft cloud environment: global (default) or china (21Vianet)
---auth-scopes <scopes> Override auth scopes requested from Microsoft (whitespace-separated)
+--allowed-scopes <scopes> Limit exposed tools to Graph scopes covered by this allowlist
 ```
 
 ### Server Options

--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -743,6 +743,111 @@ describe('graph-tools', () => {
   });
 
   // ---- 10. Utility tools surface in --discovery mode ----
+  describe('allowed scopes filtering', () => {
+    it('registerGraphTools hides Graph tools outside the allowed scopes', async () => {
+      mockEndpoints.push(
+        {
+          alias: 'list-mail-messages',
+          method: 'get',
+          path: '/me/messages',
+          description: 'List mail',
+          parameters: [],
+        },
+        {
+          alias: 'list-calendar-events',
+          method: 'get',
+          path: '/me/events',
+          description: 'List events',
+          parameters: [],
+        }
+      );
+      mockEndpointsJson = [
+        {
+          toolName: 'list-mail-messages',
+          method: 'get',
+          pathPattern: '/me/messages',
+          scopes: ['Mail.Read'],
+        },
+        {
+          toolName: 'list-calendar-events',
+          method: 'get',
+          pathPattern: '/me/events',
+          scopes: ['Calendars.Read'],
+        },
+      ];
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(
+        server as any,
+        createMockGraphClient() as any,
+        false,
+        undefined,
+        false,
+        undefined,
+        false,
+        [],
+        'Mail.Read'
+      );
+
+      expect(server.tools.has('list-mail-messages')).toBe(true);
+      expect(server.tools.has('list-calendar-events')).toBe(false);
+    });
+
+    it('discovery hides Graph tools outside the allowed scopes', async () => {
+      mockEndpoints.push(
+        {
+          alias: 'list-mail-messages',
+          method: 'get',
+          path: '/me/messages',
+          description: 'List mail',
+          parameters: [],
+        },
+        {
+          alias: 'list-calendar-events',
+          method: 'get',
+          path: '/me/events',
+          description: 'List events',
+          parameters: [],
+        }
+      );
+      mockEndpointsJson = [
+        {
+          toolName: 'list-mail-messages',
+          method: 'get',
+          pathPattern: '/me/messages',
+          scopes: ['Mail.Read'],
+        },
+        {
+          toolName: 'list-calendar-events',
+          method: 'get',
+          pathPattern: '/me/events',
+          scopes: ['Calendars.Read'],
+        },
+      ];
+
+      const server = createMockServer();
+      const { registerDiscoveryTools } = await loadModule();
+      registerDiscoveryTools(
+        server as any,
+        {} as any,
+        false,
+        false,
+        undefined,
+        false,
+        [],
+        undefined,
+        'Mail.Read'
+      );
+
+      const result = await server.tools.get('search-tools')!.handler({ limit: 50 });
+      const found = JSON.parse(result.content[0].text).tools.map((t: any) => t.name);
+      expect(found).toContain('list-mail-messages');
+      expect(found).not.toContain('list-calendar-events');
+    });
+  });
+
+  // ---- 11. Utility tools surface in --discovery mode ----
   describe('discovery mode: utility tools', () => {
     it('search-tools surfaces download-bytes for "download" queries', async () => {
       mockEndpoints.length = 0;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -41,6 +41,7 @@ interface EndpointConfig {
   scopes?: string[];
   workScopes?: string[];
   llmTip?: string;
+  readOnly?: boolean;
 }
 
 const __filename = fileURLToPath(import.meta.url);
@@ -145,19 +146,68 @@ const SCOPE_HIERARCHY: ScopeHierarchy = {
   'Contacts.ReadWrite': ['Contacts.Read'],
 };
 
-interface AuthScopeOptions {
+interface AllowedScopeOptions {
   orgMode?: boolean;
   enabledTools?: string;
   readOnly?: boolean;
-  authScopes?: string;
+  allowedScopes?: string;
+}
+
+interface DisabledToolScope {
+  toolName: string;
+  requiredScopes: string[];
+  missingScopes: string[];
 }
 
 interface ScopeDiagnostics {
   permissions: string[];
   toolPermissions: string[];
-  authScopes: string[];
-  missingAuthScopesForEnabledTools: string[];
-  extraAuthScopesNotImpliedByTools: string[];
+  effectivePermissions: string[];
+  allowedScopes?: string[];
+  disabledTools: DisabledToolScope[];
+  missingAllowedScopesForTools: string[];
+  extraAllowedScopesNotUsedByTools: string[];
+}
+
+function parseAllowedScopes(value?: string): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return Array.from(new Set(value.trim().split(/\s+/).filter(Boolean)));
+}
+
+function getEndpointRequiredScopes(
+  endpoint: Pick<EndpointConfig, 'scopes' | 'workScopes'> | undefined,
+  includeWorkAccountScopes: boolean = false
+): string[] {
+  if (!endpoint) {
+    return [];
+  }
+
+  const scopes = new Set<string>();
+  if (endpoint.scopes && Array.isArray(endpoint.scopes)) {
+    endpoint.scopes.forEach((scope) => scopes.add(scope));
+  }
+  if (includeWorkAccountScopes && endpoint.workScopes && Array.isArray(endpoint.workScopes)) {
+    endpoint.workScopes.forEach((scope) => scopes.add(scope));
+  }
+  return Array.from(scopes);
+}
+
+function collapseRedundantScopes(scopes: string[]): string[] {
+  const scopesSet = new Set(scopes);
+
+  // Scope hierarchy: if we have BOTH a higher scope (ReadWrite) AND lower scopes (Read),
+  // keep only the higher scope since it includes the permissions of the lower scopes.
+  // Do NOT upgrade Read to ReadWrite if we only have Read scopes.
+  Object.entries(SCOPE_HIERARCHY).forEach(([higherScope, lowerScopes]) => {
+    if (scopesSet.has(higherScope) && lowerScopes.every((scope) => scopesSet.has(scope))) {
+      lowerScopes.forEach((scope) => scopesSet.delete(scope));
+    }
+  });
+
+  return Array.from(scopesSet);
 }
 
 function buildScopesFromEndpoints(
@@ -183,7 +233,9 @@ function buildScopesFromEndpoints(
   endpoints.default.forEach((endpoint) => {
     // Skip write operations in read-only mode
     if (readOnly && endpoint.method.toUpperCase() !== 'GET') {
-      return;
+      if (!(endpoint.method.toUpperCase() === 'POST' && endpoint.readOnly)) {
+        return;
+      }
     }
 
     // Skip endpoints that don't match the tool filter
@@ -196,50 +248,17 @@ function buildScopesFromEndpoints(
       return;
     }
 
-    // Add regular scopes
-    if (endpoint.scopes && Array.isArray(endpoint.scopes)) {
-      endpoint.scopes.forEach((scope) => scopesSet.add(scope));
-    }
-
-    // Add workScopes if in work mode
-    if (includeWorkAccountScopes && endpoint.workScopes && Array.isArray(endpoint.workScopes)) {
-      endpoint.workScopes.forEach((scope) => scopesSet.add(scope));
-    }
+    getEndpointRequiredScopes(endpoint, includeWorkAccountScopes).forEach((scope) =>
+      scopesSet.add(scope)
+    );
   });
 
-  // Scope hierarchy: if we have BOTH a higher scope (ReadWrite) AND lower scopes (Read),
-  // keep only the higher scope since it includes the permissions of the lower scopes.
-  // Do NOT upgrade Read to ReadWrite if we only have Read scopes.
-  Object.entries(SCOPE_HIERARCHY).forEach(([higherScope, lowerScopes]) => {
-    if (scopesSet.has(higherScope) && lowerScopes.every((scope) => scopesSet.has(scope))) {
-      // We have both ReadWrite and Read, so remove the redundant Read scope
-      lowerScopes.forEach((scope) => scopesSet.delete(scope));
-    }
-  });
-
-  const scopes = Array.from(scopesSet);
+  const scopes = collapseRedundantScopes(Array.from(scopesSet));
   if (enabledToolsPattern) {
     logger.info(`Built ${scopes.length} scopes for filtered tools: ${scopes.join(', ')}`);
   }
 
   return scopes;
-}
-
-function parseExplicitAuthScopes(value?: string): string[] | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  return Array.from(new Set(value.trim().split(/\s+/).filter(Boolean)));
-}
-
-function resolveAuthScopes(options: AuthScopeOptions = {}): string[] {
-  const explicitAuthScopes = parseExplicitAuthScopes(options.authScopes);
-  if (explicitAuthScopes !== undefined) {
-    return explicitAuthScopes;
-  }
-
-  return buildScopesFromEndpoints(options.orgMode, options.enabledTools, options.readOnly);
 }
 
 function lowerScopesFor(scope: string): string[] {
@@ -280,22 +299,151 @@ function collapseScopeHierarchy(scopes: string[]): string[] {
   return Array.from(scopesSet);
 }
 
-function buildScopeDiagnostics(toolScopes: string[], authScopes: string[]): ScopeDiagnostics {
-  const toolPermissions = [...toolScopes].sort((a, b) => a.localeCompare(b));
-  const sortedAuthScopes = [...authScopes].sort((a, b) => a.localeCompare(b));
-  const coveredAuthScopes = new Set(collapseScopeHierarchy(authScopes));
-  const coveredToolScopes = new Set(collapseScopeHierarchy(toolScopes));
+function getMissingAllowedScopes(requiredScopes: string[], allowedScopes?: string[]): string[] {
+  if (allowedScopes === undefined) {
+    return [];
+  }
+
+  const coveredAllowedScopes = new Set(collapseScopeHierarchy(allowedScopes));
+  return requiredScopes.filter((scope) => !coveredAllowedScopes.has(scope));
+}
+
+function isEndpointCoveredByAllowedScopes(
+  endpoint: Pick<EndpointConfig, 'scopes' | 'workScopes'> | undefined,
+  includeWorkAccountScopes: boolean,
+  allowedScopes?: string[]
+): boolean {
+  return (
+    getMissingAllowedScopes(
+      getEndpointRequiredScopes(endpoint, includeWorkAccountScopes),
+      allowedScopes
+    ).length === 0
+  );
+}
+
+function isScopeUsedByTools(allowedScope: string, toolScopes: string[]): boolean {
+  const coveredByAllowedScope = new Set(collapseScopeHierarchy([allowedScope]));
+  return toolScopes.some((scope) => coveredByAllowedScope.has(scope));
+}
+
+function endpointMatchesNormalToolSurface(
+  endpoint: EndpointConfig,
+  includeWorkAccountScopes: boolean,
+  enabledToolsRegex?: RegExp,
+  readOnly: boolean = false
+): boolean {
+  if (readOnly && endpoint.method.toUpperCase() !== 'GET') {
+    if (!(endpoint.method.toUpperCase() === 'POST' && endpoint.readOnly)) {
+      return false;
+    }
+  }
+
+  if (enabledToolsRegex && !enabledToolsRegex.test(endpoint.toolName)) {
+    return false;
+  }
+
+  if (!includeWorkAccountScopes && !endpoint.scopes && endpoint.workScopes) {
+    return false;
+  }
+
+  return true;
+}
+
+function buildAllowedScopeDiagnostics(options: AllowedScopeOptions = {}): ScopeDiagnostics {
+  const allowedScopes = parseAllowedScopes(options.allowedScopes);
+  let enabledToolsRegex: RegExp | undefined;
+  if (options.enabledTools) {
+    try {
+      enabledToolsRegex = new RegExp(options.enabledTools, 'i');
+    } catch {
+      logger.error(
+        `Invalid tool filter regex pattern: ${options.enabledTools}. Building diagnostics without filter.`
+      );
+    }
+  }
+
+  const normalToolScopes = new Set<string>();
+  const effectiveToolScopes = new Set<string>();
+  const disabledTools: DisabledToolScope[] = [];
+
+  for (const endpoint of endpoints.default) {
+    if (
+      !endpointMatchesNormalToolSurface(
+        endpoint,
+        Boolean(options.orgMode),
+        enabledToolsRegex,
+        Boolean(options.readOnly)
+      )
+    ) {
+      continue;
+    }
+
+    const requiredScopes = getEndpointRequiredScopes(endpoint, Boolean(options.orgMode));
+    requiredScopes.forEach((scope) => normalToolScopes.add(scope));
+
+    const missingScopes = getMissingAllowedScopes(requiredScopes, allowedScopes);
+    if (missingScopes.length > 0) {
+      disabledTools.push({
+        toolName: endpoint.toolName,
+        requiredScopes: requiredScopes.sort((a, b) => a.localeCompare(b)),
+        missingScopes: missingScopes.sort((a, b) => a.localeCompare(b)),
+      });
+      continue;
+    }
+
+    requiredScopes.forEach((scope) => effectiveToolScopes.add(scope));
+  }
+
+  const toolPermissions = collapseRedundantScopes(Array.from(normalToolScopes)).sort((a, b) =>
+    a.localeCompare(b)
+  );
+  const effectivePermissions = collapseRedundantScopes(Array.from(effectiveToolScopes)).sort(
+    (a, b) => a.localeCompare(b)
+  );
+  const sortedAllowedScopes = allowedScopes
+    ? [...allowedScopes].sort((a, b) => a.localeCompare(b))
+    : undefined;
+  const missingAllowedScopesForTools = Array.from(
+    new Set(disabledTools.flatMap((tool) => tool.missingScopes))
+  ).sort((a, b) => a.localeCompare(b));
+  const extraAllowedScopesNotUsedByTools =
+    sortedAllowedScopes?.filter((scope) => !isScopeUsedByTools(scope, effectivePermissions)) ?? [];
 
   return {
-    permissions: toolPermissions,
+    permissions: effectivePermissions,
     toolPermissions,
-    authScopes: sortedAuthScopes,
-    missingAuthScopesForEnabledTools: toolPermissions.filter(
-      (scope) => !coveredAuthScopes.has(scope)
-    ),
-    extraAuthScopesNotImpliedByTools: sortedAuthScopes.filter(
-      (scope) => !coveredToolScopes.has(scope)
-    ),
+    effectivePermissions,
+    ...(sortedAllowedScopes ? { allowedScopes: sortedAllowedScopes } : {}),
+    disabledTools,
+    missingAllowedScopesForTools,
+    extraAllowedScopesNotUsedByTools,
+  };
+}
+
+function resolveAuthScopes(options: AllowedScopeOptions = {}): string[] {
+  return buildAllowedScopeDiagnostics(options).effectivePermissions;
+}
+
+function buildScopeDiagnostics(
+  toolScopes: string[],
+  allowedScopesInput: string[]
+): ScopeDiagnostics {
+  const toolPermissions = [...toolScopes].sort((a, b) => a.localeCompare(b));
+  const coveredAllowedScopes = new Set(collapseScopeHierarchy(allowedScopesInput));
+  const missingAllowedScopesForTools = toolPermissions.filter(
+    (scope) => !coveredAllowedScopes.has(scope)
+  );
+
+  return {
+    permissions: toolPermissions.filter((scope) => coveredAllowedScopes.has(scope)),
+    toolPermissions,
+    effectivePermissions: toolPermissions.filter((scope) => coveredAllowedScopes.has(scope)),
+    allowedScopes: [...allowedScopesInput].sort((a, b) => a.localeCompare(b)),
+    disabledTools: [],
+    missingAllowedScopesForTools,
+    extraAllowedScopesNotUsedByTools: [...allowedScopesInput]
+      .sort((a, b) => a.localeCompare(b))
+      .filter((scope) => !isScopeUsedByTools(scope, toolPermissions)),
   };
 }
 
@@ -871,12 +1019,16 @@ class AuthManager {
 
 export default AuthManager;
 export {
+  buildAllowedScopeDiagnostics,
   buildScopesFromEndpoints,
   buildScopeDiagnostics,
   collapseScopeHierarchy,
+  getEndpointRequiredScopes,
+  getMissingAllowedScopes,
   getTokenCachePath,
   getSelectedAccountPath,
-  parseExplicitAuthScopes,
+  isEndpointCoveredByAllowedScopes,
+  parseAllowedScopes,
   resolveAuthScopes,
   wrapCache,
   unwrapCache,

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -145,6 +145,21 @@ const SCOPE_HIERARCHY: ScopeHierarchy = {
   'Contacts.ReadWrite': ['Contacts.Read'],
 };
 
+interface AuthScopeOptions {
+  orgMode?: boolean;
+  enabledTools?: string;
+  readOnly?: boolean;
+  authScopes?: string;
+}
+
+interface ScopeDiagnostics {
+  permissions: string[];
+  toolPermissions: string[];
+  authScopes: string[];
+  missingAuthScopesForEnabledTools: string[];
+  extraAuthScopesNotImpliedByTools: string[];
+}
+
 function buildScopesFromEndpoints(
   includeWorkAccountScopes: boolean = false,
   enabledToolsPattern?: string,
@@ -210,6 +225,80 @@ function buildScopesFromEndpoints(
   return scopes;
 }
 
+function parseExplicitAuthScopes(value?: string): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return Array.from(new Set(value.trim().split(/\s+/).filter(Boolean)));
+}
+
+function resolveAuthScopes(options: AuthScopeOptions = {}): string[] {
+  const explicitAuthScopes = parseExplicitAuthScopes(options.authScopes);
+  if (explicitAuthScopes !== undefined) {
+    return explicitAuthScopes;
+  }
+
+  return buildScopesFromEndpoints(options.orgMode, options.enabledTools, options.readOnly);
+}
+
+function lowerScopesFor(scope: string): string[] {
+  const lowerScopes = new Set(SCOPE_HIERARCHY[scope] ?? []);
+
+  if (scope.endsWith('.ReadWrite.All')) {
+    const readAllScope = scope.replace(/\.ReadWrite\.All$/, '.Read.All');
+    const readWriteScope = scope.replace(/\.ReadWrite\.All$/, '.ReadWrite');
+    const readScope = scope.replace(/\.ReadWrite\.All$/, '.Read');
+    lowerScopes.add(readAllScope);
+    lowerScopes.add(readWriteScope);
+    lowerScopes.add(readScope);
+  } else if (scope.endsWith('.ReadWrite.Shared')) {
+    lowerScopes.add(scope.replace(/\.ReadWrite\.Shared$/, '.Read.Shared'));
+  } else if (scope.endsWith('.ReadWrite')) {
+    lowerScopes.add(scope.replace(/\.ReadWrite$/, '.Read'));
+  } else if (scope.endsWith('.Read.All')) {
+    lowerScopes.add(scope.replace(/\.Read\.All$/, '.Read'));
+  }
+
+  return Array.from(lowerScopes);
+}
+
+function addImpliedScopes(scope: string, scopesSet: Set<string>): void {
+  for (const lowerScope of lowerScopesFor(scope)) {
+    if (!scopesSet.has(lowerScope)) {
+      scopesSet.add(lowerScope);
+      addImpliedScopes(lowerScope, scopesSet);
+    }
+  }
+}
+
+function collapseScopeHierarchy(scopes: string[]): string[] {
+  const scopesSet = new Set(scopes);
+  for (const scope of scopes) {
+    addImpliedScopes(scope, scopesSet);
+  }
+  return Array.from(scopesSet);
+}
+
+function buildScopeDiagnostics(toolScopes: string[], authScopes: string[]): ScopeDiagnostics {
+  const toolPermissions = [...toolScopes].sort((a, b) => a.localeCompare(b));
+  const sortedAuthScopes = [...authScopes].sort((a, b) => a.localeCompare(b));
+  const coveredAuthScopes = new Set(collapseScopeHierarchy(authScopes));
+  const coveredToolScopes = new Set(collapseScopeHierarchy(toolScopes));
+
+  return {
+    permissions: toolPermissions,
+    toolPermissions,
+    authScopes: sortedAuthScopes,
+    missingAuthScopesForEnabledTools: toolPermissions.filter(
+      (scope) => !coveredAuthScopes.has(scope)
+    ),
+    extraAuthScopesNotImpliedByTools: sortedAuthScopes.filter(
+      (scope) => !coveredToolScopes.has(scope)
+    ),
+  };
+}
+
 interface LoginTestResult {
   success: boolean;
   message: string;
@@ -230,7 +319,7 @@ class AuthManager {
   private selectedAccountId: string | null;
   private useInteractiveAuth: boolean;
 
-  constructor(config: Configuration, scopes: string[] = buildScopesFromEndpoints()) {
+  constructor(config: Configuration, scopes: string[] = []) {
     logger.info(`And scopes are ${scopes.join(', ')}`, scopes);
     this.config = config;
     this.scopes = scopes;
@@ -249,7 +338,7 @@ class AuthManager {
    * Creates an AuthManager instance with secrets loaded from the configured provider.
    * Uses Key Vault if MS365_MCP_KEYVAULT_URL is set, otherwise environment variables.
    */
-  static async create(scopes: string[] = buildScopesFromEndpoints()): Promise<AuthManager> {
+  static async create(scopes: string[] = []): Promise<AuthManager> {
     const secrets = await getSecrets();
     const config = createMsalConfig(secrets);
     return new AuthManager(config, scopes);
@@ -783,8 +872,12 @@ class AuthManager {
 export default AuthManager;
 export {
   buildScopesFromEndpoints,
+  buildScopeDiagnostics,
+  collapseScopeHierarchy,
   getTokenCachePath,
   getSelectedAccountPath,
+  parseExplicitAuthScopes,
+  resolveAuthScopes,
   wrapCache,
   unwrapCache,
   pickNewest,

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -308,19 +308,6 @@ function getMissingAllowedScopes(requiredScopes: string[], allowedScopes?: strin
   return requiredScopes.filter((scope) => !coveredAllowedScopes.has(scope));
 }
 
-function isEndpointCoveredByAllowedScopes(
-  endpoint: Pick<EndpointConfig, 'scopes' | 'workScopes'> | undefined,
-  includeWorkAccountScopes: boolean,
-  allowedScopes?: string[]
-): boolean {
-  return (
-    getMissingAllowedScopes(
-      getEndpointRequiredScopes(endpoint, includeWorkAccountScopes),
-      allowedScopes
-    ).length === 0
-  );
-}
-
 function isScopeUsedByTools(allowedScope: string, toolScopes: string[]): boolean {
   const coveredByAllowedScope = new Set(collapseScopeHierarchy([allowedScope]));
   return toolScopes.some((scope) => coveredByAllowedScope.has(scope));
@@ -1027,7 +1014,6 @@ export {
   getMissingAllowedScopes,
   getTokenCachePath,
   getSelectedAccountPath,
-  isEndpointCoveredByAllowedScopes,
   parseAllowedScopes,
   resolveAuthScopes,
   wrapCache,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,10 @@ program
     'Filter tools using regex pattern (e.g., "excel|contact" to enable Excel and Contact tools)'
   )
   .option(
+    '--auth-scopes <scopes>',
+    'Override auth scopes requested from Microsoft (whitespace-separated). Does not change exposed tools.'
+  )
+  .option(
     '--preset <names>',
     'Use preset tool categories (comma-separated). Available: mail, calendar, files, personal, work, excel, contacts, tasks, onenote, search, users, all'
   )
@@ -89,6 +93,7 @@ export interface CommandOptions {
   http?: string | boolean;
   enableAuthTools?: boolean;
   enabledTools?: string;
+  authScopes?: string;
   preset?: string;
   listPresets?: boolean;
   listPermissions?: boolean;
@@ -142,6 +147,18 @@ export function parseArgs(): CommandOptions {
 
   if (process.env.ENABLED_TOOLS) {
     options.enabledTools = process.env.ENABLED_TOOLS;
+  }
+
+  if (options.authScopes === undefined && process.env.MS365_MCP_AUTH_SCOPES !== undefined) {
+    options.authScopes = process.env.MS365_MCP_AUTH_SCOPES;
+  }
+
+  if (options.authScopes !== undefined && options.authScopes.trim() === '') {
+    console.error(
+      'Error: --auth-scopes / MS365_MCP_AUTH_SCOPES was provided but is empty. ' +
+        'Provide one or more whitespace-separated scopes, or omit it to use tool-derived scopes.'
+    );
+    process.exit(1);
   }
 
   // Validate tool filter regex early — fail at startup instead of silently

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,8 +36,8 @@ program
     'Filter tools using regex pattern (e.g., "excel|contact" to enable Excel and Contact tools)'
   )
   .option(
-    '--auth-scopes <scopes>',
-    'Override auth scopes requested from Microsoft (whitespace-separated). Does not change exposed tools.'
+    '--allowed-scopes <scopes>',
+    'Limit exposed tools to Graph scopes covered by this whitespace-separated allowlist'
   )
   .option(
     '--preset <names>',
@@ -93,7 +93,7 @@ export interface CommandOptions {
   http?: string | boolean;
   enableAuthTools?: boolean;
   enabledTools?: string;
-  authScopes?: string;
+  allowedScopes?: string;
   preset?: string;
   listPresets?: boolean;
   listPermissions?: boolean;
@@ -149,13 +149,13 @@ export function parseArgs(): CommandOptions {
     options.enabledTools = process.env.ENABLED_TOOLS;
   }
 
-  if (options.authScopes === undefined && process.env.MS365_MCP_AUTH_SCOPES !== undefined) {
-    options.authScopes = process.env.MS365_MCP_AUTH_SCOPES;
+  if (options.allowedScopes === undefined && process.env.MS365_MCP_ALLOWED_SCOPES !== undefined) {
+    options.allowedScopes = process.env.MS365_MCP_ALLOWED_SCOPES;
   }
 
-  if (options.authScopes !== undefined && options.authScopes.trim() === '') {
+  if (options.allowedScopes !== undefined && options.allowedScopes.trim() === '') {
     console.error(
-      'Error: --auth-scopes / MS365_MCP_AUTH_SCOPES was provided but is empty. ' +
+      'Error: --allowed-scopes / MS365_MCP_ALLOWED_SCOPES was provided but is empty. ' +
         'Provide one or more whitespace-separated scopes, or omit it to use tool-derived scopes.'
     );
     process.exit(1);

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -927,7 +927,8 @@ export function buildToolsRegistry(
   readOnly: boolean,
   orgMode: boolean,
   enabledToolsRegex?: RegExp,
-  allowedScopesValue?: string
+  allowedScopesValue?: string,
+  disabledByAllowedScopes: Array<{ toolName: string; missingScopes: string[] }> = []
 ): Map<string, { tool: (typeof api.endpoints)[0]; config: EndpointConfig | undefined }> {
   const toolsMap = new Map<
     string,
@@ -953,14 +954,15 @@ export function buildToolsRegistry(
       continue;
     }
 
-    if (allowedScopes !== undefined && !endpointConfig) {
-      continue;
-    }
-
-    if (
-      getMissingAllowedScopes(getEndpointRequiredScopes(endpointConfig, orgMode), allowedScopes)
-        .length > 0
-    ) {
+    const missingScopes =
+      allowedScopes !== undefined && !endpointConfig
+        ? ['endpoint scope metadata']
+        : getMissingAllowedScopes(
+            getEndpointRequiredScopes(endpointConfig, orgMode),
+            allowedScopes
+          );
+    if (missingScopes.length > 0) {
+      disabledByAllowedScopes.push({ toolName: tool.alias, missingScopes });
       continue;
     }
 
@@ -1076,29 +1078,19 @@ export function registerDiscoveryTools(
     }
   }
 
-  const allowedScopes = parseAllowedScopes(allowedScopesValue);
-  const toolsBeforeAllowedScopeFilter = buildToolsRegistry(readOnly, orgMode, enabledToolsRegex);
-  const disabledByAllowedScopes = [...toolsBeforeAllowedScopeFilter.entries()]
-    .map(([toolName, { config }]) => ({
-      toolName,
-      missingScopes:
-        allowedScopes !== undefined && !config
-          ? ['endpoint scope metadata']
-          : getMissingAllowedScopes(getEndpointRequiredScopes(config, orgMode), allowedScopes),
-    }))
-    .filter((tool) => tool.missingScopes.length > 0);
+  const disabledByAllowedScopes: Array<{ toolName: string; missingScopes: string[] }> = [];
+  const toolsRegistry = buildToolsRegistry(
+    readOnly,
+    orgMode,
+    enabledToolsRegex,
+    allowedScopesValue,
+    disabledByAllowedScopes
+  );
   if (disabledByAllowedScopes.length > 0) {
     logger.info(
       `Discovery mode: allowed scopes disabled ${disabledByAllowedScopes.length} Graph tools: ${formatDisabledToolsForLog(disabledByAllowedScopes)}`
     );
   }
-
-  const toolsRegistry = buildToolsRegistry(
-    readOnly,
-    orgMode,
-    enabledToolsRegex,
-    allowedScopesValue
-  );
   const utilityTools = UTILITY_TOOLS.filter((u) => {
     if (readOnly && !u.readOnlyHint) return false;
     if (enabledToolsRegex && !enabledToolsRegex.test(u.name)) return false;

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -1,7 +1,11 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import logger from './logger.js';
 import GraphClient from './graph-client.js';
-import AuthManager from './auth.js';
+import AuthManager, {
+  getEndpointRequiredScopes,
+  getMissingAllowedScopes,
+  parseAllowedScopes,
+} from './auth.js';
 import { api } from './generated/client.js';
 import { z } from 'zod';
 import { readFileSync } from 'fs';
@@ -135,6 +139,20 @@ interface UtilityTool {
   execute: (params: Record<string, unknown>, ctx: UtilityToolContext) => Promise<CallToolResult>;
   readOnlyHint?: boolean;
   openWorldHint?: boolean;
+}
+
+interface DisabledToolScope {
+  toolName: string;
+  missingScopes: string[];
+}
+
+function formatDisabledToolsForLog(disabledTools: DisabledToolScope[]): string {
+  const shown = disabledTools
+    .slice(0, 20)
+    .map((tool) => `${tool.toolName} (missing: ${tool.missingScopes.join(', ')})`);
+  const suffix =
+    disabledTools.length > shown.length ? `, ... +${disabledTools.length - shown.length} more` : '';
+  return `${shown.join('; ')}${suffix}`;
 }
 
 export const UTILITY_TOOLS: readonly UtilityTool[] = [
@@ -649,7 +667,8 @@ export function registerGraphTools(
   orgMode: boolean = false,
   authManager?: AuthManager,
   multiAccount: boolean = false,
-  accountNames: string[] = []
+  accountNames: string[] = [],
+  allowedScopesValue?: string
 ): number {
   let enabledToolsRegex: RegExp | undefined;
   if (enabledToolsPattern) {
@@ -664,6 +683,8 @@ export function registerGraphTools(
   let registeredCount = 0;
   let skippedCount = 0;
   let failedCount = 0;
+  const allowedScopes = parseAllowedScopes(allowedScopesValue);
+  const disabledByAllowedScopes: DisabledToolScope[] = [];
 
   for (const tool of api.endpoints) {
     const endpointConfig = endpointsData.find((e) => e.toolName === tool.alias);
@@ -687,6 +708,17 @@ export function registerGraphTools(
 
     if (enabledToolsRegex && !enabledToolsRegex.test(tool.alias)) {
       logger.info(`Skipping tool ${tool.alias} - doesn't match filter pattern`);
+      skippedCount++;
+      continue;
+    }
+
+    const requiredScopes = getEndpointRequiredScopes(endpointConfig, orgMode);
+    const missingScopes =
+      allowedScopes !== undefined && !endpointConfig
+        ? ['endpoint scope metadata']
+        : getMissingAllowedScopes(requiredScopes, allowedScopes);
+    if (missingScopes.length > 0) {
+      disabledByAllowedScopes.push({ toolName: tool.alias, missingScopes });
       skippedCount++;
       continue;
     }
@@ -858,6 +890,12 @@ export function registerGraphTools(
     logger.info('Multi-account mode: "account" parameter injected into all tool schemas');
   }
 
+  if (disabledByAllowedScopes.length > 0) {
+    logger.info(
+      `Allowed scopes disabled ${disabledByAllowedScopes.length} Graph tools: ${formatDisabledToolsForLog(disabledByAllowedScopes)}`
+    );
+  }
+
   const utilityCtx: UtilityToolContext = {
     graphClient,
     authManager,
@@ -888,12 +926,14 @@ export function registerGraphTools(
 export function buildToolsRegistry(
   readOnly: boolean,
   orgMode: boolean,
-  enabledToolsRegex?: RegExp
+  enabledToolsRegex?: RegExp,
+  allowedScopesValue?: string
 ): Map<string, { tool: (typeof api.endpoints)[0]; config: EndpointConfig | undefined }> {
   const toolsMap = new Map<
     string,
     { tool: (typeof api.endpoints)[0]; config: EndpointConfig | undefined }
   >();
+  const allowedScopes = parseAllowedScopes(allowedScopesValue);
 
   for (const tool of api.endpoints) {
     const endpointConfig = endpointsData.find((e) => e.toolName === tool.alias);
@@ -910,6 +950,17 @@ export function buildToolsRegistry(
     }
 
     if (enabledToolsRegex && !enabledToolsRegex.test(tool.alias)) {
+      continue;
+    }
+
+    if (allowedScopes !== undefined && !endpointConfig) {
+      continue;
+    }
+
+    if (
+      getMissingAllowedScopes(getEndpointRequiredScopes(endpointConfig, orgMode), allowedScopes)
+        .length > 0
+    ) {
       continue;
     }
 
@@ -1010,7 +1061,8 @@ export function registerDiscoveryTools(
   authManager?: AuthManager,
   multiAccount: boolean = false,
   accountNames: string[] = [],
-  enabledTools?: string
+  enabledTools?: string,
+  allowedScopesValue?: string
 ): void {
   let enabledToolsRegex: RegExp | undefined;
   if (enabledTools) {
@@ -1024,7 +1076,29 @@ export function registerDiscoveryTools(
     }
   }
 
-  const toolsRegistry = buildToolsRegistry(readOnly, orgMode, enabledToolsRegex);
+  const allowedScopes = parseAllowedScopes(allowedScopesValue);
+  const toolsBeforeAllowedScopeFilter = buildToolsRegistry(readOnly, orgMode, enabledToolsRegex);
+  const disabledByAllowedScopes = [...toolsBeforeAllowedScopeFilter.entries()]
+    .map(([toolName, { config }]) => ({
+      toolName,
+      missingScopes:
+        allowedScopes !== undefined && !config
+          ? ['endpoint scope metadata']
+          : getMissingAllowedScopes(getEndpointRequiredScopes(config, orgMode), allowedScopes),
+    }))
+    .filter((tool) => tool.missingScopes.length > 0);
+  if (disabledByAllowedScopes.length > 0) {
+    logger.info(
+      `Discovery mode: allowed scopes disabled ${disabledByAllowedScopes.length} Graph tools: ${formatDisabledToolsForLog(disabledByAllowedScopes)}`
+    );
+  }
+
+  const toolsRegistry = buildToolsRegistry(
+    readOnly,
+    orgMode,
+    enabledToolsRegex,
+    allowedScopesValue
+  );
   const utilityTools = UTILITY_TOOLS.filter((u) => {
     if (readOnly && !u.readOnlyHint) return false;
     if (enabledToolsRegex && !enabledToolsRegex.test(u.name)) return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,11 @@
 import 'dotenv/config';
 import { parseArgs } from './cli.js';
 import logger from './logger.js';
-import AuthManager, { buildScopesFromEndpoints } from './auth.js';
+import AuthManager, {
+  buildScopesFromEndpoints,
+  buildScopeDiagnostics,
+  resolveAuthScopes,
+} from './auth.js';
 import MicrosoftGraphServer from './server.js';
 import { version } from './version.js';
 
@@ -17,17 +21,34 @@ async function main(): Promise<void> {
     }
 
     const readOnly = args.readOnly || false;
-    const scopes = buildScopesFromEndpoints(includeWorkScopes, args.enabledTools, readOnly);
+    const toolScopes = buildScopesFromEndpoints(includeWorkScopes, args.enabledTools, readOnly);
+    const authScopes = resolveAuthScopes(args);
 
     if (args.listPermissions) {
-      const sorted = [...scopes].sort((a, b) => a.localeCompare(b));
+      const diagnostics = buildScopeDiagnostics(toolScopes, authScopes);
       const mode = includeWorkScopes ? 'org' : 'personal';
       const filter = args.enabledTools ? args.enabledTools : undefined;
-      console.log(JSON.stringify({ mode, readOnly, filter, permissions: sorted }, null, 2));
+      if (diagnostics.missingAuthScopesForEnabledTools.length > 0) {
+        console.error(
+          `Warning: auth scopes are missing permissions required by enabled tools: ${diagnostics.missingAuthScopesForEnabledTools.join(', ')}`
+        );
+      }
+      console.log(
+        JSON.stringify(
+          {
+            mode,
+            readOnly,
+            filter,
+            ...diagnostics,
+          },
+          null,
+          2
+        )
+      );
       process.exit(0);
     }
 
-    const authManager = await AuthManager.create(scopes);
+    const authManager = await AuthManager.create(authScopes);
     await authManager.loadTokenCache();
 
     if (args.authBrowser) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,7 @@
 import 'dotenv/config';
 import { parseArgs } from './cli.js';
 import logger from './logger.js';
-import AuthManager, {
-  buildScopesFromEndpoints,
-  buildScopeDiagnostics,
-  resolveAuthScopes,
-} from './auth.js';
+import AuthManager, { buildAllowedScopeDiagnostics, resolveAuthScopes } from './auth.js';
 import MicrosoftGraphServer from './server.js';
 import { version } from './version.js';
 
@@ -21,16 +17,15 @@ async function main(): Promise<void> {
     }
 
     const readOnly = args.readOnly || false;
-    const toolScopes = buildScopesFromEndpoints(includeWorkScopes, args.enabledTools, readOnly);
-    const authScopes = resolveAuthScopes(args);
+    const effectiveScopes = resolveAuthScopes(args);
 
     if (args.listPermissions) {
-      const diagnostics = buildScopeDiagnostics(toolScopes, authScopes);
+      const diagnostics = buildAllowedScopeDiagnostics(args);
       const mode = includeWorkScopes ? 'org' : 'personal';
       const filter = args.enabledTools ? args.enabledTools : undefined;
-      if (diagnostics.missingAuthScopesForEnabledTools.length > 0) {
+      if (diagnostics.disabledTools.length > 0) {
         console.error(
-          `Warning: auth scopes are missing permissions required by enabled tools: ${diagnostics.missingAuthScopesForEnabledTools.join(', ')}`
+          `Warning: allowed scopes disabled ${diagnostics.disabledTools.length} tools. Missing scopes: ${diagnostics.missingAllowedScopesForTools.join(', ')}`
         );
       }
       console.log(
@@ -48,7 +43,7 @@ async function main(): Promise<void> {
       process.exit(0);
     }
 
-    const authManager = await AuthManager.create(authScopes);
+    const authManager = await AuthManager.create(effectiveScopes);
     await authManager.loadTokenCache();
 
     if (args.authBrowser) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@ import { buildMcpServerInstructions } from './mcp-instructions.js';
 import GraphClient from './graph-client.js';
 import AuthManager, {
   buildScopesFromEndpoints,
-  parseExplicitAuthScopes,
+  parseAllowedScopes,
   resolveAuthScopes,
 } from './auth.js';
 import { MicrosoftOAuthProvider } from './oauth-provider.js';
@@ -114,7 +114,8 @@ class MicrosoftGraphServer {
         this.authManager,
         this.multiAccount,
         this.accountNames,
-        this.options.enabledTools
+        this.options.enabledTools,
+        this.options.allowedScopes
       );
     } else {
       registerGraphTools(
@@ -125,7 +126,8 @@ class MicrosoftGraphServer {
         this.options.orgMode,
         this.authManager,
         this.multiAccount,
-        this.accountNames
+        this.accountNames,
+        this.options.allowedScopes
       );
     }
 
@@ -445,17 +447,18 @@ class MicrosoftGraphServer {
         //     access to data" consent line that fails in tenants where user
         //     consent for applications is restricted by policy (even when
         //     admin has pre-consented every scope).
-        const explicitAuthScopes = parseExplicitAuthScopes(this.options.authScopes);
+        const explicitAllowedScopes = parseAllowedScopes(this.options.allowedScopes);
         const clientScope = microsoftAuthUrl.searchParams.get('scope');
         const baseScopes =
-          explicitAuthScopes ??
-          (clientScope
-            ? clientScope.split(/\s+/).filter(Boolean)
-            : buildScopesFromEndpoints(
-                this.options.orgMode,
-                this.options.enabledTools,
-                this.options.readOnly
-              ));
+          explicitAllowedScopes !== undefined
+            ? resolveAuthScopes(this.options)
+            : clientScope
+              ? clientScope.split(/\s+/).filter(Boolean)
+              : buildScopesFromEndpoints(
+                  this.options.orgMode,
+                  this.options.enabledTools,
+                  this.options.readOnly
+                );
         const scopeSet = new Set([...baseScopes, 'User.Read', 'offline_access']);
         microsoftAuthUrl.searchParams.set('scope', Array.from(scopeSet).join(' '));
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,11 @@ import { registerAuthTools } from './auth-tools.js';
 import { registerGraphTools, registerDiscoveryTools } from './graph-tools.js';
 import { buildMcpServerInstructions } from './mcp-instructions.js';
 import GraphClient from './graph-client.js';
-import AuthManager, { buildScopesFromEndpoints } from './auth.js';
+import AuthManager, {
+  buildScopesFromEndpoints,
+  parseExplicitAuthScopes,
+  resolveAuthScopes,
+} from './auth.js';
 import { MicrosoftOAuthProvider } from './oauth-provider.js';
 import {
   exchangeCodeForToken,
@@ -253,11 +257,7 @@ class MicrosoftGraphServer {
         const requestOrigin = `${protocol}://${req.get('host')}`;
         const browserBase = publicBase ?? requestOrigin;
 
-        const scopes = buildScopesFromEndpoints(
-          this.options.orgMode,
-          this.options.enabledTools,
-          this.options.readOnly
-        );
+        const scopes = resolveAuthScopes(this.options);
 
         const metadata: Record<string, unknown> = {
           issuer: browserBase,
@@ -286,11 +286,7 @@ class MicrosoftGraphServer {
 
         const scopes = this.options.obo
           ? [`api://${this.secrets!.clientId}/access_as_user`]
-          : buildScopesFromEndpoints(
-              this.options.orgMode,
-              this.options.enabledTools,
-              this.options.readOnly
-            );
+          : resolveAuthScopes(this.options);
 
         res.json({
           resource: `${requestOrigin}/mcp`,
@@ -449,14 +445,17 @@ class MicrosoftGraphServer {
         //     access to data" consent line that fails in tenants where user
         //     consent for applications is restricted by policy (even when
         //     admin has pre-consented every scope).
+        const explicitAuthScopes = parseExplicitAuthScopes(this.options.authScopes);
         const clientScope = microsoftAuthUrl.searchParams.get('scope');
-        const baseScopes = clientScope
-          ? clientScope.split(/\s+/).filter(Boolean)
-          : buildScopesFromEndpoints(
-              this.options.orgMode,
-              this.options.enabledTools,
-              this.options.readOnly
-            );
+        const baseScopes =
+          explicitAuthScopes ??
+          (clientScope
+            ? clientScope.split(/\s+/).filter(Boolean)
+            : buildScopesFromEndpoints(
+                this.options.orgMode,
+                this.options.enabledTools,
+                this.options.readOnly
+              ));
         const scopeSet = new Set([...baseScopes, 'User.Read', 'offline_access']);
         microsoftAuthUrl.searchParams.set('scope', Array.from(scopeSet).join(' '));
 

--- a/test/allowed-scopes.test.ts
+++ b/test/allowed-scopes.test.ts
@@ -94,7 +94,7 @@ async function startHttpServer(options: Record<string, unknown>) {
   return server;
 }
 
-describe('auth scope HTTP behavior', () => {
+describe('allowed scope HTTP behavior', () => {
   beforeEach(() => {
     expressMocks.routes.clear();
     graphToolMocks.registerDiscoveryTools.mockClear();
@@ -114,19 +114,19 @@ describe('auth scope HTTP behavior', () => {
     clearSecretsCache();
   });
 
-  it('advertises explicit auth scopes in OAuth metadata', async () => {
-    await startHttpServer({ authScopes: 'Mail.Read Files.Read' });
+  it('advertises effective scopes in OAuth metadata', async () => {
+    await startHttpServer({ allowedScopes: 'Mail.Read Files.Read' });
     const handler = expressMocks.routes.get('/.well-known/oauth-authorization-server')!;
     const res = mockResponse();
 
     await handler(mockRequest('/.well-known/oauth-authorization-server'), res);
 
     expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ scopes_supported: ['Mail.Read', 'Files.Read'] })
+      expect.objectContaining({ scopes_supported: ['Files.Read', 'Mail.Read'] })
     );
   });
 
-  it('preserves client-requested authorize scopes without explicit auth scopes', async () => {
+  it('preserves client-requested authorize scopes when no allowed scopes are set', async () => {
     await startHttpServer({ enabledTools: 'mail' });
     const handler = expressMocks.routes.get('/authorize')!;
     const res = mockResponse();
@@ -146,8 +146,8 @@ describe('auth scope HTTP behavior', () => {
     expect(scopes).not.toContain('Mail.Read');
   });
 
-  it('forces explicit auth scopes in authorize redirects', async () => {
-    await startHttpServer({ authScopes: 'Mail.Read Files.Read' });
+  it('uses allowed-scope-filtered permissions in authorize redirects', async () => {
+    await startHttpServer({ allowedScopes: 'Mail.Read' });
     const handler = expressMocks.routes.get('/authorize')!;
     const res = mockResponse();
 
@@ -160,16 +160,14 @@ describe('auth scope HTTP behavior', () => {
 
     const redirectUrl = new URL(res.redirect.mock.calls[0][0]);
     const scopes = redirectUrl.searchParams.get('scope')!.split(' ');
-    expect(scopes).toEqual(
-      expect.arrayContaining(['Mail.Read', 'Files.Read', 'User.Read', 'offline_access'])
-    );
+    expect(scopes).toEqual(expect.arrayContaining(['Mail.Read', 'User.Read', 'offline_access']));
     expect(scopes).not.toContain('Calendars.Read');
   });
 
-  it('keeps OBO protected-resource metadata ahead of explicit auth scopes', async () => {
+  it('keeps OBO protected-resource metadata ahead of allowed scopes', async () => {
     process.env.MS365_MCP_CLIENT_SECRET = 'secret';
     clearSecretsCache();
-    await startHttpServer({ authScopes: 'Mail.Read', obo: true });
+    await startHttpServer({ allowedScopes: 'Mail.Read', obo: true });
     const handler = expressMocks.routes.get('/.well-known/oauth-protected-resource')!;
     const res = mockResponse();
 
@@ -180,9 +178,9 @@ describe('auth scope HTTP behavior', () => {
     );
   });
 
-  it('registers tools independently from explicit auth scopes', () => {
+  it('passes allowed scopes to tool registration', () => {
     const server = new MicrosoftGraphServer(mockAuthManager(), {
-      authScopes: 'Mail.Read',
+      allowedScopes: 'Mail.Read',
       enabledTools: 'mail',
       http: true,
     });
@@ -198,7 +196,8 @@ describe('auth scope HTTP behavior', () => {
       undefined,
       expect.anything(),
       false,
-      []
+      [],
+      'Mail.Read'
     );
   });
 });

--- a/test/auth-scopes.test.ts
+++ b/test/auth-scopes.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import MicrosoftGraphServer from '../src/server.js';
+import type AuthManager from '../src/auth.js';
+import { clearSecretsCache } from '../src/secrets.js';
+
+const expressMocks = vi.hoisted(() => {
+  type Handler = (req: Record<string, unknown>, res: Record<string, unknown>) => unknown;
+  const routes = new Map<string, Handler>();
+  const app: Record<string, ReturnType<typeof vi.fn>> = {};
+  app.set = vi.fn(() => app);
+  app.use = vi.fn(() => app);
+  app.get = vi.fn((path: string, handler: Handler) => {
+    routes.set(path, handler);
+    return app;
+  });
+  app.post = vi.fn(() => app);
+  app.listen = vi.fn((...args: unknown[]) => {
+    const callback = args.find((arg): arg is () => void => typeof arg === 'function');
+    callback?.();
+    return { close: vi.fn() };
+  });
+
+  const express = Object.assign(
+    vi.fn(() => app),
+    {
+      json: vi.fn(() => (_req: unknown, _res: unknown, next: () => void) => next()),
+      urlencoded: vi.fn(() => (_req: unknown, _res: unknown, next: () => void) => next()),
+    }
+  );
+
+  return { app, express, routes };
+});
+
+const graphToolMocks = vi.hoisted(() => ({
+  registerDiscoveryTools: vi.fn(),
+  registerGraphTools: vi.fn(),
+}));
+
+vi.mock('express', () => ({
+  default: expressMocks.express,
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/auth/router.js', () => ({
+  mcpAuthRouter: vi.fn(() => (_req: unknown, _res: unknown, next?: () => void) => next?.()),
+}));
+
+vi.mock('../src/graph-tools.js', () => graphToolMocks);
+
+vi.mock('../src/oauth-provider.js', () => ({
+  MicrosoftOAuthProvider: vi.fn(),
+}));
+
+vi.mock('../src/logger.js', () => ({
+  default: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  enableConsoleLogging: vi.fn(),
+}));
+
+function mockAuthManager(): AuthManager {
+  return {
+    isMultiAccount: vi.fn().mockResolvedValue(false),
+    listAccounts: vi.fn().mockResolvedValue([]),
+  } as unknown as AuthManager;
+}
+
+function mockRequest(path: string) {
+  return {
+    secure: false,
+    protocol: 'http',
+    url: path,
+    get: vi.fn((header: string) =>
+      header.toLowerCase() === 'host' ? 'localhost:3000' : undefined
+    ),
+  };
+}
+
+function mockResponse() {
+  const res = {
+    json: vi.fn(),
+    redirect: vi.fn(),
+    status: vi.fn(),
+  };
+  res.status.mockReturnValue(res);
+  return res;
+}
+
+async function startHttpServer(options: Record<string, unknown>) {
+  const server = new MicrosoftGraphServer(mockAuthManager(), { http: true, ...options });
+  await server.initialize('test');
+  await server.start();
+  return server;
+}
+
+describe('auth scope HTTP behavior', () => {
+  beforeEach(() => {
+    expressMocks.routes.clear();
+    graphToolMocks.registerDiscoveryTools.mockClear();
+    graphToolMocks.registerGraphTools.mockClear();
+    process.env.MS365_MCP_CLIENT_ID = 'test-client-id';
+    process.env.MS365_MCP_TENANT_ID = 'test-tenant';
+    delete process.env.MS365_MCP_CLIENT_SECRET;
+    delete process.env.MS365_MCP_KEYVAULT_URL;
+    clearSecretsCache();
+  });
+
+  afterEach(() => {
+    delete process.env.MS365_MCP_CLIENT_ID;
+    delete process.env.MS365_MCP_TENANT_ID;
+    delete process.env.MS365_MCP_CLIENT_SECRET;
+    delete process.env.MS365_MCP_KEYVAULT_URL;
+    clearSecretsCache();
+  });
+
+  it('advertises explicit auth scopes in OAuth metadata', async () => {
+    await startHttpServer({ authScopes: 'Mail.Read Files.Read' });
+    const handler = expressMocks.routes.get('/.well-known/oauth-authorization-server')!;
+    const res = mockResponse();
+
+    await handler(mockRequest('/.well-known/oauth-authorization-server'), res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ scopes_supported: ['Mail.Read', 'Files.Read'] })
+    );
+  });
+
+  it('preserves client-requested authorize scopes without explicit auth scopes', async () => {
+    await startHttpServer({ enabledTools: 'mail' });
+    const handler = expressMocks.routes.get('/authorize')!;
+    const res = mockResponse();
+
+    await handler(
+      mockRequest(
+        '/authorize?response_type=code&redirect_uri=http://localhost:6274/oauth/callback&scope=Calendars.Read&state=abc'
+      ),
+      res
+    );
+
+    const redirectUrl = new URL(res.redirect.mock.calls[0][0]);
+    const scopes = redirectUrl.searchParams.get('scope')!.split(' ');
+    expect(scopes).toEqual(
+      expect.arrayContaining(['Calendars.Read', 'User.Read', 'offline_access'])
+    );
+    expect(scopes).not.toContain('Mail.Read');
+  });
+
+  it('forces explicit auth scopes in authorize redirects', async () => {
+    await startHttpServer({ authScopes: 'Mail.Read Files.Read' });
+    const handler = expressMocks.routes.get('/authorize')!;
+    const res = mockResponse();
+
+    await handler(
+      mockRequest(
+        '/authorize?response_type=code&redirect_uri=http://localhost:6274/oauth/callback&scope=Calendars.Read&state=abc'
+      ),
+      res
+    );
+
+    const redirectUrl = new URL(res.redirect.mock.calls[0][0]);
+    const scopes = redirectUrl.searchParams.get('scope')!.split(' ');
+    expect(scopes).toEqual(
+      expect.arrayContaining(['Mail.Read', 'Files.Read', 'User.Read', 'offline_access'])
+    );
+    expect(scopes).not.toContain('Calendars.Read');
+  });
+
+  it('keeps OBO protected-resource metadata ahead of explicit auth scopes', async () => {
+    process.env.MS365_MCP_CLIENT_SECRET = 'secret';
+    clearSecretsCache();
+    await startHttpServer({ authScopes: 'Mail.Read', obo: true });
+    const handler = expressMocks.routes.get('/.well-known/oauth-protected-resource')!;
+    const res = mockResponse();
+
+    await handler(mockRequest('/.well-known/oauth-protected-resource'), res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ scopes_supported: ['api://test-client-id/access_as_user'] })
+    );
+  });
+
+  it('registers tools independently from explicit auth scopes', () => {
+    const server = new MicrosoftGraphServer(mockAuthManager(), {
+      authScopes: 'Mail.Read',
+      enabledTools: 'mail',
+      http: true,
+    });
+    Object.assign(server, { graphClient: {}, version: 'test' });
+
+    (server as unknown as { createMcpServer: () => unknown }).createMcpServer();
+
+    expect(graphToolMocks.registerGraphTools).toHaveBeenCalledWith(
+      expect.anything(),
+      {},
+      undefined,
+      'mail',
+      undefined,
+      expect.anything(),
+      false,
+      []
+    );
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -48,11 +48,11 @@ describe('CLI Module', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     commanderMocks.mockCommand.opts.mockReturnValue({ file: 'test.xlsx' });
-    delete process.env.MS365_MCP_AUTH_SCOPES;
+    delete process.env.MS365_MCP_ALLOWED_SCOPES;
   });
 
   afterEach(() => {
-    delete process.env.MS365_MCP_AUTH_SCOPES;
+    delete process.env.MS365_MCP_ALLOWED_SCOPES;
   });
 
   describe('parseArgs', () => {
@@ -61,38 +61,50 @@ describe('CLI Module', () => {
       expect(result).toEqual({ file: 'test.xlsx' });
     });
 
-    it('should parse --auth-scopes from CLI options', () => {
-      commanderMocks.mockCommand.opts.mockReturnValue({ authScopes: 'Mail.Read Files.Read' });
+    it('should parse --allowed-scopes from CLI options', () => {
+      commanderMocks.mockCommand.opts.mockReturnValue({ allowedScopes: 'Mail.Read Files.Read' });
 
       const result = parseArgs();
 
-      expect(result.authScopes).toBe('Mail.Read Files.Read');
+      expect(result.allowedScopes).toBe('Mail.Read Files.Read');
     });
 
-    it('should use MS365_MCP_AUTH_SCOPES as a fallback', () => {
-      process.env.MS365_MCP_AUTH_SCOPES = 'Mail.Read Files.Read';
+    it('should use MS365_MCP_ALLOWED_SCOPES as a fallback', () => {
+      process.env.MS365_MCP_ALLOWED_SCOPES = 'Mail.Read Files.Read';
       commanderMocks.mockCommand.opts.mockReturnValue({});
 
       const result = parseArgs();
 
-      expect(result.authScopes).toBe('Mail.Read Files.Read');
+      expect(result.allowedScopes).toBe('Mail.Read Files.Read');
     });
 
-    it('should prefer CLI auth scopes over environment auth scopes', () => {
-      process.env.MS365_MCP_AUTH_SCOPES = 'Files.Read';
-      commanderMocks.mockCommand.opts.mockReturnValue({ authScopes: 'Mail.Read' });
+    it('should prefer CLI allowed scopes over environment allowed scopes', () => {
+      process.env.MS365_MCP_ALLOWED_SCOPES = 'Files.Read';
+      commanderMocks.mockCommand.opts.mockReturnValue({ allowedScopes: 'Mail.Read' });
 
       const result = parseArgs();
 
-      expect(result.authScopes).toBe('Mail.Read');
+      expect(result.allowedScopes).toBe('Mail.Read');
     });
 
-    it('should fail closed when auth scopes are supplied empty', () => {
-      commanderMocks.mockCommand.opts.mockReturnValue({ authScopes: '   ' });
+    it('should fail closed when allowed scopes are supplied empty', () => {
+      commanderMocks.mockCommand.opts.mockReturnValue({ allowedScopes: '   ' });
 
       parseArgs();
 
-      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--auth-scopes'));
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--allowed-scopes'));
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('should fail closed when allowed scopes env var is supplied empty', () => {
+      process.env.MS365_MCP_ALLOWED_SCOPES = '   ';
+      commanderMocks.mockCommand.opts.mockReturnValue({});
+
+      parseArgs();
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('MS365_MCP_ALLOWED_SCOPES')
+      );
       expect(process.exit).toHaveBeenCalledWith(1);
     });
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { parseArgs } from '../src/cli.js';
 
-vi.mock('commander', () => {
+const commanderMocks = vi.hoisted(() => {
   const mockCommand = {
     name: vi.fn().mockReturnThis(),
     description: vi.fn().mockReturnThis(),
@@ -12,6 +12,10 @@ vi.mock('commander', () => {
     opts: vi.fn().mockReturnValue({ file: 'test.xlsx' }),
   };
 
+  return { mockCommand };
+});
+
+vi.mock('commander', () => {
   class MockOption {
     constructor(
       public flags: string,
@@ -23,7 +27,7 @@ vi.mock('commander', () => {
   }
 
   return {
-    Command: vi.fn(() => mockCommand),
+    Command: vi.fn(() => commanderMocks.mockCommand),
     Option: MockOption,
   };
 });
@@ -38,20 +42,58 @@ vi.mock('../src/auth.js', () => {
 });
 vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 vi.spyOn(process, 'exit').mockImplementation(() => {});
+vi.spyOn(console, 'error').mockImplementation(() => {});
 
 describe('CLI Module', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    commanderMocks.mockCommand.opts.mockReturnValue({ file: 'test.xlsx' });
+    delete process.env.MS365_MCP_AUTH_SCOPES;
   });
 
   afterEach(() => {
-    vi.resetAllMocks();
+    delete process.env.MS365_MCP_AUTH_SCOPES;
   });
 
   describe('parseArgs', () => {
     it('should return command options', () => {
       const result = parseArgs();
       expect(result).toEqual({ file: 'test.xlsx' });
+    });
+
+    it('should parse --auth-scopes from CLI options', () => {
+      commanderMocks.mockCommand.opts.mockReturnValue({ authScopes: 'Mail.Read Files.Read' });
+
+      const result = parseArgs();
+
+      expect(result.authScopes).toBe('Mail.Read Files.Read');
+    });
+
+    it('should use MS365_MCP_AUTH_SCOPES as a fallback', () => {
+      process.env.MS365_MCP_AUTH_SCOPES = 'Mail.Read Files.Read';
+      commanderMocks.mockCommand.opts.mockReturnValue({});
+
+      const result = parseArgs();
+
+      expect(result.authScopes).toBe('Mail.Read Files.Read');
+    });
+
+    it('should prefer CLI auth scopes over environment auth scopes', () => {
+      process.env.MS365_MCP_AUTH_SCOPES = 'Files.Read';
+      commanderMocks.mockCommand.opts.mockReturnValue({ authScopes: 'Mail.Read' });
+
+      const result = parseArgs();
+
+      expect(result.authScopes).toBe('Mail.Read');
+    });
+
+    it('should fail closed when auth scopes are supplied empty', () => {
+      commanderMocks.mockCommand.opts.mockReturnValue({ authScopes: '   ' });
+
+      parseArgs();
+
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--auth-scopes'));
+      expect(process.exit).toHaveBeenCalledWith(1);
     });
   });
 });

--- a/test/list-permissions.test.ts
+++ b/test/list-permissions.test.ts
@@ -1,24 +1,41 @@
 import { describe, expect, it } from 'vitest';
-import { buildScopeDiagnostics } from '../src/auth.js';
+import { buildAllowedScopeDiagnostics, buildScopeDiagnostics } from '../src/auth.js';
 
 describe('--list-permissions diagnostics', () => {
-  it('prints legacy permissions alias and hierarchy-aware diagnostics', () => {
-    const output = buildScopeDiagnostics(
-      ['Files.Read', 'Mail.Read'],
-      ['Mail.ReadWrite', 'Files.ReadWrite.All', 'User.Read']
-    );
+  it('prints legacy permissions alias for effective permissions', () => {
+    const output = buildAllowedScopeDiagnostics({
+      enabledTools: 'list-mail-messages|list-drive-items',
+      allowedScopes: 'Mail.ReadWrite Files.ReadWrite.All User.Read',
+    });
 
-    expect(output.permissions).toEqual(output.toolPermissions);
-    expect(output.authScopes).toEqual(['Files.ReadWrite.All', 'Mail.ReadWrite', 'User.Read']);
-    expect(output.missingAuthScopesForEnabledTools).toEqual([]);
-    expect(output.extraAuthScopesNotImpliedByTools).toEqual(
-      expect.arrayContaining(['Files.ReadWrite.All', 'Mail.ReadWrite', 'User.Read'])
+    expect(output.permissions).toEqual(output.effectivePermissions);
+    expect(output.allowedScopes).toEqual(['Files.ReadWrite.All', 'Mail.ReadWrite', 'User.Read']);
+    expect(output.missingAllowedScopesForTools).toEqual([]);
+    expect(output.extraAllowedScopesNotUsedByTools).not.toContain('Mail.ReadWrite');
+  });
+
+  it('reports disabled tools and missing scopes', () => {
+    const output = buildAllowedScopeDiagnostics({
+      enabledTools: 'list-mail-messages|list-calendar-events',
+      allowedScopes: 'Mail.Read',
+    });
+
+    expect(output.toolPermissions).toEqual(expect.arrayContaining(['Mail.Read', 'Calendars.Read']));
+    expect(output.effectivePermissions).toEqual(['Mail.Read']);
+    expect(output.permissions).toEqual(output.effectivePermissions);
+    expect(output.disabledTools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          toolName: 'list-calendar-events',
+          missingScopes: ['Calendars.Read'],
+        }),
+      ])
     );
   });
 
-  it('reports missing scopes without treating hierarchy coverage as missing', () => {
+  it('keeps hierarchy coverage from reporting false missing scopes', () => {
     const output = buildScopeDiagnostics(['Files.Read', 'Mail.Read'], ['Mail.Read']);
 
-    expect(output.missingAuthScopesForEnabledTools).toEqual(['Files.Read']);
+    expect(output.missingAllowedScopesForTools).toEqual(['Files.Read']);
   });
 });

--- a/test/list-permissions.test.ts
+++ b/test/list-permissions.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { buildScopeDiagnostics } from '../src/auth.js';
+
+describe('--list-permissions diagnostics', () => {
+  it('prints legacy permissions alias and hierarchy-aware diagnostics', () => {
+    const output = buildScopeDiagnostics(
+      ['Files.Read', 'Mail.Read'],
+      ['Mail.ReadWrite', 'Files.ReadWrite.All', 'User.Read']
+    );
+
+    expect(output.permissions).toEqual(output.toolPermissions);
+    expect(output.authScopes).toEqual(['Files.ReadWrite.All', 'Mail.ReadWrite', 'User.Read']);
+    expect(output.missingAuthScopesForEnabledTools).toEqual([]);
+    expect(output.extraAuthScopesNotImpliedByTools).toEqual(
+      expect.arrayContaining(['Files.ReadWrite.All', 'Mail.ReadWrite', 'User.Read'])
+    );
+  });
+
+  it('reports missing scopes without treating hierarchy coverage as missing', () => {
+    const output = buildScopeDiagnostics(['Files.Read', 'Mail.Read'], ['Mail.Read']);
+
+    expect(output.missingAuthScopesForEnabledTools).toEqual(['Files.Read']);
+  });
+});

--- a/test/scope-derivation.test.ts
+++ b/test/scope-derivation.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { buildScopesFromEndpoints } from '../src/auth.js';
+import {
+  buildScopesFromEndpoints,
+  collapseScopeHierarchy,
+  parseExplicitAuthScopes,
+  resolveAuthScopes,
+} from '../src/auth.js';
 
 describe('buildScopesFromEndpoints', () => {
   it('returns a non-empty scope set with default arguments', () => {
@@ -56,6 +61,62 @@ describe('buildScopesFromEndpoints', () => {
     it('includes Files.Read and Sites.Read.All for read-only search tools', () => {
       expect(scopes).toContain('Files.Read');
       expect(scopes).toContain('Sites.Read.All');
+    });
+  });
+});
+
+describe('explicit auth scope helpers', () => {
+  describe('parseExplicitAuthScopes', () => {
+    it('returns undefined when no value is provided', () => {
+      expect(parseExplicitAuthScopes()).toBeUndefined();
+    });
+
+    it('splits on whitespace, trims, and deduplicates scopes', () => {
+      expect(parseExplicitAuthScopes('  Mail.Read   Files.Read\nMail.Read\tUser.Read  ')).toEqual([
+        'Mail.Read',
+        'Files.Read',
+        'User.Read',
+      ]);
+    });
+
+    it('returns an empty array for supplied empty input', () => {
+      expect(parseExplicitAuthScopes('   ')).toEqual([]);
+    });
+  });
+
+  describe('resolveAuthScopes', () => {
+    it('uses explicit auth scopes when supplied', () => {
+      expect(resolveAuthScopes({ authScopes: 'Mail.Read Files.Read' })).toEqual([
+        'Mail.Read',
+        'Files.Read',
+      ]);
+    });
+
+    it('falls back to tool-derived scopes when no explicit auth scopes are supplied', () => {
+      expect(
+        resolveAuthScopes({ orgMode: true, enabledTools: 'search|query', readOnly: true })
+      ).toEqual(buildScopesFromEndpoints(true, 'search|query', true));
+    });
+  });
+
+  describe('collapseScopeHierarchy', () => {
+    it('expands existing ReadWrite hierarchy for diagnostics', () => {
+      expect(collapseScopeHierarchy(['Mail.ReadWrite'])).toEqual(
+        expect.arrayContaining(['Mail.ReadWrite', 'Mail.Read'])
+      );
+    });
+
+    it('treats broad .All Graph scopes as covering narrower read scopes', () => {
+      expect(collapseScopeHierarchy(['Files.ReadWrite.All', 'Sites.ReadWrite.All'])).toEqual(
+        expect.arrayContaining([
+          'Files.ReadWrite.All',
+          'Files.Read.All',
+          'Files.ReadWrite',
+          'Files.Read',
+          'Sites.ReadWrite.All',
+          'Sites.Read.All',
+        ])
+      );
     });
   });
 });

--- a/test/scope-derivation.test.ts
+++ b/test/scope-derivation.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   buildScopesFromEndpoints,
   collapseScopeHierarchy,
-  parseExplicitAuthScopes,
+  parseAllowedScopes,
   resolveAuthScopes,
 } from '../src/auth.js';
 
@@ -65,14 +65,14 @@ describe('buildScopesFromEndpoints', () => {
   });
 });
 
-describe('explicit auth scope helpers', () => {
-  describe('parseExplicitAuthScopes', () => {
+describe('allowed scope helpers', () => {
+  describe('parseAllowedScopes', () => {
     it('returns undefined when no value is provided', () => {
-      expect(parseExplicitAuthScopes()).toBeUndefined();
+      expect(parseAllowedScopes()).toBeUndefined();
     });
 
     it('splits on whitespace, trims, and deduplicates scopes', () => {
-      expect(parseExplicitAuthScopes('  Mail.Read   Files.Read\nMail.Read\tUser.Read  ')).toEqual([
+      expect(parseAllowedScopes('  Mail.Read   Files.Read\nMail.Read\tUser.Read  ')).toEqual([
         'Mail.Read',
         'Files.Read',
         'User.Read',
@@ -80,22 +80,35 @@ describe('explicit auth scope helpers', () => {
     });
 
     it('returns an empty array for supplied empty input', () => {
-      expect(parseExplicitAuthScopes('   ')).toEqual([]);
+      expect(parseAllowedScopes('   ')).toEqual([]);
     });
   });
 
   describe('resolveAuthScopes', () => {
-    it('uses explicit auth scopes when supplied', () => {
-      expect(resolveAuthScopes({ authScopes: 'Mail.Read Files.Read' })).toEqual([
-        'Mail.Read',
-        'Files.Read',
-      ]);
-    });
-
-    it('falls back to tool-derived scopes when no explicit auth scopes are supplied', () => {
+    it('uses tool-derived scopes when allowed scopes are not supplied', () => {
       expect(
         resolveAuthScopes({ orgMode: true, enabledTools: 'search|query', readOnly: true })
       ).toEqual(buildScopesFromEndpoints(true, 'search|query', true));
+    });
+
+    it('filters tool-derived scopes when allowed scopes are supplied', () => {
+      expect(
+        resolveAuthScopes({
+          orgMode: true,
+          enabledTools: 'mail|drive',
+          allowedScopes: 'Mail.Read Files.Read',
+        })
+      ).toEqual(expect.arrayContaining(['Files.Read', 'Mail.Read']));
+    });
+
+    it('treats broader allowed scopes as covering narrower tool scopes', () => {
+      const scopes = resolveAuthScopes({
+        enabledTools: 'list-mail-messages',
+        allowedScopes: 'Mail.ReadWrite',
+        readOnly: true,
+      });
+
+      expect(scopes).toEqual(['Mail.Read']);
     });
   });
 


### PR DESCRIPTION
## Summary
- Replaces the explicit auth-scope override with `--allowed-scopes` / `MS365_MCP_ALLOWED_SCOPES` as a tool-surface boundary.
- Filters the normal Graph tool surface after `--enabled-tools`, `--preset`, `--org-mode`, and `--read-only`, and logs tools hidden by missing allowed scopes.
- Updates OAuth metadata, authorize redirects, and `--list-permissions` diagnostics to use effective permissions from the filtered tool set while preserving OBO protected-resource metadata.

## Notes
- Default behavior is unchanged when `--allowed-scopes` is not configured.
- Scope coverage is hierarchy-aware, so broader scopes such as `Mail.ReadWrite` cover narrower read tools.
- Durable headless token-cache storage and account pinning are intentionally left as separate follow-up concerns.

## Validation
- `npm test -- test/allowed-scopes.test.ts test/list-permissions.test.ts test/scope-derivation.test.ts test/cli.test.ts test/tool-filtering.test.ts test/http-oauth-fix.test.ts src/__tests__/graph-tools.test.ts`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `npx prettier --check README.md src/auth.ts src/cli.ts src/graph-tools.ts src/index.ts src/server.ts test/allowed-scopes.test.ts test/cli.test.ts test/list-permissions.test.ts test/scope-derivation.test.ts src/__tests__/graph-tools.test.ts`
- `npm test -- test/auth-paths.test.ts src/__tests__/graph-tools.test.ts`

## Caveats
- `npm run format:check` still reports pre-existing formatting drift across untouched files.
- Full `npm test` timed out in two tests during the whole-suite run on Windows; both timed-out files passed when rerun directly.

Made with [Cursor](https://cursor.com)