### PR TITLE
feat(auth): add pluggable auth cache storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,14 @@ MS365_MCP_TENANT_ID=common
 #   - Environment variables (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID)
 #
 # See README.md for detailed Azure Key Vault setup instructions.
+
+# -------------------------------------------------------------------
+# External Auth Cache Storage (Optional)
+# -------------------------------------------------------------------
+# Headless local-MSAL deployments can store token-cache and selected-account
+# metadata with a provider-neutral executable wrapper. The value is a real
+# executable path, not a shell command string; put any provider-specific args
+# inside the wrapper script.
+#
+# MS365_MCP_AUTH_CACHE_COMMAND=/path/to/ms365-auth-cache-store
+# MS365_MCP_AUTH_CACHE_COMMAND_TIMEOUT_MS=10000

--- a/README.md
+++ b/README.md
@@ -571,6 +571,8 @@ Environment variables:
 - `MS365_MCP_KEYVAULT_URL`: Azure Key Vault URL for secrets management (see Azure Key Vault section)
 - `MS365_MCP_TOKEN_CACHE_PATH`: Custom file path for MSAL token cache (see Token Storage below)
 - `MS365_MCP_SELECTED_ACCOUNT_PATH`: Custom file path for selected account metadata (see Token Storage below)
+- `MS365_MCP_AUTH_CACHE_COMMAND`: External executable wrapper for provider-neutral auth-cache storage (see Token Storage below)
+- `MS365_MCP_AUTH_CACHE_COMMAND_TIMEOUT_MS`: Per-invocation timeout for `MS365_MCP_AUTH_CACHE_COMMAND` (default: `10000`)
 - `MS365_MCP_EXPECTED_USERNAME`: Require local MSAL auth to use this Microsoft account username (case-insensitive; CLI flag takes precedence)
 - `MS365_MCP_EXPECTED_HOME_ACCOUNT_ID`: Require local MSAL auth to use this exact MSAL homeAccountId (CLI flag takes precedence)
 
@@ -592,6 +594,42 @@ Parent directories are created automatically. Files are written with `0600` perm
 > **Security note**: File-based token storage writes sensitive credentials to disk. Ensure the chosen directory has appropriate access controls. The OS credential store (keytar) is preferred when available.
 
 > **Hosted/sandboxed environments** (e.g. Anthropic Cowork): Set `MS365_MCP_TOKEN_CACHE_PATH` and `MS365_MCP_SELECTED_ACCOUNT_PATH` to a persistent mount so tokens survive between sessions.
+
+### External auth-cache command
+
+Headless local-MSAL deployments can replace the built-in keytar/file storage with a provider-neutral external command:
+
+```bash
+export MS365_MCP_AUTH_CACHE_COMMAND="/path/to/ms365-auth-cache-store"
+export MS365_MCP_AUTH_CACHE_COMMAND_TIMEOUT_MS=10000
+```
+
+When `MS365_MCP_AUTH_CACHE_COMMAND` is set for a local auth flow, the server uses only that command for the MSAL token cache and selected-account metadata. It does not fall back to keytar or local files. If the command path is missing, not executable on POSIX, exits non-zero, times out, or returns malformed data, auth-cache operations fail closed with a sanitized error message.
+
+The value must be a real executable wrapper path. It is not a shell command string, and there is no companion args environment variable. Put any interpreter, region, profile, or provider-specific settings inside the wrapper. Windows users should point the variable at a wrapper executable or script that can be launched directly by Node without shell parsing.
+
+The server invokes the wrapper with:
+
+```text
+$MS365_MCP_AUTH_CACHE_COMMAND load token-cache
+$MS365_MCP_AUTH_CACHE_COMMAND save token-cache
+$MS365_MCP_AUTH_CACHE_COMMAND delete token-cache
+$MS365_MCP_AUTH_CACHE_COMMAND load selected-account
+$MS365_MCP_AUTH_CACHE_COMMAND save selected-account
+$MS365_MCP_AUTH_CACHE_COMMAND delete selected-account
+```
+
+Protocol v1:
+
+- `load <key>` reads no stdin. Exit `0` with `{"found":true,"value":"<stored envelope string>"}` when present. A miss is exit `0` with `{"found":false}` or empty stdout.
+- `save <key>` receives `{"value":"<stamped envelope string>"}` on stdin and must exit `0` only after the value is durably committed. There are no fire-and-forget or coalesced saves in v1.
+- `delete <key>` reads no stdin and exits `0` whether the key existed or not.
+- `<key>` is `token-cache` or `selected-account`.
+- Any non-zero exit is a storage error. Do not use exit code `2` for cache misses.
+- Stderr is captured and truncated in sanitized errors. Stdin and stdout payloads are never logged by the server.
+- Token-cache payloads can be large; wrappers should handle at least 256 KB values.
+
+Normal stateless HTTP Graph requests do not use local auth-cache storage. In HTTP mode, command storage is skipped at startup and per request unless local auth tools are explicitly enabled or a local account command such as `--login`, `--verify-login`, `--list-accounts`, `--select-account`, or `--logout` is used.
 
 ## Azure Key Vault Integration
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,6 +18,14 @@ MCP Clients (Claude Desktop, Claude Code, Open WebUI, ...)
          Microsoft Graph API
 ```
 
+## Headless stdio auth-cache storage
+
+Production HTTP deployments are stateless: normal Graph requests carry a per-user bearer token, including On-Behalf-Of (`--obo`) deployments, and the server does not store MSAL token state for those requests.
+
+For headless stdio deployments that use local MSAL login (`--login`, `--verify-login`, auth tools, account selection, and regular stdio Graph calls), `MS365_MCP_AUTH_CACHE_COMMAND` can point at an external executable wrapper that stores the MSAL token cache and selected-account metadata in a deployment-approved backing store. The package only defines the provider-neutral command protocol; provider-specific scripts for AWS, Azure, GCP, Redis, databases, or other stores live outside this package.
+
+In HTTP mode, `MS365_MCP_AUTH_CACHE_COMMAND` is skipped at startup and per Graph request unless local auth tools are explicitly enabled with `--enable-auth-tools` or a local account command such as `--login`, `--verify-login`, `--list-accounts`, `--select-account`, `--remove-account`, or `--logout` is invoked.
+
 ## Docker
 
 A `Dockerfile` is included for containerized deployments:

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -419,7 +419,9 @@ class AuthManager {
   ): Promise<AuthManager> {
     const secrets = await getSecrets();
     const config = createMsalConfig(secrets);
-    const storage = options.storage ?? (await createTokenCacheStorage({ logProvider: true }));
+    const storage =
+      options.storage ??
+      (await createTokenCacheStorage({ allowCommandStorage: false, logProvider: true }));
     return new AuthManager(config, scopes, expectedAccount, storage);
   }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,38 +1,21 @@
 import type { AccountInfo, Configuration } from '@azure/msal-node';
 import { PublicClientApplication } from '@azure/msal-node';
 import logger from './logger.js';
-import fs, { existsSync, readFileSync } from 'fs';
+import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import { getSecrets, type AppSecrets } from './secrets.js';
 import { getCloudEndpoints, getDefaultClientId } from './cloud-config.js';
-
-// Ok so this is a hack to lazily import keytar only when needed
-// since --http mode may not need it at all, and keytar can be a pain to install (looking at you alpine)
-let keytar: typeof import('keytar') | null = null;
-async function getKeytar() {
-  if (keytar === undefined) {
-    return null;
-  }
-  if (keytar === null) {
-    try {
-      // Normalize ESM/CJS interop: under Node 24+ `await import('keytar')` returns a
-      // namespace object whose top-level `setPassword` is undefined (functions live on
-      // `.default`). On older Node and pure CJS, methods live on the namespace itself.
-      // Falling back to the namespace keeps backward compatibility. See issue #418.
-      const mod = (await import('keytar')) as typeof import('keytar') & {
-        default?: typeof import('keytar');
-      };
-      keytar = mod.default ?? mod;
-      return keytar;
-    } catch (error) {
-      logger.info('keytar not available, using file-based credential storage');
-      keytar = undefined as any;
-      return null;
-    }
-  }
-  return keytar;
-}
+import {
+  createTokenCacheStorage,
+  DefaultTokenCacheStorage,
+  getSelectedAccountPath,
+  getTokenCachePath,
+  pickNewest,
+  type TokenCacheStorage,
+  unwrapCache,
+  wrapCache,
+} from './token-cache-storage.js';
 
 interface EndpointConfig {
   pathPattern: string;
@@ -53,72 +36,6 @@ const endpointsData = JSON.parse(
 const endpoints = {
   default: endpointsData,
 };
-
-const SERVICE_NAME = 'ms-365-mcp-server';
-const TOKEN_CACHE_ACCOUNT = 'msal-token-cache';
-const SELECTED_ACCOUNT_KEY = 'selected-account';
-const FALLBACK_DIR = path.dirname(fileURLToPath(import.meta.url));
-const DEFAULT_TOKEN_CACHE_PATH = path.join(FALLBACK_DIR, '..', '.token-cache.json');
-const DEFAULT_SELECTED_ACCOUNT_PATH = path.join(FALLBACK_DIR, '..', '.selected-account.json');
-
-/**
- * Returns the token cache file path.
- * Uses MS365_MCP_TOKEN_CACHE_PATH env var if set, otherwise the default fallback.
- */
-function getTokenCachePath(): string {
-  const envPath = process.env.MS365_MCP_TOKEN_CACHE_PATH?.trim();
-  return envPath || DEFAULT_TOKEN_CACHE_PATH;
-}
-
-/**
- * Returns the selected-account file path.
- * Uses MS365_MCP_SELECTED_ACCOUNT_PATH env var if set, otherwise the default fallback.
- */
-function getSelectedAccountPath(): string {
-  const envPath = process.env.MS365_MCP_SELECTED_ACCOUNT_PATH?.trim();
-  return envPath || DEFAULT_SELECTED_ACCOUNT_PATH;
-}
-
-/**
- * Ensures the parent directory of a file path exists, creating it recursively if needed.
- */
-function ensureParentDir(filePath: string): void {
-  const dir = path.dirname(filePath);
-  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-}
-
-function wrapCache(data: string): string {
-  return JSON.stringify({ _cacheEnvelope: true, data, savedAt: Date.now() });
-}
-
-function unwrapCache(raw: string): { data: string; savedAt?: number } {
-  try {
-    const parsed = JSON.parse(raw);
-    if (parsed._cacheEnvelope && typeof parsed.data === 'string') {
-      return { data: parsed.data, savedAt: parsed.savedAt };
-    }
-  } catch {
-    // not our envelope format
-  }
-  return { data: raw };
-}
-
-function pickNewest(
-  keytarRaw: string | undefined,
-  fileRaw: string | undefined
-): string | undefined {
-  if (!keytarRaw && !fileRaw) return undefined;
-  if (keytarRaw && !fileRaw) return unwrapCache(keytarRaw).data;
-  if (!keytarRaw && fileRaw) return unwrapCache(fileRaw).data;
-
-  const kt = unwrapCache(keytarRaw!);
-  const file = unwrapCache(fileRaw!);
-
-  if (kt.savedAt === undefined && file.savedAt === undefined) return kt.data;
-  if (kt.savedAt !== undefined && file.savedAt === undefined) return kt.data;
-  if (kt.savedAt === undefined && file.savedAt !== undefined) return file.data;
-  return kt.savedAt! >= file.savedAt! ? kt.data : file.data;
-}
 
 /**
  * Creates MSAL configuration from secrets.
@@ -223,7 +140,7 @@ function buildScopesFromEndpoints(
     try {
       enabledToolsRegex = new RegExp(enabledToolsPattern, 'i');
       logger.info(`Building scopes with tool filter pattern: ${enabledToolsPattern}`);
-    } catch (error) {
+    } catch {
       logger.error(
         `Invalid tool filter regex pattern: ${enabledToolsPattern}. Building scopes without filter.`
       );
@@ -448,6 +365,10 @@ interface ExpectedAccountOptions {
   expectedHomeAccountId?: string;
 }
 
+interface AuthManagerCreateOptions {
+  storage?: TokenCacheStorage;
+}
+
 class AuthManager {
   private config: Configuration;
   private scopes: string[];
@@ -460,11 +381,13 @@ class AuthManager {
   private useInteractiveAuth: boolean;
   private expectedUsername: string | null;
   private expectedHomeAccountId: string | null;
+  private storage: TokenCacheStorage;
 
   constructor(
     config: Configuration,
     scopes: string[] = [],
-    expectedAccount?: ExpectedAccountOptions
+    expectedAccount?: ExpectedAccountOptions,
+    storage?: TokenCacheStorage
   ) {
     logger.info(`And scopes are ${scopes.join(', ')}`, scopes);
     this.config = config;
@@ -478,6 +401,7 @@ class AuthManager {
     this.expectedHomeAccountId = this.normalizeExpectedHomeAccountId(
       expectedAccount?.expectedHomeAccountId
     );
+    this.storage = storage ?? new DefaultTokenCacheStorage();
 
     const oauthTokenFromEnv = process.env.MS365_MCP_OAUTH_TOKEN;
     this.oauthToken = oauthTokenFromEnv ?? null;
@@ -490,125 +414,69 @@ class AuthManager {
    */
   static async create(
     scopes: string[] = [],
-    expectedAccount?: ExpectedAccountOptions
+    expectedAccount?: ExpectedAccountOptions,
+    options: AuthManagerCreateOptions = {}
   ): Promise<AuthManager> {
     const secrets = await getSecrets();
     const config = createMsalConfig(secrets);
-    return new AuthManager(config, scopes, expectedAccount);
+    const storage = options.storage ?? (await createTokenCacheStorage({ logProvider: true }));
+    return new AuthManager(config, scopes, expectedAccount, storage);
   }
 
   async loadTokenCache(): Promise<void> {
     try {
-      let keytarRaw: string | undefined;
-      try {
-        const kt = await getKeytar();
-        if (kt) {
-          keytarRaw = (await kt.getPassword(SERVICE_NAME, TOKEN_CACHE_ACCOUNT)) ?? undefined;
-        }
-      } catch (keytarError) {
-        logger.warn(`Keychain access failed: ${(keytarError as Error).message}`);
-      }
-
-      let fileRaw: string | undefined;
-      const cachePath = getTokenCachePath();
-      if (existsSync(cachePath)) {
-        fileRaw = readFileSync(cachePath, 'utf8');
-      }
-
-      const cacheData = pickNewest(keytarRaw, fileRaw);
-      if (cacheData) {
-        this.msalApp.getTokenCache().deserialize(cacheData);
+      const cacheRaw = await this.storage.load('token-cache');
+      if (cacheRaw) {
+        this.msalApp.getTokenCache().deserialize(unwrapCache(cacheRaw).data);
       }
 
       // Load selected account
       await this.loadSelectedAccount();
     } catch (error) {
       logger.error(`Error loading token cache: ${(error as Error).message}`);
+      if (this.storage.failClosed) {
+        throw error;
+      }
     }
   }
 
   private async loadSelectedAccount(): Promise<void> {
     try {
-      let keytarRaw: string | undefined;
-      try {
-        const kt = await getKeytar();
-        if (kt) {
-          keytarRaw = (await kt.getPassword(SERVICE_NAME, SELECTED_ACCOUNT_KEY)) ?? undefined;
-        }
-      } catch (keytarError) {
-        logger.warn(
-          `Keychain access failed for selected account: ${(keytarError as Error).message}`
-        );
-      }
-
-      let fileRaw: string | undefined;
-      const accountPath = getSelectedAccountPath();
-      if (existsSync(accountPath)) {
-        fileRaw = readFileSync(accountPath, 'utf8');
-      }
-
-      const selectedAccountData = pickNewest(keytarRaw, fileRaw);
-      if (selectedAccountData) {
-        const parsed = JSON.parse(selectedAccountData);
+      const selectedAccountRaw = await this.storage.load('selected-account');
+      if (selectedAccountRaw) {
+        const parsed = JSON.parse(unwrapCache(selectedAccountRaw).data);
         this.selectedAccountId = parsed.accountId;
         logger.info(`Loaded selected account: ${this.selectedAccountId}`);
       }
     } catch (error) {
       logger.error(`Error loading selected account: ${(error as Error).message}`);
+      if (this.storage.failClosed) {
+        throw error;
+      }
     }
   }
 
   async saveTokenCache(): Promise<void> {
     try {
       const stamped = wrapCache(this.msalApp.getTokenCache().serialize());
-
-      try {
-        const kt = await getKeytar();
-        if (kt) {
-          await kt.setPassword(SERVICE_NAME, TOKEN_CACHE_ACCOUNT, stamped);
-        } else {
-          const cachePath = getTokenCachePath();
-          ensureParentDir(cachePath);
-          fs.writeFileSync(cachePath, stamped, { mode: 0o600 });
-        }
-      } catch (keytarError) {
-        logger.warn(
-          `Keychain save failed, falling back to file storage: ${(keytarError as Error).message}`
-        );
-
-        const cachePath = getTokenCachePath();
-        ensureParentDir(cachePath);
-        fs.writeFileSync(cachePath, stamped, { mode: 0o600 });
-      }
+      await this.storage.save('token-cache', stamped);
     } catch (error) {
       logger.error(`Error saving token cache: ${(error as Error).message}`);
+      if (this.storage.failClosed) {
+        throw error;
+      }
     }
   }
 
   private async saveSelectedAccount(): Promise<void> {
     try {
       const stamped = wrapCache(JSON.stringify({ accountId: this.selectedAccountId }));
-
-      try {
-        const kt = await getKeytar();
-        if (kt) {
-          await kt.setPassword(SERVICE_NAME, SELECTED_ACCOUNT_KEY, stamped);
-        } else {
-          const accountPath = getSelectedAccountPath();
-          ensureParentDir(accountPath);
-          fs.writeFileSync(accountPath, stamped, { mode: 0o600 });
-        }
-      } catch (keytarError) {
-        logger.warn(
-          `Keychain save failed for selected account, falling back to file storage: ${(keytarError as Error).message}`
-        );
-
-        const accountPath = getSelectedAccountPath();
-        ensureParentDir(accountPath);
-        fs.writeFileSync(accountPath, stamped, { mode: 0o600 });
-      }
+      await this.storage.save('selected-account', stamped);
     } catch (error) {
       logger.error(`Error saving selected account: ${(error as Error).message}`);
+      if (this.storage.failClosed) {
+        throw error;
+      }
     }
   }
 
@@ -976,25 +844,8 @@ class AuthManager {
       this.tokenExpiry = null;
       this.selectedAccountId = null;
 
-      try {
-        const kt = await getKeytar();
-        if (kt) {
-          await kt.deletePassword(SERVICE_NAME, TOKEN_CACHE_ACCOUNT);
-          await kt.deletePassword(SERVICE_NAME, SELECTED_ACCOUNT_KEY);
-        }
-      } catch (keytarError) {
-        logger.warn(`Keychain deletion failed: ${(keytarError as Error).message}`);
-      }
-
-      const cachePath = getTokenCachePath();
-      if (fs.existsSync(cachePath)) {
-        fs.unlinkSync(cachePath);
-      }
-
-      const accountPath = getSelectedAccountPath();
-      if (fs.existsSync(accountPath)) {
-        fs.unlinkSync(accountPath);
-      }
+      await this.storage.delete('token-cache');
+      await this.storage.delete('selected-account');
 
       return true;
     } catch (error) {
@@ -1189,6 +1040,7 @@ class AuthManager {
 
 export default AuthManager;
 export {
+  type AuthManagerCreateOptions,
   type ExpectedAccountOptions,
   buildAllowedScopeDiagnostics,
   buildScopesFromEndpoints,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,9 @@ import MicrosoftGraphServer from './server.js';
 import {
   getExpectedAccountInertWarning,
   shouldAssertExpectedAccountAtStartup,
+  shouldUseLocalAuthStorage,
 } from './startup-pinning.js';
+import { createTokenCacheStorage } from './token-cache-storage.js';
 import { version } from './version.js';
 
 async function main(): Promise<void> {
@@ -47,11 +49,22 @@ async function main(): Promise<void> {
       process.exit(0);
     }
 
-    const authManager = await AuthManager.create(effectiveScopes, {
-      expectedUsername: args.expectedUsername,
-      expectedHomeAccountId: args.expectedHomeAccountId,
+    const useLocalAuthStorage = shouldUseLocalAuthStorage(args);
+    const storage = await createTokenCacheStorage({
+      allowCommandStorage: useLocalAuthStorage,
+      logProvider: useLocalAuthStorage,
     });
-    await authManager.loadTokenCache();
+    const authManager = await AuthManager.create(
+      effectiveScopes,
+      {
+        expectedUsername: args.expectedUsername,
+        expectedHomeAccountId: args.expectedHomeAccountId,
+      },
+      { storage }
+    );
+    if (useLocalAuthStorage) {
+      await authManager.loadTokenCache();
+    }
 
     if (args.authBrowser) {
       authManager.setUseInteractiveAuth(true);

--- a/src/startup-pinning.ts
+++ b/src/startup-pinning.ts
@@ -51,3 +51,13 @@ export function shouldAssertExpectedAccountAtStartup(
   }
   return !LOCAL_ACCOUNT_COMMANDS.some((key) => Boolean(args[key]));
 }
+
+export function shouldUseLocalAuthStorage(args: CommandOptions): boolean {
+  if (!args.http) {
+    return true;
+  }
+  if (args.enableAuthTools) {
+    return true;
+  }
+  return LOCAL_ACCOUNT_COMMANDS.some((key) => Boolean(args[key]));
+}

--- a/src/token-cache-storage.ts
+++ b/src/token-cache-storage.ts
@@ -355,6 +355,10 @@ function runCommand(
     child.stderr.on('data', (chunk) => {
       stderr += chunk;
     });
+    child.stdin.on('error', () => {
+      // Early-exiting wrappers may close stdin before consuming the payload; command
+      // exit status/stdout/stderr remain the protocol signal.
+    });
     child.once('error', (error) => {
       clearTimeout(timeout);
       if (killTimer) clearTimeout(killTimer);

--- a/src/token-cache-storage.ts
+++ b/src/token-cache-storage.ts
@@ -1,0 +1,432 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import fs, { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import logger from './logger.js';
+
+export type TokenCacheStorageKey = 'token-cache' | 'selected-account';
+
+export interface TokenCacheStorage {
+  readonly description: string;
+  readonly failClosed: boolean;
+  load(key: TokenCacheStorageKey): Promise<string | undefined>;
+  save(key: TokenCacheStorageKey, value: string): Promise<void>;
+  delete(key: TokenCacheStorageKey): Promise<void>;
+}
+
+interface CreateTokenCacheStorageOptions {
+  allowCommandStorage?: boolean;
+  logProvider?: boolean;
+}
+
+type SpawnCommand = (
+  command: string,
+  args: string[],
+  options: { stdio: 'pipe'; shell: false }
+) => ChildProcessWithoutNullStreams;
+
+const SERVICE_NAME = 'ms-365-mcp-server';
+const TOKEN_CACHE_ACCOUNT = 'msal-token-cache';
+const SELECTED_ACCOUNT_KEY = 'selected-account';
+const AUTH_CACHE_COMMAND_ENV = 'MS365_MCP_AUTH_CACHE_COMMAND';
+const AUTH_CACHE_COMMAND_TIMEOUT_ENV = 'MS365_MCP_AUTH_CACHE_COMMAND_TIMEOUT_MS';
+const DEFAULT_AUTH_CACHE_COMMAND_TIMEOUT_MS = 10_000;
+const STDERR_LIMIT = 2048;
+const COMMAND_KILL_GRACE_MS = 1000;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const FALLBACK_DIR = __dirname;
+const DEFAULT_TOKEN_CACHE_PATH = path.join(FALLBACK_DIR, '..', '.token-cache.json');
+const DEFAULT_SELECTED_ACCOUNT_PATH = path.join(FALLBACK_DIR, '..', '.selected-account.json');
+
+let keytar: typeof import('keytar') | null | undefined = null;
+
+async function getKeytar() {
+  if (keytar === undefined) {
+    return null;
+  }
+  if (keytar === null) {
+    try {
+      // Normalize ESM/CJS interop: under Node 24+ `await import('keytar')` returns a
+      // namespace object whose top-level `setPassword` is undefined (functions live on
+      // `.default`). On older Node and pure CJS, methods live on the namespace itself.
+      // Falling back to the namespace keeps backward compatibility. See issue #418.
+      const mod = (await import('keytar')) as typeof import('keytar') & {
+        default?: typeof import('keytar');
+      };
+      keytar = mod.default ?? mod;
+      return keytar;
+    } catch {
+      logger.info('keytar not available, using file-based credential storage');
+      keytar = undefined;
+      return null;
+    }
+  }
+  return keytar;
+}
+
+export function wrapCache(data: string): string {
+  return JSON.stringify({ _cacheEnvelope: true, data, savedAt: Date.now() });
+}
+
+export function unwrapCache(raw: string): { data: string; savedAt?: number } {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed._cacheEnvelope && typeof parsed.data === 'string') {
+      return { data: parsed.data, savedAt: parsed.savedAt };
+    }
+  } catch {
+    // not our envelope format
+  }
+  return { data: raw };
+}
+
+export function pickNewest(
+  keytarRaw: string | undefined,
+  fileRaw: string | undefined
+): string | undefined {
+  const newest = pickNewestRaw(keytarRaw, fileRaw);
+  return newest ? unwrapCache(newest).data : undefined;
+}
+
+function pickNewestRaw(
+  keytarRaw: string | undefined,
+  fileRaw: string | undefined
+): string | undefined {
+  if (!keytarRaw && !fileRaw) return undefined;
+  if (keytarRaw && !fileRaw) return keytarRaw;
+  if (!keytarRaw && fileRaw) return fileRaw;
+
+  const kt = unwrapCache(keytarRaw!);
+  const file = unwrapCache(fileRaw!);
+
+  if (kt.savedAt === undefined && file.savedAt === undefined) return keytarRaw;
+  if (kt.savedAt !== undefined && file.savedAt === undefined) return keytarRaw;
+  if (kt.savedAt === undefined && file.savedAt !== undefined) return fileRaw;
+  return kt.savedAt! >= file.savedAt! ? keytarRaw : fileRaw;
+}
+
+export function getTokenCachePath(): string {
+  const envPath = process.env.MS365_MCP_TOKEN_CACHE_PATH?.trim();
+  return envPath || DEFAULT_TOKEN_CACHE_PATH;
+}
+
+export function getSelectedAccountPath(): string {
+  const envPath = process.env.MS365_MCP_SELECTED_ACCOUNT_PATH?.trim();
+  return envPath || DEFAULT_SELECTED_ACCOUNT_PATH;
+}
+
+function storageAccountForKey(key: TokenCacheStorageKey): string {
+  assertValidKey(key);
+  return key === 'token-cache' ? TOKEN_CACHE_ACCOUNT : SELECTED_ACCOUNT_KEY;
+}
+
+function filePathForKey(key: TokenCacheStorageKey): string {
+  assertValidKey(key);
+  return key === 'token-cache' ? getTokenCachePath() : getSelectedAccountPath();
+}
+
+function assertValidKey(key: TokenCacheStorageKey): void {
+  if (key !== 'token-cache' && key !== 'selected-account') {
+    throw new Error(`Unknown auth cache storage key: ${String(key)}`);
+  }
+}
+
+function ensureParentDir(filePath: string): void {
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+}
+
+function writeFileAtomically(filePath: string, value: string): void {
+  ensureParentDir(filePath);
+  const tempPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${Date.now()}.tmp`
+  );
+  fs.writeFileSync(tempPath, value, { mode: 0o600 });
+  fs.renameSync(tempPath, filePath);
+}
+
+export class DefaultTokenCacheStorage implements TokenCacheStorage {
+  readonly description = 'default (keytar+file)';
+  readonly failClosed = false;
+
+  async load(key: TokenCacheStorageKey): Promise<string | undefined> {
+    assertValidKey(key);
+    let keytarRaw: string | undefined;
+    try {
+      const kt = await getKeytar();
+      if (kt) {
+        keytarRaw = (await kt.getPassword(SERVICE_NAME, storageAccountForKey(key))) ?? undefined;
+      }
+    } catch (error) {
+      logger.warn(`Keychain access failed for ${key}: ${(error as Error).message}`);
+    }
+
+    let fileRaw: string | undefined;
+    const cachePath = filePathForKey(key);
+    if (existsSync(cachePath)) {
+      fileRaw = readFileSync(cachePath, 'utf8');
+    }
+
+    return pickNewestRaw(keytarRaw, fileRaw);
+  }
+
+  async save(key: TokenCacheStorageKey, value: string): Promise<void> {
+    assertValidKey(key);
+    try {
+      const kt = await getKeytar();
+      if (kt) {
+        await kt.setPassword(SERVICE_NAME, storageAccountForKey(key), value);
+        return;
+      }
+    } catch (error) {
+      logger.warn(
+        `Keychain save failed for ${key}, falling back to file storage: ${(error as Error).message}`
+      );
+    }
+
+    writeFileAtomically(filePathForKey(key), value);
+  }
+
+  async delete(key: TokenCacheStorageKey): Promise<void> {
+    assertValidKey(key);
+    try {
+      const kt = await getKeytar();
+      if (kt) {
+        await kt.deletePassword(SERVICE_NAME, storageAccountForKey(key));
+      }
+    } catch (error) {
+      logger.warn(`Keychain deletion failed for ${key}: ${(error as Error).message}`);
+    }
+
+    const cachePath = filePathForKey(key);
+    try {
+      if (fs.existsSync(cachePath)) {
+        fs.unlinkSync(cachePath);
+      }
+    } catch (error) {
+      logger.warn(`File deletion failed for ${key}: ${(error as Error).message}`);
+    }
+  }
+}
+
+interface CommandResult {
+  exitCode: number | null;
+  signal: string | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+export class CommandTokenCacheStorage implements TokenCacheStorage {
+  readonly description: string;
+  readonly failClosed = true;
+
+  constructor(
+    private readonly commandPath: string,
+    private readonly timeoutMs: number = DEFAULT_AUTH_CACHE_COMMAND_TIMEOUT_MS,
+    private readonly spawnCommand: SpawnCommand = spawn
+  ) {
+    this.description = `command (${path.basename(commandPath)})`;
+  }
+
+  async load(key: TokenCacheStorageKey): Promise<string | undefined> {
+    assertValidKey(key);
+    const result = await this.invoke('load', key);
+    const trimmed = result.stdout.trim();
+    if (trimmed === '') {
+      return undefined;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      throw new Error(`Auth cache command returned invalid JSON for load ${key}.`);
+    }
+
+    if (!parsed || typeof parsed !== 'object') {
+      throw new Error(`Auth cache command returned invalid JSON shape for load ${key}.`);
+    }
+
+    const response = parsed as { found?: unknown; value?: unknown };
+    if (response.found === false) {
+      return undefined;
+    }
+    if (response.found === true && typeof response.value === 'string') {
+      return response.value;
+    }
+
+    throw new Error(`Auth cache command returned invalid load response for ${key}.`);
+  }
+
+  async save(key: TokenCacheStorageKey, value: string): Promise<void> {
+    assertValidKey(key);
+    await this.invoke('save', key, JSON.stringify({ value }));
+  }
+
+  async delete(key: TokenCacheStorageKey): Promise<void> {
+    assertValidKey(key);
+    await this.invoke('delete', key);
+  }
+
+  private async invoke(
+    operation: 'load' | 'save' | 'delete',
+    key: TokenCacheStorageKey,
+    stdinPayload?: string
+  ): Promise<CommandResult> {
+    let result: CommandResult;
+    try {
+      result = await runCommand(
+        this.commandPath,
+        [operation, key],
+        stdinPayload,
+        this.timeoutMs,
+        this.spawnCommand
+      );
+    } catch (error) {
+      throw new Error(
+        `Auth cache command failed for ${operation} ${key}: ${(error as Error).message}`
+      );
+    }
+
+    if (result.timedOut) {
+      throw new Error(`Auth cache command timed out for ${operation} ${key}.`);
+    }
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Auth cache command failed for ${operation} ${key} ` +
+          `(exit ${result.exitCode ?? `signal ${result.signal ?? 'unknown'}`})${formatStderr(
+            result.stderr
+          )}.`
+      );
+    }
+
+    return result;
+  }
+}
+
+function formatStderr(stderr: string): string {
+  const trimmed = stderr.trim();
+  if (!trimmed) {
+    return '';
+  }
+  const truncated =
+    trimmed.length > STDERR_LIMIT ? `${trimmed.slice(0, STDERR_LIMIT)}...` : trimmed;
+  return `: ${truncated}`;
+}
+
+function runCommand(
+  commandPath: string,
+  args: string[],
+  stdinPayload: string | undefined,
+  timeoutMs: number,
+  spawnCommand: SpawnCommand
+): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawnCommand(commandPath, args, { stdio: 'pipe', shell: false });
+    } catch (error) {
+      reject(new Error(`could not be started: ${(error as Error).message}`));
+      return;
+    }
+
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+      killTimer = setTimeout(() => {
+        child.kill('SIGKILL');
+      }, COMMAND_KILL_GRACE_MS);
+    }, timeoutMs);
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      if (killTimer) clearTimeout(killTimer);
+      reject(new Error(`could not be started: ${error.message}`));
+    });
+    child.once('close', (exitCode, signal) => {
+      clearTimeout(timeout);
+      if (killTimer) clearTimeout(killTimer);
+      resolve({ exitCode, signal, stdout, stderr, timedOut });
+    });
+
+    if (stdinPayload !== undefined) {
+      child.stdin.end(stdinPayload, 'utf8');
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+function parseTimeoutMs(value: string | undefined): number {
+  if (value === undefined || value.trim() === '') {
+    return DEFAULT_AUTH_CACHE_COMMAND_TIMEOUT_MS;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${AUTH_CACHE_COMMAND_TIMEOUT_ENV} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+async function assertCommandUsable(commandPath: string): Promise<void> {
+  let stats: fs.Stats;
+  try {
+    stats = await fs.promises.stat(commandPath);
+  } catch {
+    throw new Error(`${AUTH_CACHE_COMMAND_ENV} points to a path that does not exist.`);
+  }
+
+  if (!stats.isFile()) {
+    throw new Error(`${AUTH_CACHE_COMMAND_ENV} must point to an executable file.`);
+  }
+
+  if (process.platform !== 'win32' && (stats.mode & 0o111) === 0) {
+    throw new Error(`${AUTH_CACHE_COMMAND_ENV} must point to an executable file.`);
+  }
+}
+
+export async function createTokenCacheStorage(
+  options: CreateTokenCacheStorageOptions = {}
+): Promise<TokenCacheStorage> {
+  const allowCommandStorage = options.allowCommandStorage ?? true;
+  const configuredCommand = process.env[AUTH_CACHE_COMMAND_ENV];
+
+  let storage: TokenCacheStorage;
+  if (allowCommandStorage && configuredCommand !== undefined) {
+    const commandPath = configuredCommand.trim();
+    if (commandPath === '') {
+      throw new Error(`${AUTH_CACHE_COMMAND_ENV} was provided but is empty.`);
+    }
+    await assertCommandUsable(commandPath);
+    storage = new CommandTokenCacheStorage(
+      commandPath,
+      parseTimeoutMs(process.env[AUTH_CACHE_COMMAND_TIMEOUT_ENV])
+    );
+  } else {
+    storage = new DefaultTokenCacheStorage();
+  }
+
+  if (options.logProvider) {
+    logger.info(`Auth cache storage provider: ${storage.description}`);
+  }
+
+  return storage;
+}

--- a/test/auth-storage.test.ts
+++ b/test/auth-storage.test.ts
@@ -1,6 +1,7 @@
 import type { AccountInfo, Configuration } from '@azure/msal-node';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import AuthManager from '../src/auth.js';
+import { clearSecretsCache } from '../src/secrets.js';
 import { shouldUseLocalAuthStorage } from '../src/startup-pinning.js';
 import type { TokenCacheStorage } from '../src/token-cache-storage.js';
 import { unwrapCache, wrapCache } from '../src/token-cache-storage.js';
@@ -63,6 +64,13 @@ function createAuth(storage: TokenCacheStorage, accounts: AccountInfo[] = [accou
 describe('AuthManager token cache storage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    clearSecretsCache();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    clearSecretsCache();
   });
 
   it('loads token cache and selected-account metadata through storage', async () => {
@@ -131,6 +139,15 @@ describe('AuthManager token cache storage', () => {
     const { auth } = createAuth(storage);
 
     await expect(auth.loadTokenCache()).resolves.toBeUndefined();
+  });
+
+  it('disables command storage when create() builds fallback storage', async () => {
+    vi.stubEnv('MS365_MCP_AUTH_CACHE_COMMAND', '   ');
+
+    const auth = await AuthManager.create(['User.Read']);
+
+    const storage = (auth as unknown as { storage: TokenCacheStorage }).storage;
+    expect(storage.description).toBe('default (keytar+file)');
   });
 });
 

--- a/test/auth-storage.test.ts
+++ b/test/auth-storage.test.ts
@@ -1,0 +1,152 @@
+import type { AccountInfo, Configuration } from '@azure/msal-node';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AuthManager from '../src/auth.js';
+import { shouldUseLocalAuthStorage } from '../src/startup-pinning.js';
+import type { TokenCacheStorage } from '../src/token-cache-storage.js';
+import { unwrapCache, wrapCache } from '../src/token-cache-storage.js';
+
+vi.mock('../src/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const msalConfig: Configuration = {
+  auth: {
+    clientId: 'test-client',
+    authority: 'https://login.microsoftonline.com/common',
+  },
+};
+
+const account = {
+  username: 'user@example.com',
+  name: 'User',
+  homeAccountId: 'account.home',
+} as AccountInfo;
+
+function createStorage(overrides: Partial<TokenCacheStorage> = {}): TokenCacheStorage {
+  return {
+    description: 'mock-storage',
+    failClosed: true,
+    load: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function createAuth(storage: TokenCacheStorage, accounts: AccountInfo[] = [account]) {
+  const tokenCache = {
+    serialize: vi.fn().mockReturnValue('serialized-cache'),
+    deserialize: vi.fn(),
+    getAllAccounts: vi.fn().mockResolvedValue(accounts),
+    removeAccount: vi.fn().mockResolvedValue(undefined),
+  };
+  const msalApp = {
+    getTokenCache: vi.fn(() => tokenCache),
+    acquireTokenSilent: vi.fn().mockResolvedValue({
+      accessToken: 'silent-token',
+      expiresOn: new Date(Date.now() + 60_000),
+    }),
+    acquireTokenByDeviceCode: vi.fn(),
+    acquireTokenInteractive: vi.fn(),
+  };
+  const auth = new AuthManager(msalConfig, ['User.Read'], undefined, storage);
+
+  Object.assign(auth as unknown as Record<string, unknown>, { msalApp });
+
+  return { auth, msalApp, tokenCache };
+}
+
+describe('AuthManager token cache storage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads token cache and selected-account metadata through storage', async () => {
+    const storage = createStorage({
+      load: vi
+        .fn()
+        .mockResolvedValueOnce(wrapCache('serialized-cache'))
+        .mockResolvedValueOnce(wrapCache(JSON.stringify({ accountId: 'account.home' }))),
+    });
+    const { auth, tokenCache } = createAuth(storage);
+
+    await auth.loadTokenCache();
+
+    expect(storage.load).toHaveBeenNthCalledWith(1, 'token-cache');
+    expect(storage.load).toHaveBeenNthCalledWith(2, 'selected-account');
+    expect(tokenCache.deserialize).toHaveBeenCalledWith('serialized-cache');
+    expect(auth.getSelectedAccountId()).toBe('account.home');
+  });
+
+  it('saves the MSAL cache after silent token refresh', async () => {
+    const storage = createStorage();
+    const { auth } = createAuth(storage);
+
+    await auth.getToken();
+
+    expect(storage.save).toHaveBeenCalledWith('token-cache', expect.any(String));
+    const saved = vi.mocked(storage.save).mock.calls[0][1];
+    expect(unwrapCache(saved).data).toBe('serialized-cache');
+  });
+
+  it('saves selected-account metadata on account selection', async () => {
+    const storage = createStorage();
+    const { auth } = createAuth(storage);
+
+    await auth.selectAccount('user@example.com');
+
+    expect(storage.save).toHaveBeenCalledWith('selected-account', expect.any(String));
+    const saved = vi.mocked(storage.save).mock.calls[0][1];
+    expect(JSON.parse(unwrapCache(saved).data)).toEqual({ accountId: 'account.home' });
+  });
+
+  it('deletes both storage keys on logout', async () => {
+    const storage = createStorage();
+    const { auth } = createAuth(storage);
+
+    await auth.logout();
+
+    expect(storage.delete).toHaveBeenCalledWith('token-cache');
+    expect(storage.delete).toHaveBeenCalledWith('selected-account');
+  });
+
+  it('rethrows fail-closed storage errors', async () => {
+    const storage = createStorage({
+      load: vi.fn().mockRejectedValue(new Error('storage unavailable')),
+    });
+    const { auth } = createAuth(storage);
+
+    await expect(auth.loadTokenCache()).rejects.toThrow(/storage unavailable/);
+  });
+
+  it('preserves best-effort default behavior for non-strict storage errors', async () => {
+    const storage = createStorage({
+      failClosed: false,
+      load: vi.fn().mockRejectedValue(new Error('best-effort miss')),
+    });
+    const { auth } = createAuth(storage);
+
+    await expect(auth.loadTokenCache()).resolves.toBeUndefined();
+  });
+});
+
+describe('HTTP startup local storage selection', () => {
+  it('skips local storage for stateless HTTP graph requests', () => {
+    expect(shouldUseLocalAuthStorage({ http: true })).toBe(false);
+    expect(shouldUseLocalAuthStorage({ http: true, obo: true })).toBe(false);
+  });
+
+  it('uses local storage when HTTP auth tools or account commands are explicit', () => {
+    expect(shouldUseLocalAuthStorage({ http: true, enableAuthTools: true })).toBe(true);
+    expect(shouldUseLocalAuthStorage({ http: true, login: true })).toBe(true);
+    expect(shouldUseLocalAuthStorage({ http: true, listAccounts: true })).toBe(true);
+  });
+
+  it('uses local storage for stdio/local auth flows', () => {
+    expect(shouldUseLocalAuthStorage({})).toBe(true);
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -51,12 +51,14 @@ describe('CLI Module', () => {
     delete process.env.MS365_MCP_ALLOWED_SCOPES;
     delete process.env.MS365_MCP_EXPECTED_USERNAME;
     delete process.env.MS365_MCP_EXPECTED_HOME_ACCOUNT_ID;
+    delete process.env.MS365_MCP_AUTH_CACHE_COMMAND;
   });
 
   afterEach(() => {
     delete process.env.MS365_MCP_ALLOWED_SCOPES;
     delete process.env.MS365_MCP_EXPECTED_USERNAME;
     delete process.env.MS365_MCP_EXPECTED_HOME_ACCOUNT_ID;
+    delete process.env.MS365_MCP_AUTH_CACHE_COMMAND;
   });
 
   describe('parseArgs', () => {
@@ -168,6 +170,18 @@ describe('CLI Module', () => {
         expect.stringContaining('MS365_MCP_EXPECTED_HOME_ACCOUNT_ID')
       );
       expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('does not add auth-cache command CLI or args env parsing', () => {
+      process.env.MS365_MCP_AUTH_CACHE_COMMAND = '/tmp/wrapper';
+      commanderMocks.mockCommand.opts.mockReturnValue({});
+
+      const result = parseArgs();
+      const optionFlags = commanderMocks.mockCommand.option.mock.calls.map(([flags]) => flags);
+
+      expect(optionFlags).not.toContain('--auth-cache-command <command>');
+      expect(result).not.toHaveProperty('authCacheCommand');
+      expect(result).not.toHaveProperty('authCacheCommandArgs');
     });
   });
 });

--- a/test/token-cache-storage.test.ts
+++ b/test/token-cache-storage.test.ts
@@ -196,6 +196,16 @@ describe('token cache storage', () => {
       expect(resolved).toBe(true);
     });
 
+    it('ignores stdin stream errors and uses command exit status as the signal', async () => {
+      const { spawnCommand } = createFakeSpawn(({ child }) => {
+        child.stdin.emit('error', new Error('EPIPE'));
+        closeChild(child);
+      });
+      const storage = new CommandTokenCacheStorage('/cache-wrapper', 1000, spawnCommand);
+
+      await expect(storage.save('token-cache', 'cached-value')).resolves.toBeUndefined();
+    });
+
     it('deletes by operation and key without stdin payload', async () => {
       const { spawnCommand, calls } = createFakeSpawn(({ child }) => closeChild(child));
       const storage = new CommandTokenCacheStorage('/cache-wrapper', 1000, spawnCommand);

--- a/test/token-cache-storage.test.ts
+++ b/test/token-cache-storage.test.ts
@@ -1,0 +1,251 @@
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PassThrough, Writable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CommandTokenCacheStorage,
+  DefaultTokenCacheStorage,
+  createTokenCacheStorage,
+  type TokenCacheStorageKey,
+  wrapCache,
+} from '../src/token-cache-storage.js';
+
+vi.mock('../src/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+type FakeChild = EventEmitter & {
+  stdin: Writable;
+  stdout: PassThrough;
+  stderr: PassThrough;
+  kill: ReturnType<typeof vi.fn>;
+};
+
+type SpawnHandler = (context: { args: string[]; stdin: string; child: FakeChild }) => void;
+
+function createFakeSpawn(handler: SpawnHandler) {
+  const calls: Array<{ command: string; args: string[]; stdin: string }> = [];
+
+  const spawnCommand = vi.fn((command: string, args: string[]) => {
+    let stdin = '';
+    const child = new EventEmitter() as FakeChild;
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.kill = vi.fn((signal?: string | number) => {
+      if (signal === 'SIGKILL') {
+        child.emit('close', null, 'SIGKILL');
+      }
+      return true;
+    });
+    child.stdin = new Writable({
+      write(chunk, _encoding, callback) {
+        stdin += chunk.toString();
+        callback();
+      },
+      final(callback) {
+        calls.push({ command, args, stdin });
+        handler({ args, stdin, child });
+        callback();
+      },
+    });
+    return child;
+  });
+
+  return { spawnCommand, calls };
+}
+
+function closeChild(child: FakeChild, exitCode = 0): void {
+  child.stdout.end();
+  child.stderr.end();
+  child.emit('close', exitCode, null);
+}
+
+describe('token cache storage', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  describe('provider selection', () => {
+    it('uses default storage when no command is configured', async () => {
+      const storage = await createTokenCacheStorage();
+
+      expect(storage).toBeInstanceOf(DefaultTokenCacheStorage);
+      expect(storage.description).toBe('default (keytar+file)');
+    });
+
+    it('rejects a whitespace-only command for local auth flows', async () => {
+      vi.stubEnv('MS365_MCP_AUTH_CACHE_COMMAND', '   ');
+
+      await expect(createTokenCacheStorage()).rejects.toThrow(/MS365_MCP_AUTH_CACHE_COMMAND/);
+    });
+
+    it('ignores invalid command configuration when command storage is disabled', async () => {
+      vi.stubEnv('MS365_MCP_AUTH_CACHE_COMMAND', '   ');
+
+      const storage = await createTokenCacheStorage({ allowCommandStorage: false });
+
+      expect(storage).toBeInstanceOf(DefaultTokenCacheStorage);
+    });
+
+    it('rejects a missing command path for local auth flows', async () => {
+      vi.stubEnv('MS365_MCP_AUTH_CACHE_COMMAND', path.join(os.tmpdir(), 'missing-ms365-cache'));
+
+      await expect(createTokenCacheStorage()).rejects.toThrow(/does not exist/);
+    });
+
+    it('rejects a non-executable command path on POSIX', async () => {
+      if (process.platform === 'win32') {
+        return;
+      }
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms365-cache-test-'));
+      const commandPath = path.join(dir, 'store');
+      fs.writeFileSync(commandPath, '#!/bin/sh\nexit 0\n', { mode: 0o600 });
+      vi.stubEnv('MS365_MCP_AUTH_CACHE_COMMAND', commandPath);
+
+      await expect(createTokenCacheStorage()).rejects.toThrow(/executable file/);
+    });
+  });
+
+  describe('command protocol', () => {
+    it('loads present and missing values from the command protocol', async () => {
+      const { spawnCommand } = createFakeSpawn(({ args, child }) => {
+        if (args[1] === 'token-cache') {
+          child.stdout.write(JSON.stringify({ found: true, value: 'stored-envelope' }));
+        } else {
+          child.stdout.write(JSON.stringify({ found: false }));
+        }
+        closeChild(child);
+      });
+      const storage = new CommandTokenCacheStorage('/cache-wrapper', 1000, spawnCommand);
+
+      await expect(storage.load('token-cache')).resolves.toBe('stored-envelope');
+      await expect(storage.load('selected-account')).resolves.toBeUndefined();
+    });
+
+    it('treats empty stdout as a cache miss', async () => {
+      const { spawnCommand } = createFakeSpawn(({ child }) => closeChild(child));
+      const storage = new CommandTokenCacheStorage('/cache-wrapper', 1000, spawnCommand);
+
+      await expect(storage.load('token-cache')).resolves.toBeUndefined();
+    });
+
+    it('treats non-zero exits as storage errors, not misses', async () => {
+      const { spawnCommand } = createFakeSpawn(({ child }) => closeChild(child, 2));
+      const storage = new CommandTokenCacheStorage('/cache-wrapper', 1000, spawnCommand);
+
+      await expect(storage.load('token-cache')).rejects.toThrow(/exit 2/);
+    });
+
+    it('fails closed on invalid load JSON and malformed payloads', async () => {
+      const invalidJson = createFakeSpawn(({ child }) => {
+        child.stdout.write('not-json');
+        closeChild(child);
+      });
+      const missingValue = createFakeSpawn(({ child }) => {
+        child.stdout.write(JSON.stringify({ found: true }));
+        closeChild(child);
+      });
+
+      await expect(
+        new CommandTokenCacheStorage('/cache-wrapper', 1000, invalidJson.spawnCommand).load(
+          'token-cache'
+        )
+      ).rejects.toThrow(/invalid JSON/);
+      await expect(
+        new CommandTokenCacheStorage('/cache-wrapper', 1000, missingValue.spawnCommand).load(
+          'token-cache'
+        )
+      ).rejects.toThrow(/invalid load response/);
+    });
+
+    it('sends save values through stdin and waits for command exit', async () => {
+      let deferredChild: FakeChild | undefined;
+      let resolved = false;
+      const value = 'x'.repeat(64 * 1024);
+      const { spawnCommand, calls } = createFakeSpawn(({ child }) => {
+        deferredChild = child;
+      });
+      const storage = new CommandTokenCacheStorage('/cache-wrapper', 1000, spawnCommand);
+
+      const promise = storage.save('token-cache', value).then(() => {
+        resolved = true;
+      });
+      await Promise.resolve();
+
+      expect(resolved).toBe(false);
+      expect(calls[0].args).toEqual(['save', 'token-cache']);
+      expect(JSON.parse(calls[0].stdin)).toEqual({ value });
+
+      closeChild(deferredChild!);
+      await promise;
+      expect(resolved).toBe(true);
+    });
+
+    it('deletes by operation and key without stdin payload', async () => {
+      const { spawnCommand, calls } = createFakeSpawn(({ child }) => closeChild(child));
+      const storage = new CommandTokenCacheStorage('/cache-wrapper', 1000, spawnCommand);
+
+      await storage.delete('selected-account');
+
+      expect(calls[0]).toMatchObject({
+        args: ['delete', 'selected-account'],
+        stdin: '',
+      });
+    });
+
+    it('sanitizes command errors without echoing stdin or stdout payloads', async () => {
+      const secretValue = wrapCache('secret-token-value');
+      const longStderr = `adapter failed ${'x'.repeat(3000)}`;
+      const { spawnCommand } = createFakeSpawn(({ child }) => {
+        child.stdout.write(secretValue);
+        child.stderr.write(longStderr);
+        closeChild(child, 1);
+      });
+      const storage = new CommandTokenCacheStorage('/cache-wrapper', 1000, spawnCommand);
+
+      await expect(storage.save('token-cache', secretValue)).rejects.toThrow(/adapter failed/);
+      await expect(storage.save('token-cache', secretValue)).rejects.not.toThrow(
+        /secret-token-value/
+      );
+    });
+
+    it('times out by sending SIGTERM then SIGKILL', async () => {
+      vi.useFakeTimers();
+      let childRef: FakeChild | undefined;
+      const { spawnCommand } = createFakeSpawn(({ child }) => {
+        childRef = child;
+      });
+      const storage = new CommandTokenCacheStorage('/cache-wrapper', 10, spawnCommand);
+
+      const assertion = expect(storage.load('token-cache')).rejects.toThrow(/timed out/);
+      await vi.advanceTimersByTimeAsync(1010);
+      await assertion;
+
+      expect(childRef?.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(childRef?.kill).toHaveBeenCalledWith('SIGKILL');
+    });
+
+    it('rejects unknown storage keys before spawning', async () => {
+      const { spawnCommand } = createFakeSpawn(({ child }) => closeChild(child));
+      const storage = new CommandTokenCacheStorage('/cache-wrapper', 1000, spawnCommand);
+
+      await expect(storage.load('unknown' as TokenCacheStorageKey)).rejects.toThrow(/Unknown/);
+      expect(spawnCommand).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a provider-neutral auth cache storage abstraction while preserving the default keytar/file behavior when no command is configured.
- Add `MS365_MCP_AUTH_CACHE_COMMAND` command storage for local MSAL token-cache and selected-account metadata, with durable save semantics and fail-closed sanitized command errors.
- Skip configured command storage for stateless HTTP request-token/OBO startup and Graph requests unless local auth tools or account commands explicitly use local auth state.

## Validation
- `npm test -- test/token-cache-storage.test.ts test/auth-storage.test.ts test/cache-stamp.test.ts test/auth-paths.test.ts test/auth-pinning.test.ts test/multi-account.test.ts test/auth-tools.test.ts test/cli.test.ts`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `npx prettier --check src/token-cache-storage.ts src/auth.ts src/index.ts src/startup-pinning.ts test/token-cache-storage.test.ts test/auth-storage.test.ts test/cli.test.ts README.md docs/deployment.md`
- `npm test` currently times out locally in the pre-existing `src/__tests__/graph-tools.test.ts` `$count advanced query mode` test when the full suite runs; rerunning that single test passes locally.

## Notes
- The command env var is an executable wrapper path only. It is not shell parsed, and v1 does not add an args env var or CLI flag.
- Command storage stores the existing stamped envelope string as an opaque payload so `_cacheEnvelope`, saved-at ordering, legacy raw cache compatibility, and selected-account storage remain compatible.

Made with [Cursor](https://cursor.com)