### PR TITLE
feat(auth): add strict account pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,32 @@ npx @softeria/ms-365-mcp-server --list-accounts
 - **100% backward compatible**: existing single-account setups work unchanged.
 - The `account` parameter accepts email address (e.g. `user@outlook.com`) or MSAL `homeAccountId`.
 
+### Strict Account Pinning
+
+Headless stdio deployments can pin the local MSAL cache to one expected Microsoft account:
+
+```bash
+# Username matching is case-insensitive
+MS365_MCP_EXPECTED_USERNAME=work@company.com npx @softeria/ms-365-mcp-server --login
+
+# Or pin the exact MSAL homeAccountId shown by --list-accounts
+npx @softeria/ms-365-mcp-server --expected-home-account-id <homeAccountId> --login
+```
+
+Use `--list-accounts` to discover `homeAccountId` values. The MCP `list-accounts` tool intentionally hides account IDs, so use the CLI for exact ID pinning.
+
+Pinning is opt-in and local-MSAL only:
+
+- CLI values (`--expected-username`, `--expected-home-account-id`) take precedence over `MS365_MCP_EXPECTED_USERNAME` and `MS365_MCP_EXPECTED_HOME_ACCOUNT_ID`.
+- Supplying an empty pin value fails at startup instead of being ignored.
+- Username pins are compared case-insensitively; `homeAccountId` pins are exact.
+- If both pins are set, they must resolve to the same cached account.
+- Local stdio startup fails fast when the expected account is not in the token cache. Bootstrap by setting the pin, running `--login`, then starting the headless server.
+- Device-code and browser logins reject a missing or mismatched account before persisting the selected account or token cache.
+- Pinning collapses the effective MCP mode to single-account: the server does not advertise an `account` parameter and MCP instructions do not suggest account switching.
+- `--http`, `--obo`, and `MS365_MCP_OAUTH_TOKEN` use request-provided tokens for Graph calls, so account pins are warning-only in those modes. If HTTP auth tools are enabled, the pin still applies to those local MSAL helper flows.
+- `--logout` clears all cached accounts, including the pinned account. For surgical cleanup, prefer `--remove-account <id>`.
+
 > **For MCP multiplexers (Legate, Governor):** Multi-account mode replaces the N-process pattern. Instead of spawning one server per account, a single instance handles all accounts via the `account` parameter, reducing tool duplication from N×110 to 110.
 
 ## Tool Presets
@@ -504,6 +530,8 @@ The following options can be used when running ms-365-mcp-server directly from t
 --force-work-scopes Backwards compatibility alias for --org-mode (deprecated)
 --cloud <type>    Microsoft cloud environment: global (default) or china (21Vianet)
 --allowed-scopes <scopes> Limit exposed tools to Graph scopes covered by this allowlist
+--expected-username <username> Require local MSAL auth to use this account username
+--expected-home-account-id <id> Require local MSAL auth to use this exact homeAccountId
 ```
 
 ### Server Options
@@ -543,6 +571,8 @@ Environment variables:
 - `MS365_MCP_KEYVAULT_URL`: Azure Key Vault URL for secrets management (see Azure Key Vault section)
 - `MS365_MCP_TOKEN_CACHE_PATH`: Custom file path for MSAL token cache (see Token Storage below)
 - `MS365_MCP_SELECTED_ACCOUNT_PATH`: Custom file path for selected account metadata (see Token Storage below)
+- `MS365_MCP_EXPECTED_USERNAME`: Require local MSAL auth to use this Microsoft account username (case-insensitive; CLI flag takes precedence)
+- `MS365_MCP_EXPECTED_HOME_ACCOUNT_ID`: Require local MSAL auth to use this exact MSAL homeAccountId (CLI flag takes precedence)
 
 ## Token Storage
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -194,6 +194,7 @@ The client automatically discovers OAuth endpoints and opens a browser for authe
 ## Security Considerations
 
 - **Stateless**: the server does not store tokens — each request carries the user's Bearer token
+- **Account pinning**: `MS365_MCP_EXPECTED_USERNAME` and `MS365_MCP_EXPECTED_HOME_ACCOUNT_ID` protect local MSAL cache flows for headless stdio deployments. In `--http`, `--obo`, or `MS365_MCP_OAUTH_TOKEN` deployments they are warning-only because Graph calls use request-provided tokens.
 - **Admin consent**: grant tenant-wide consent to avoid per-user consent prompts
 - **Managed identity**: use managed identity for Key Vault access (no secrets in environment variables)
 - **Read-only mode**: use `--read-only` to disable all write operations (send, delete, update, create)

--- a/src/auth-tools.ts
+++ b/src/auth-tools.ts
@@ -96,7 +96,15 @@ export function registerAuthTools(server: McpServer, authManager: AuthManager): 
   });
 
   server.tool('verify-login', 'Check current Microsoft authentication status', {}, async () => {
-    const testResult = await authManager.testLogin();
+    let testResult: Awaited<ReturnType<AuthManager['testLogin']>>;
+    try {
+      testResult = await authManager.testLogin();
+    } catch (error) {
+      testResult = {
+        success: false,
+        message: `Login failed: ${(error as Error).message}`,
+      };
+    }
 
     return {
       content: [
@@ -121,6 +129,7 @@ export function registerAuthTools(server: McpServer, authManager: AuthManager): 
       try {
         const accounts = await authManager.listAccounts();
         const selectedAccountId = authManager.getSelectedAccountId();
+        const pinnedMode = authManager.hasExpectedAccount();
         const result = accounts.map((account) => ({
           email: account.username || 'unknown',
           name: account.name,
@@ -134,7 +143,9 @@ export function registerAuthTools(server: McpServer, authManager: AuthManager): 
               text: JSON.stringify({
                 accounts: result,
                 count: result.length,
-                tip: "Pass the 'email' value as the 'account' parameter in any tool call to target a specific account.",
+                tip: pinnedMode
+                  ? 'Expected account pinning is configured; account parameters are disabled.'
+                  : "Pass the 'email' value as the 'account' parameter in any tool call to target a specific account.",
               }),
             },
           ],

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -443,6 +443,11 @@ interface LoginTestResult {
   };
 }
 
+interface ExpectedAccountOptions {
+  expectedUsername?: string;
+  expectedHomeAccountId?: string;
+}
+
 class AuthManager {
   private config: Configuration;
   private scopes: string[];
@@ -453,8 +458,14 @@ class AuthManager {
   private isOAuthMode: boolean;
   private selectedAccountId: string | null;
   private useInteractiveAuth: boolean;
+  private expectedUsername: string | null;
+  private expectedHomeAccountId: string | null;
 
-  constructor(config: Configuration, scopes: string[] = []) {
+  constructor(
+    config: Configuration,
+    scopes: string[] = [],
+    expectedAccount?: ExpectedAccountOptions
+  ) {
     logger.info(`And scopes are ${scopes.join(', ')}`, scopes);
     this.config = config;
     this.scopes = scopes;
@@ -463,6 +474,10 @@ class AuthManager {
     this.tokenExpiry = null;
     this.selectedAccountId = null;
     this.useInteractiveAuth = false;
+    this.expectedUsername = this.normalizeExpectedUsername(expectedAccount?.expectedUsername);
+    this.expectedHomeAccountId = this.normalizeExpectedHomeAccountId(
+      expectedAccount?.expectedHomeAccountId
+    );
 
     const oauthTokenFromEnv = process.env.MS365_MCP_OAUTH_TOKEN;
     this.oauthToken = oauthTokenFromEnv ?? null;
@@ -473,10 +488,13 @@ class AuthManager {
    * Creates an AuthManager instance with secrets loaded from the configured provider.
    * Uses Key Vault if MS365_MCP_KEYVAULT_URL is set, otherwise environment variables.
    */
-  static async create(scopes: string[] = []): Promise<AuthManager> {
+  static async create(
+    scopes: string[] = [],
+    expectedAccount?: ExpectedAccountOptions
+  ): Promise<AuthManager> {
     const secrets = await getSecrets();
     const config = createMsalConfig(secrets);
-    return new AuthManager(config, scopes);
+    return new AuthManager(config, scopes, expectedAccount);
   }
 
   async loadTokenCache(): Promise<void> {
@@ -594,6 +612,146 @@ class AuthManager {
     }
   }
 
+  private normalizeExpectedUsername(value?: string): string | null {
+    if (value === undefined) {
+      return null;
+    }
+    const trimmed = value.trim();
+    if (trimmed === '') {
+      throw new Error('Expected Microsoft account username was provided but is empty.');
+    }
+    return trimmed.toLowerCase();
+  }
+
+  private normalizeExpectedHomeAccountId(value?: string): string | null {
+    if (value === undefined) {
+      return null;
+    }
+    const trimmed = value.trim();
+    if (trimmed === '') {
+      throw new Error('Expected Microsoft account homeAccountId was provided but is empty.');
+    }
+    return trimmed;
+  }
+
+  hasExpectedAccount(): boolean {
+    return this.expectedUsername !== null || this.expectedHomeAccountId !== null;
+  }
+
+  private expectedAccountLabel(): string {
+    const parts: string[] = [];
+    if (this.expectedUsername) {
+      parts.push(`username ${this.expectedUsername}`);
+    }
+    if (this.expectedHomeAccountId) {
+      parts.push(`homeAccountId ${this.expectedHomeAccountId}`);
+    }
+    return parts.join(' and ');
+  }
+
+  private describeAccount(account: AccountInfo | null | undefined): string {
+    return account?.username || account?.name || 'unknown';
+  }
+
+  private describeCachedAccounts(accounts: AccountInfo[]): string {
+    if (accounts.length === 0) {
+      return 'none';
+    }
+    return accounts.map((account) => this.describeAccount(account)).join(', ');
+  }
+
+  private accountMatchesExpected(account: AccountInfo | null | undefined): boolean {
+    if (!this.hasExpectedAccount() || !account) {
+      return !this.hasExpectedAccount();
+    }
+    if (this.expectedUsername && account.username?.toLowerCase() !== this.expectedUsername) {
+      return false;
+    }
+    if (this.expectedHomeAccountId && account.homeAccountId !== this.expectedHomeAccountId) {
+      return false;
+    }
+    return true;
+  }
+
+  private buildExpectedAccountMissingError(accounts: AccountInfo[]): Error {
+    return new Error(
+      `Expected Microsoft account '${this.expectedAccountLabel()}' not found in token cache. ` +
+        `Cached accounts: ${this.describeCachedAccounts(accounts)}. ` +
+        'Run --login after configuring the expected account, or use --select-account to recover.'
+    );
+  }
+
+  private resolveExpectedAccountFromAccounts(accounts: AccountInfo[]): AccountInfo {
+    if (!this.hasExpectedAccount()) {
+      throw new Error('No expected Microsoft account is configured.');
+    }
+
+    const usernameMatch = this.expectedUsername
+      ? accounts.find((account) => account.username?.toLowerCase() === this.expectedUsername)
+      : undefined;
+    const homeAccountIdMatch = this.expectedHomeAccountId
+      ? accounts.find((account) => account.homeAccountId === this.expectedHomeAccountId)
+      : undefined;
+
+    if (this.expectedUsername && this.expectedHomeAccountId) {
+      if (!usernameMatch || !homeAccountIdMatch) {
+        throw this.buildExpectedAccountMissingError(accounts);
+      }
+      if (usernameMatch.homeAccountId !== homeAccountIdMatch.homeAccountId) {
+        throw new Error(
+          `Expected Microsoft account pins conflict: username ${this.expectedUsername} matched ` +
+            `${this.describeAccount(usernameMatch)}, but homeAccountId ${this.expectedHomeAccountId} matched ` +
+            `${this.describeAccount(homeAccountIdMatch)}.`
+        );
+      }
+      return usernameMatch;
+    }
+
+    const expectedAccount = usernameMatch ?? homeAccountIdMatch;
+    if (!expectedAccount) {
+      throw this.buildExpectedAccountMissingError(accounts);
+    }
+    return expectedAccount;
+  }
+
+  async assertExpectedAccountAvailable(): Promise<void> {
+    if (!this.hasExpectedAccount()) {
+      return;
+    }
+    const accounts = await this.msalApp.getTokenCache().getAllAccounts();
+    this.resolveExpectedAccountFromAccounts(accounts);
+  }
+
+  private async rejectUnexpectedLoginAccount(
+    account: AccountInfo | null | undefined
+  ): Promise<void> {
+    if (!this.hasExpectedAccount()) {
+      return;
+    }
+
+    if (this.accountMatchesExpected(account)) {
+      return;
+    }
+
+    this.accessToken = null;
+    this.tokenExpiry = null;
+
+    if (account) {
+      try {
+        await this.msalApp.getTokenCache().removeAccount(account);
+      } catch (error) {
+        logger.warn(`Failed to remove unexpected account from cache: ${(error as Error).message}`);
+      }
+      throw new Error(
+        `Authenticated Microsoft account '${this.describeAccount(account)}' does not match expected Microsoft account '${this.expectedAccountLabel()}'. Login was not persisted.`
+      );
+    }
+
+    throw new Error(
+      `Microsoft login did not return an account. Expected Microsoft account '${this.expectedAccountLabel()}'. Login was not persisted.`
+    );
+  }
+
   async setOAuthToken(token: string): Promise<void> {
     this.oauthToken = token;
     this.isOAuthMode = true;
@@ -633,6 +791,10 @@ class AuthManager {
 
   async getCurrentAccount(): Promise<AccountInfo | null> {
     const accounts = await this.msalApp.getTokenCache().getAllAccounts();
+
+    if (this.hasExpectedAccount()) {
+      return this.resolveExpectedAccountFromAccounts(accounts);
+    }
 
     if (accounts.length === 0) {
       return null;
@@ -677,6 +839,7 @@ class AuthManager {
       logger.info('Device code login successful');
       this.accessToken = response?.accessToken || null;
       this.tokenExpiry = response?.expiresOn ? new Date(response.expiresOn).getTime() : null;
+      await this.rejectUnexpectedLoginAccount(response?.account);
 
       // Set the newly authenticated account as selected if no account is currently selected
       if (!this.selectedAccountId && response?.account) {
@@ -727,6 +890,7 @@ class AuthManager {
       logger.info('Interactive browser login successful');
       this.accessToken = response?.accessToken || null;
       this.tokenExpiry = response?.expiresOn ? new Date(response.expiresOn).getTime() : null;
+      await this.rejectUnexpectedLoginAccount(response?.account);
 
       // Set the newly authenticated account as selected if no account is currently selected
       if (!this.selectedAccountId && response?.account) {
@@ -846,6 +1010,11 @@ class AuthManager {
 
   async selectAccount(identifier: string): Promise<boolean> {
     const account = await this.resolveAccount(identifier);
+    if (this.hasExpectedAccount() && !this.accountMatchesExpected(account)) {
+      throw new Error(
+        `Account '${identifier}' does not match expected Microsoft account '${this.expectedAccountLabel()}'.`
+      );
+    }
 
     this.selectedAccountId = account.homeAccountId;
     await this.saveSelectedAccount();
@@ -931,6 +1100,9 @@ class AuthManager {
    * Used to decide whether to inject the `account` parameter into tool schemas.
    */
   async isMultiAccount(): Promise<boolean> {
+    if (this.hasExpectedAccount()) {
+      return false;
+    }
     const accounts = await this.msalApp.getTokenCache().getAllAccounts();
     return accounts.length > 1;
   }
@@ -954,7 +1126,18 @@ class AuthManager {
 
     let targetAccount: AccountInfo | null = null;
 
-    if (identifier) {
+    if (this.hasExpectedAccount()) {
+      const accounts = await this.msalApp.getTokenCache().getAllAccounts();
+      targetAccount = this.resolveExpectedAccountFromAccounts(accounts);
+      if (identifier) {
+        const requestedAccount = await this.resolveAccount(identifier);
+        if (requestedAccount.homeAccountId !== targetAccount.homeAccountId) {
+          throw new Error(
+            `Account '${identifier}' does not match expected Microsoft account '${this.expectedAccountLabel()}'.`
+          );
+        }
+      }
+    } else if (identifier) {
       // resolveAccount handles empty-cache check internally
       targetAccount = await this.resolveAccount(identifier);
     } else {
@@ -1006,6 +1189,7 @@ class AuthManager {
 
 export default AuthManager;
 export {
+  type ExpectedAccountOptions,
   buildAllowedScopeDiagnostics,
   buildScopesFromEndpoints,
   buildScopeDiagnostics,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,14 @@ program
   .option('--list-accounts', 'List all cached accounts')
   .option('--select-account <accountId>', 'Select a specific account by ID')
   .option('--remove-account <accountId>', 'Remove a specific account by ID')
+  .option(
+    '--expected-username <username>',
+    'Require local MSAL authentication to use this Microsoft account username'
+  )
+  .option(
+    '--expected-home-account-id <id>',
+    'Require local MSAL authentication to use this exact MSAL homeAccountId'
+  )
   .option('--read-only', 'Start server in read-only mode, disabling write operations')
   .option(
     '--http [address]',
@@ -89,6 +97,8 @@ export interface CommandOptions {
   listAccounts?: boolean;
   selectAccount?: string;
   removeAccount?: string;
+  expectedUsername?: string;
+  expectedHomeAccountId?: string;
   readOnly?: boolean;
   http?: string | boolean;
   enableAuthTools?: boolean;
@@ -159,6 +169,44 @@ export function parseArgs(): CommandOptions {
         'Provide one or more whitespace-separated scopes, or omit it to use tool-derived scopes.'
     );
     process.exit(1);
+  }
+
+  if (
+    options.expectedUsername === undefined &&
+    process.env.MS365_MCP_EXPECTED_USERNAME !== undefined
+  ) {
+    options.expectedUsername = process.env.MS365_MCP_EXPECTED_USERNAME;
+  }
+
+  if (
+    options.expectedHomeAccountId === undefined &&
+    process.env.MS365_MCP_EXPECTED_HOME_ACCOUNT_ID !== undefined
+  ) {
+    options.expectedHomeAccountId = process.env.MS365_MCP_EXPECTED_HOME_ACCOUNT_ID;
+  }
+
+  if (options.expectedUsername !== undefined) {
+    const expectedUsername = String(options.expectedUsername).trim();
+    if (expectedUsername === '') {
+      console.error(
+        'Error: --expected-username / MS365_MCP_EXPECTED_USERNAME was provided but is empty. ' +
+          'Provide a Microsoft account username, or omit it to allow any cached account.'
+      );
+      process.exit(1);
+    }
+    options.expectedUsername = expectedUsername;
+  }
+
+  if (options.expectedHomeAccountId !== undefined) {
+    const expectedHomeAccountId = String(options.expectedHomeAccountId).trim();
+    if (expectedHomeAccountId === '') {
+      console.error(
+        'Error: --expected-home-account-id / MS365_MCP_EXPECTED_HOME_ACCOUNT_ID was provided but is empty. ' +
+          'Provide an MSAL homeAccountId, or omit it to allow any cached account.'
+      );
+      process.exit(1);
+    }
+    options.expectedHomeAccountId = expectedHomeAccountId;
   }
 
   // Validate tool filter regex early — fail at startup instead of silently

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,10 @@ import { parseArgs } from './cli.js';
 import logger from './logger.js';
 import AuthManager, { buildAllowedScopeDiagnostics, resolveAuthScopes } from './auth.js';
 import MicrosoftGraphServer from './server.js';
+import {
+  getExpectedAccountInertWarning,
+  shouldAssertExpectedAccountAtStartup,
+} from './startup-pinning.js';
 import { version } from './version.js';
 
 async function main(): Promise<void> {
@@ -43,12 +47,21 @@ async function main(): Promise<void> {
       process.exit(0);
     }
 
-    const authManager = await AuthManager.create(effectiveScopes);
+    const authManager = await AuthManager.create(effectiveScopes, {
+      expectedUsername: args.expectedUsername,
+      expectedHomeAccountId: args.expectedHomeAccountId,
+    });
     await authManager.loadTokenCache();
 
     if (args.authBrowser) {
       authManager.setUseInteractiveAuth(true);
       logger.info('Browser-based interactive auth enabled');
+    }
+
+    const expectedAccountWarning = getExpectedAccountInertWarning(args, authManager);
+    if (expectedAccountWarning) {
+      logger.warn(expectedAccountWarning);
+      console.error(expectedAccountWarning);
     }
 
     if (args.login) {
@@ -109,6 +122,10 @@ async function main(): Promise<void> {
         process.exit(1);
       }
       process.exit(0);
+    }
+
+    if (shouldAssertExpectedAccountAtStartup(args, authManager)) {
+      await authManager.assertExpectedAccountAvailable();
     }
 
     const server = new MicrosoftGraphServer(authManager, args);

--- a/src/startup-pinning.ts
+++ b/src/startup-pinning.ts
@@ -1,0 +1,53 @@
+import type AuthManager from './auth.js';
+import type { CommandOptions } from './cli.js';
+
+const LOCAL_ACCOUNT_COMMANDS = [
+  'login',
+  'logout',
+  'listAccounts',
+  'selectAccount',
+  'removeAccount',
+  'verifyLogin',
+] as const;
+
+export function getExpectedAccountInertWarning(
+  args: CommandOptions,
+  authManager: Pick<AuthManager, 'hasExpectedAccount' | 'isOAuthModeEnabled'>
+): string | null {
+  if (!authManager.hasExpectedAccount()) {
+    return null;
+  }
+
+  const inertModes: string[] = [];
+  if (args.http) {
+    inertModes.push('--http');
+  }
+  if (args.obo) {
+    inertModes.push('--obo');
+  }
+  if (authManager.isOAuthModeEnabled()) {
+    inertModes.push('MS365_MCP_OAUTH_TOKEN');
+  }
+
+  if (inertModes.length === 0) {
+    return null;
+  }
+
+  return (
+    `Warning: expected account pinning is configured, but ${inertModes.join(', ')} ` +
+    'uses request-provided tokens for Graph calls. The pin only guards local MSAL auth helpers.'
+  );
+}
+
+export function shouldAssertExpectedAccountAtStartup(
+  args: CommandOptions,
+  authManager: Pick<AuthManager, 'hasExpectedAccount' | 'isOAuthModeEnabled'>
+): boolean {
+  if (!authManager.hasExpectedAccount()) {
+    return false;
+  }
+  if (getExpectedAccountInertWarning(args, authManager)) {
+    return false;
+  }
+  return !LOCAL_ACCOUNT_COMMANDS.some((key) => Boolean(args[key]));
+}

--- a/test/auth-paths.test.ts
+++ b/test/auth-paths.test.ts
@@ -1,51 +1,38 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import path from 'path';
+import { getSelectedAccountPath, getTokenCachePath } from '../src/auth.js';
 
 describe('token cache path configuration', () => {
   beforeEach(() => {
     vi.unstubAllEnvs();
-    vi.resetModules();
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
-    vi.resetModules();
   });
 
-  async function importHelpers() {
-    const mod = await import('../src/auth.js');
-    return {
-      getTokenCachePath: mod.getTokenCachePath,
-      getSelectedAccountPath: mod.getSelectedAccountPath,
-    };
-  }
-
   describe('getTokenCachePath', () => {
-    it('should return default path when env var is not set', async () => {
+    it('should return default path when env var is not set', () => {
       vi.stubEnv('MS365_MCP_TOKEN_CACHE_PATH', '');
-      const { getTokenCachePath } = await importHelpers();
       const result = getTokenCachePath();
       expect(result).toContain('.token-cache.json');
       expect(path.isAbsolute(result)).toBe(true);
     });
 
-    it('should return env var path when set', async () => {
+    it('should return env var path when set', () => {
       vi.stubEnv('MS365_MCP_TOKEN_CACHE_PATH', '/tmp/test-cache/.token-cache.json');
-      const { getTokenCachePath } = await importHelpers();
       const result = getTokenCachePath();
       expect(result).toBe('/tmp/test-cache/.token-cache.json');
     });
 
-    it('should trim whitespace from env var', async () => {
+    it('should trim whitespace from env var', () => {
       vi.stubEnv('MS365_MCP_TOKEN_CACHE_PATH', '  /tmp/test-cache/.token-cache.json  ');
-      const { getTokenCachePath } = await importHelpers();
       const result = getTokenCachePath();
       expect(result).toBe('/tmp/test-cache/.token-cache.json');
     });
 
-    it('should return default path when env var is undefined', async () => {
+    it('should return default path when env var is undefined', () => {
       delete process.env.MS365_MCP_TOKEN_CACHE_PATH;
-      const { getTokenCachePath } = await importHelpers();
       const result = getTokenCachePath();
       expect(result).toContain('.token-cache.json');
       expect(path.isAbsolute(result)).toBe(true);
@@ -53,31 +40,27 @@ describe('token cache path configuration', () => {
   });
 
   describe('getSelectedAccountPath', () => {
-    it('should return default path when env var is not set', async () => {
+    it('should return default path when env var is not set', () => {
       vi.stubEnv('MS365_MCP_SELECTED_ACCOUNT_PATH', '');
-      const { getSelectedAccountPath } = await importHelpers();
       const result = getSelectedAccountPath();
       expect(result).toContain('.selected-account.json');
       expect(path.isAbsolute(result)).toBe(true);
     });
 
-    it('should return env var path when set', async () => {
+    it('should return env var path when set', () => {
       vi.stubEnv('MS365_MCP_SELECTED_ACCOUNT_PATH', '/tmp/test-cache/.selected-account.json');
-      const { getSelectedAccountPath } = await importHelpers();
       const result = getSelectedAccountPath();
       expect(result).toBe('/tmp/test-cache/.selected-account.json');
     });
 
-    it('should trim whitespace from env var', async () => {
+    it('should trim whitespace from env var', () => {
       vi.stubEnv('MS365_MCP_SELECTED_ACCOUNT_PATH', '  /tmp/test-cache/.selected-account.json  ');
-      const { getSelectedAccountPath } = await importHelpers();
       const result = getSelectedAccountPath();
       expect(result).toBe('/tmp/test-cache/.selected-account.json');
     });
 
-    it('should return default path when env var is undefined', async () => {
+    it('should return default path when env var is undefined', () => {
       delete process.env.MS365_MCP_SELECTED_ACCOUNT_PATH;
-      const { getSelectedAccountPath } = await importHelpers();
       const result = getSelectedAccountPath();
       expect(result).toContain('.selected-account.json');
       expect(path.isAbsolute(result)).toBe(true);

--- a/test/auth-pinning.test.ts
+++ b/test/auth-pinning.test.ts
@@ -1,0 +1,243 @@
+import type { AccountInfo, Configuration } from '@azure/msal-node';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AuthManager, { type ExpectedAccountOptions } from '../src/auth.js';
+import {
+  getExpectedAccountInertWarning,
+  shouldAssertExpectedAccountAtStartup,
+} from '../src/startup-pinning.js';
+
+vi.mock('../src/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const msalConfig: Configuration = {
+  auth: {
+    clientId: 'test-client',
+    authority: 'https://login.microsoftonline.com/common',
+  },
+};
+
+const personal = {
+  username: 'Personal@Example.com',
+  name: 'Personal User',
+  homeAccountId: 'personal.home',
+} as AccountInfo;
+
+const work = {
+  username: 'work@example.com',
+  name: 'Work User',
+  homeAccountId: 'work.home',
+} as AccountInfo;
+
+function createAuth(accounts: AccountInfo[], expectedAccount?: ExpectedAccountOptions) {
+  const tokenCache = {
+    getAllAccounts: vi.fn().mockResolvedValue(accounts),
+    removeAccount: vi.fn().mockResolvedValue(undefined),
+  };
+  const msalApp = {
+    getTokenCache: vi.fn(() => tokenCache),
+    acquireTokenSilent: vi.fn().mockResolvedValue({
+      accessToken: 'silent-token',
+      expiresOn: new Date(Date.now() + 60_000),
+    }),
+    acquireTokenByDeviceCode: vi.fn(),
+    acquireTokenInteractive: vi.fn(),
+  };
+  const auth = new AuthManager(msalConfig, ['User.Read'], expectedAccount);
+
+  Object.assign(auth as unknown as Record<string, unknown>, {
+    msalApp,
+    saveTokenCache: vi.fn(),
+    saveSelectedAccount: vi.fn(),
+  });
+
+  return { auth, msalApp, tokenCache };
+}
+
+describe('strict expected account pinning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves expected usernames case-insensitively', async () => {
+    const { auth } = createAuth([personal, work], {
+      expectedUsername: ' personal@example.com ',
+    });
+
+    const account = await auth.getCurrentAccount();
+
+    expect(account?.homeAccountId).toBe('personal.home');
+  });
+
+  it('matches expected homeAccountId exactly', async () => {
+    const { auth } = createAuth([personal, work], {
+      expectedHomeAccountId: 'work.home',
+    });
+
+    const account = await auth.getCurrentAccount();
+
+    expect(account?.username).toBe('work@example.com');
+  });
+
+  it('fails fast when no cached account matches the pin', async () => {
+    const { auth } = createAuth([personal], {
+      expectedUsername: 'missing@example.com',
+    });
+
+    await expect(auth.assertExpectedAccountAvailable()).rejects.toThrow(
+      /Expected Microsoft account/
+    );
+  });
+
+  it('fails when username and homeAccountId pins resolve to different accounts', async () => {
+    const { auth } = createAuth([personal, work], {
+      expectedUsername: 'personal@example.com',
+      expectedHomeAccountId: 'work.home',
+    });
+
+    await expect(auth.assertExpectedAccountAvailable()).rejects.toThrow(/pins conflict/);
+  });
+
+  it('uses the pinned account for silent token acquisition', async () => {
+    const { auth, msalApp } = createAuth([personal, work], {
+      expectedUsername: 'work@example.com',
+    });
+
+    await auth.getToken();
+
+    expect(msalApp.acquireTokenSilent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: work,
+      })
+    );
+  });
+
+  it('rejects explicit account overrides that do not match the pin', async () => {
+    const { auth } = createAuth([personal, work], {
+      expectedUsername: 'work@example.com',
+    });
+
+    await expect(auth.getTokenForAccount('personal@example.com')).rejects.toThrow(
+      /does not match expected Microsoft account/
+    );
+  });
+
+  it('rejects select-account values that do not match the pin', async () => {
+    const { auth } = createAuth([personal, work], {
+      expectedUsername: 'work@example.com',
+    });
+
+    await expect(auth.selectAccount('personal@example.com')).rejects.toThrow(
+      /does not match expected Microsoft account/
+    );
+    expect(
+      (auth as unknown as { saveSelectedAccount: ReturnType<typeof vi.fn> }).saveSelectedAccount
+    ).not.toHaveBeenCalled();
+  });
+
+  it('does not persist a mismatched device-code login account', async () => {
+    const { auth, msalApp, tokenCache } = createAuth([personal], {
+      expectedUsername: 'work@example.com',
+    });
+    msalApp.acquireTokenByDeviceCode.mockResolvedValue({
+      accessToken: 'bad-token',
+      expiresOn: new Date(Date.now() + 60_000),
+      account: personal,
+      scopes: ['User.Read'],
+    });
+
+    await expect(auth.acquireTokenByDeviceCode()).rejects.toThrow(/does not match expected/);
+
+    expect(tokenCache.removeAccount).toHaveBeenCalledWith(personal);
+    expect(
+      (auth as unknown as { saveTokenCache: ReturnType<typeof vi.fn> }).saveTokenCache
+    ).not.toHaveBeenCalled();
+    expect(
+      (auth as unknown as { saveSelectedAccount: ReturnType<typeof vi.fn> }).saveSelectedAccount
+    ).not.toHaveBeenCalled();
+    expect((auth as unknown as { accessToken: string | null }).accessToken).toBeNull();
+  });
+
+  it('rejects login responses that do not include an account', async () => {
+    const { auth, msalApp, tokenCache } = createAuth([], {
+      expectedUsername: 'work@example.com',
+    });
+    msalApp.acquireTokenByDeviceCode.mockResolvedValue({
+      accessToken: 'bad-token',
+      expiresOn: new Date(Date.now() + 60_000),
+      account: null,
+      scopes: ['User.Read'],
+    });
+
+    await expect(auth.acquireTokenByDeviceCode()).rejects.toThrow(/did not return an account/);
+
+    expect(tokenCache.removeAccount).not.toHaveBeenCalled();
+    expect(
+      (auth as unknown as { saveTokenCache: ReturnType<typeof vi.fn> }).saveTokenCache
+    ).not.toHaveBeenCalled();
+  });
+
+  it('collapses effective multi-account mode when a pin is configured', async () => {
+    const { auth } = createAuth([personal, work], {
+      expectedUsername: 'work@example.com',
+    });
+
+    await expect(auth.isMultiAccount()).resolves.toBe(false);
+  });
+
+  it('leaves BYOT token mode inert for account pinning', async () => {
+    const { auth, tokenCache } = createAuth([personal, work], {
+      expectedUsername: 'work@example.com',
+    });
+    Object.assign(auth as unknown as Record<string, unknown>, {
+      oauthToken: 'byot-token',
+      isOAuthMode: true,
+    });
+
+    await expect(auth.getTokenForAccount('personal@example.com')).resolves.toBe('byot-token');
+    expect(tokenCache.getAllAccounts).not.toHaveBeenCalled();
+  });
+});
+
+describe('expected account startup behavior', () => {
+  const pinnedAuth = {
+    hasExpectedAccount: () => true,
+    isOAuthModeEnabled: () => false,
+  };
+
+  it('asserts pinned local stdio startup', () => {
+    expect(shouldAssertExpectedAccountAtStartup({}, pinnedAuth)).toBe(true);
+  });
+
+  it('skips startup assertion and warns in HTTP mode', () => {
+    expect(shouldAssertExpectedAccountAtStartup({ http: true }, pinnedAuth)).toBe(false);
+    expect(getExpectedAccountInertWarning({ http: true }, pinnedAuth)).toContain('--http');
+  });
+
+  it('skips startup assertion and warns in OBO mode', () => {
+    expect(shouldAssertExpectedAccountAtStartup({ obo: true }, pinnedAuth)).toBe(false);
+    expect(getExpectedAccountInertWarning({ obo: true }, pinnedAuth)).toContain('--obo');
+  });
+
+  it('skips startup assertion and warns in BYOT mode', () => {
+    const byotAuth = {
+      hasExpectedAccount: () => true,
+      isOAuthModeEnabled: () => true,
+    };
+
+    expect(shouldAssertExpectedAccountAtStartup({}, byotAuth)).toBe(false);
+    expect(getExpectedAccountInertWarning({}, byotAuth)).toContain('MS365_MCP_OAUTH_TOKEN');
+  });
+
+  it('skips startup assertion for local account management commands', () => {
+    expect(shouldAssertExpectedAccountAtStartup({ login: true }, pinnedAuth)).toBe(false);
+    expect(shouldAssertExpectedAccountAtStartup({ verifyLogin: true }, pinnedAuth)).toBe(false);
+    expect(
+      shouldAssertExpectedAccountAtStartup({ removeAccount: 'personal.home' }, pinnedAuth)
+    ).toBe(false);
+  });
+});

--- a/test/auth-tools.test.ts
+++ b/test/auth-tools.test.ts
@@ -26,16 +26,22 @@ describe('Auth Tools', () => {
     acquireTokenByDeviceCode: ReturnType<typeof vi.fn>;
     getUseInteractiveAuth: ReturnType<typeof vi.fn>;
     acquireTokenInteractive: ReturnType<typeof vi.fn>;
+    hasExpectedAccount: ReturnType<typeof vi.fn>;
   };
   let loginTool: ReturnType<typeof vi.fn>;
+  let verifyLoginTool: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     loginTool = vi.fn();
+    verifyLoginTool = vi.fn();
 
     server = {
       tool: vi.fn((name, description, schema, handler) => {
         if (name === 'login') {
           loginTool = handler;
+        }
+        if (name === 'verify-login') {
+          verifyLoginTool = handler;
         }
       }),
     };
@@ -45,6 +51,7 @@ describe('Auth Tools', () => {
       acquireTokenByDeviceCode: vi.fn(),
       getUseInteractiveAuth: vi.fn().mockReturnValue(false),
       acquireTokenInteractive: vi.fn().mockResolvedValue(undefined),
+      hasExpectedAccount: vi.fn().mockReturnValue(false),
     };
 
     registerAuthTools(server, authManager);
@@ -129,6 +136,41 @@ describe('Auth Tools', () => {
           message: 'Login instructions',
         })
       );
+    });
+
+    it('should proceed with login when expected account is missing', async () => {
+      authManager.testLogin.mockResolvedValue({
+        success: false,
+        message: 'Expected Microsoft account not found in token cache.',
+      });
+
+      authManager.acquireTokenByDeviceCode.mockImplementation(
+        (callback: (text: string) => void) => {
+          callback('Login instructions');
+          return Promise.resolve();
+        }
+      );
+
+      const result = await loginTool({ force: false });
+
+      expect(authManager.testLogin).toHaveBeenCalled();
+      expect(authManager.acquireTokenByDeviceCode).toHaveBeenCalled();
+      expect(result.content[0].text).toContain('device_code_required');
+    });
+  });
+
+  describe('verify-login tool', () => {
+    it('should return JSON failure when verification throws', async () => {
+      authManager.testLogin.mockRejectedValue(new Error('Expected Microsoft account missing'));
+
+      const result = await verifyLoginTool({});
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed).toEqual({
+        success: false,
+        message: 'Login failed: Expected Microsoft account missing',
+      });
+      expect(result.isError).toBeUndefined();
     });
   });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -49,10 +49,14 @@ describe('CLI Module', () => {
     vi.clearAllMocks();
     commanderMocks.mockCommand.opts.mockReturnValue({ file: 'test.xlsx' });
     delete process.env.MS365_MCP_ALLOWED_SCOPES;
+    delete process.env.MS365_MCP_EXPECTED_USERNAME;
+    delete process.env.MS365_MCP_EXPECTED_HOME_ACCOUNT_ID;
   });
 
   afterEach(() => {
     delete process.env.MS365_MCP_ALLOWED_SCOPES;
+    delete process.env.MS365_MCP_EXPECTED_USERNAME;
+    delete process.env.MS365_MCP_EXPECTED_HOME_ACCOUNT_ID;
   });
 
   describe('parseArgs', () => {
@@ -104,6 +108,64 @@ describe('CLI Module', () => {
 
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('MS365_MCP_ALLOWED_SCOPES')
+      );
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('should parse expected username and home account ID from CLI options', () => {
+      commanderMocks.mockCommand.opts.mockReturnValue({
+        expectedUsername: ' User@Example.com ',
+        expectedHomeAccountId: ' home.id ',
+      });
+
+      const result = parseArgs();
+
+      expect(result.expectedUsername).toBe('User@Example.com');
+      expect(result.expectedHomeAccountId).toBe('home.id');
+    });
+
+    it('should use expected account env vars as fallbacks', () => {
+      process.env.MS365_MCP_EXPECTED_USERNAME = 'env@example.com';
+      process.env.MS365_MCP_EXPECTED_HOME_ACCOUNT_ID = 'env.home';
+      commanderMocks.mockCommand.opts.mockReturnValue({});
+
+      const result = parseArgs();
+
+      expect(result.expectedUsername).toBe('env@example.com');
+      expect(result.expectedHomeAccountId).toBe('env.home');
+    });
+
+    it('should prefer CLI expected account values over env vars', () => {
+      process.env.MS365_MCP_EXPECTED_USERNAME = 'env@example.com';
+      process.env.MS365_MCP_EXPECTED_HOME_ACCOUNT_ID = 'env.home';
+      commanderMocks.mockCommand.opts.mockReturnValue({
+        expectedUsername: 'cli@example.com',
+        expectedHomeAccountId: 'cli.home',
+      });
+
+      const result = parseArgs();
+
+      expect(result.expectedUsername).toBe('cli@example.com');
+      expect(result.expectedHomeAccountId).toBe('cli.home');
+    });
+
+    it('should fail closed when expected username is supplied empty', () => {
+      commanderMocks.mockCommand.opts.mockReturnValue({ expectedUsername: '   ' });
+
+      parseArgs();
+
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--expected-username'));
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('should fail closed when expected home account ID env var is supplied empty', () => {
+      process.env.MS365_MCP_EXPECTED_HOME_ACCOUNT_ID = '   ';
+      commanderMocks.mockCommand.opts.mockReturnValue({});
+
+      parseArgs();
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('MS365_MCP_EXPECTED_HOME_ACCOUNT_ID')
       );
       expect(process.exit).toHaveBeenCalledWith(1);
     });

--- a/test/mcp-instructions.test.ts
+++ b/test/mcp-instructions.test.ts
@@ -22,4 +22,10 @@ describe('buildMcpServerInstructions', () => {
     const s = buildMcpServerInstructions({ ...baseCtx, discovery: false, readOnly: true });
     expect(s).toContain('read-only');
   });
+
+  it('does not suggest account switching when multiAccount is false', () => {
+    const s = buildMcpServerInstructions({ ...baseCtx, discovery: false, multiAccount: false });
+    expect(s).not.toContain('Multiple accounts');
+    expect(s).not.toContain('account parameter');
+  });
 });

--- a/test/multi-account.test.ts
+++ b/test/multi-account.test.ts
@@ -110,6 +110,7 @@ describe('Multi-account support', () => {
         logout: vi.fn(),
         selectAccount: vi.fn(),
         removeAccount: vi.fn(),
+        hasExpectedAccount: vi.fn().mockReturnValue(false),
       };
 
       // Simulate server boot: auth-tools first, then graph-tools
@@ -143,6 +144,7 @@ describe('Multi-account support', () => {
         logout: vi.fn(),
         selectAccount: vi.fn(),
         removeAccount: vi.fn(),
+        hasExpectedAccount: vi.fn().mockReturnValue(false),
       };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- handler type varies across McpServer.tool() overloads
@@ -177,6 +179,41 @@ describe('Multi-account support', () => {
       expect(parsed).toHaveProperty('tip');
 
       captureSpy.mockRestore();
+    });
+
+    it('should describe pinned mode instead of account switching when configured', async () => {
+      const mockAuthManager = {
+        listAccounts: vi
+          .fn()
+          .mockResolvedValue([
+            { username: 'work@company.com', name: 'Work', homeAccountId: 'secret-id-456' },
+          ]),
+        getSelectedAccountId: vi.fn().mockReturnValue('secret-id-456'),
+        testLogin: vi.fn(),
+        acquireTokenByDeviceCode: vi.fn(),
+        logout: vi.fn(),
+        selectAccount: vi.fn(),
+        removeAccount: vi.fn(),
+        hasExpectedAccount: vi.fn().mockReturnValue(true),
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- handler type varies across McpServer.tool() overloads
+      let listAccountsHandler: ((...args: any[]) => any) | undefined;
+      vi.spyOn(server, 'tool').mockImplementation(((...args: any[]) => {
+        const name = args[0];
+        const handler = args[args.length - 1];
+        if (name === 'list-accounts' && typeof handler === 'function') {
+          listAccountsHandler = handler;
+        }
+      }) as any);
+
+      registerAuthTools(server as any, mockAuthManager as any);
+
+      const result = await listAccountsHandler!({});
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.tip).toContain('Expected account pinning');
+      expect(parsed.tip).not.toContain('account parameter in any tool call');
     });
   });
 
@@ -243,6 +280,40 @@ describe('Multi-account support', () => {
         expect(message).not.toContain('secret-tenant-id');
         expect(message).toContain('Service Account');
       }
+    });
+
+    describe('pinned mode', () => {
+      it('should collapse multi-account schema injection', async () => {
+        const mockMsalApp = {
+          getTokenCache: () => ({
+            getAllAccounts: vi.fn().mockResolvedValue([
+              { username: 'user@outlook.com', name: 'User', homeAccountId: 'id-1' },
+              { username: 'work@company.com', name: 'Work', homeAccountId: 'id-2' },
+            ]),
+          }),
+        };
+        const authManager = Object.create(AuthManager.prototype) as AuthManager;
+        Object.assign(authManager as unknown as Record<string, unknown>, {
+          msalApp: mockMsalApp,
+          expectedUsername: 'work@company.com',
+          expectedHomeAccountId: null,
+        });
+
+        registerGraphTools(
+          server,
+          graphClient,
+          false,
+          undefined,
+          false,
+          authManager,
+          await authManager.isMultiAccount(),
+          ['user@outlook.com', 'work@company.com']
+        );
+
+        const toolCall = toolSpy.mock.calls.find(([name]) => name === 'list-mail-messages');
+        const schema = toolCall![2] as Record<string, unknown>;
+        expect(schema).not.toHaveProperty('account');
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds opt-in strict expected account pins via `--expected-username` / `MS365_MCP_EXPECTED_USERNAME` and `--expected-home-account-id` / `MS365_MCP_EXPECTED_HOME_ACCOUNT_ID`.
- Enforces the pin for local MSAL cache lookup, silent token acquisition, login persistence, explicit account selection, and account-parameter token routing.
- Keeps HTTP/OBO/BYOT Graph calls stateless with startup warnings only, while pinned mode collapses MCP multi-account tool exposure and instructions.

## Validation
- `npm test -- test/auth-pinning.test.ts test/cli.test.ts test/multi-account.test.ts test/auth-tools.test.ts test/http-oauth-fix.test.ts test/mcp-instructions.test.ts`
- `npm exec prettier -- --check src/cli.ts src/auth.ts src/auth-tools.ts src/index.ts src/startup-pinning.ts test/cli.test.ts test/auth-pinning.test.ts test/auth-tools.test.ts test/multi-account.test.ts test/mcp-instructions.test.ts test/auth-paths.test.ts README.md docs/deployment.md`
- `npm test`
- `npm run lint` (passes with existing warnings)
- `npm run build`

## Notes
- Based on `upstream/main` after allowed-scopes PR #478 merged.
- The repo-wide `npm run format:check` still reports many pre-existing unrelated formatting warnings, so changed files were checked directly.

Made with [Cursor](https://cursor.com)