### PR TITLE
feat(http): add --trust-proxy-auth to skip Bearer check on /mcp

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,6 +82,10 @@ program
     '--obo',
     'Enable On-Behalf-Of token exchange in HTTP mode. Exchanges the incoming bearer token for a Graph API token using the OBO flow. Requires MS365_MCP_CLIENT_SECRET.'
   )
+  .option(
+    '--trust-proxy-auth',
+    'In HTTP mode, skip the built-in Bearer-token check on /mcp and let an upstream reverse proxy (which is presumed to have already authenticated the caller) pass requests through unauthenticated. Microsoft Graph access still flows through the locally cached MSAL refresh token via AuthManager. Use only when the server is not reachable except via a trusted proxy.'
+  )
   .addOption(
     // DEPRECATED: kept only so existing deployments that set --base-url or
     // MS365_MCP_BASE_URL do not crash at startup. Use --public-url /
@@ -117,6 +121,7 @@ export interface CommandOptions {
   dynamicRegistration?: boolean;
   authBrowser?: boolean;
   obo?: boolean;
+  trustProxyAuth?: boolean;
   publicUrl?: string;
   /** @deprecated use publicUrl */
   baseUrl?: string;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,7 +84,7 @@ program
   )
   .option(
     '--trust-proxy-auth',
-    'In HTTP mode, skip the built-in Bearer-token check on /mcp and let an upstream reverse proxy (which is presumed to have already authenticated the caller) pass requests through unauthenticated. Microsoft Graph access still flows through the locally cached MSAL refresh token via AuthManager. Use only when the server is not reachable except via a trusted proxy.'
+    'In HTTP mode, skip the built-in Bearer-token check on /mcp. Use only when an upstream reverse proxy has already authenticated the caller.'
   )
   .addOption(
     // DEPRECATED: kept only so existing deployments that set --base-url or

--- a/src/lib/microsoft-auth.ts
+++ b/src/lib/microsoft-auth.ts
@@ -28,12 +28,24 @@ function isJwtExpired(token: string): boolean {
  * Microsoft Bearer Token Auth Middleware validates that the request has a valid Microsoft access token.
  * Returns HTTP 401 + WWW-Authenticate on missing or expired tokens so spec-compliant MCP clients
  * refresh via the /token endpoint. Opaque tokens fall through and are validated by Graph.
+ *
+ * When `trustProxyAuth` is true the bearer check is skipped — an upstream
+ * reverse proxy is presumed to have authenticated the caller, and Microsoft
+ * Graph access falls back to the locally cached MSAL refresh token via
+ * AuthManager (the same path stdio mode uses).
  */
 export const microsoftBearerTokenAuthMiddleware = (
+  opts: { trustProxyAuth?: boolean } = {}
+) => (
   req: Request & { microsoftAuth?: { accessToken: string } },
   res: Response,
   next: NextFunction
 ): void => {
+  if (opts.trustProxyAuth) {
+    next();
+    return;
+  }
+
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {

--- a/src/lib/microsoft-auth.ts
+++ b/src/lib/microsoft-auth.ts
@@ -34,51 +34,51 @@ function isJwtExpired(token: string): boolean {
  * Graph access falls back to the locally cached MSAL refresh token via
  * AuthManager (the same path stdio mode uses).
  */
-export const microsoftBearerTokenAuthMiddleware = (
-  opts: { trustProxyAuth?: boolean } = {}
-) => (
-  req: Request & { microsoftAuth?: { accessToken: string } },
-  res: Response,
-  next: NextFunction
-): void => {
-  if (opts.trustProxyAuth) {
+export const microsoftBearerTokenAuthMiddleware =
+  (opts: { trustProxyAuth?: boolean } = {}) =>
+  (
+    req: Request & { microsoftAuth?: { accessToken: string } },
+    res: Response,
+    next: NextFunction
+  ): void => {
+    if (opts.trustProxyAuth) {
+      next();
+      return;
+    }
+
+    const authHeader = req.headers.authorization;
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      res
+        .status(401)
+        .set(
+          'WWW-Authenticate',
+          buildWwwAuthenticate(req, 'invalid_token', 'Missing or malformed Authorization header')
+        )
+        .json({
+          error: 'invalid_token',
+          error_description: 'Missing or malformed Authorization header',
+        });
+      return;
+    }
+
+    const accessToken = authHeader.substring(7);
+
+    if (isJwtExpired(accessToken)) {
+      res
+        .status(401)
+        .set(
+          'WWW-Authenticate',
+          buildWwwAuthenticate(req, 'invalid_token', 'The access token has expired')
+        )
+        .json({ error: 'invalid_token', error_description: 'The access token has expired' });
+      return;
+    }
+
+    req.microsoftAuth = { accessToken };
+
     next();
-    return;
-  }
-
-  const authHeader = req.headers.authorization;
-
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    res
-      .status(401)
-      .set(
-        'WWW-Authenticate',
-        buildWwwAuthenticate(req, 'invalid_token', 'Missing or malformed Authorization header')
-      )
-      .json({
-        error: 'invalid_token',
-        error_description: 'Missing or malformed Authorization header',
-      });
-    return;
-  }
-
-  const accessToken = authHeader.substring(7);
-
-  if (isJwtExpired(accessToken)) {
-    res
-      .status(401)
-      .set(
-        'WWW-Authenticate',
-        buildWwwAuthenticate(req, 'invalid_token', 'The access token has expired')
-      )
-      .json({ error: 'invalid_token', error_description: 'The access token has expired' });
-    return;
-  }
-
-  req.microsoftAuth = { accessToken };
-
-  next();
-};
+  };
 
 /**
  * Exchange authorization code for access token

--- a/src/server.ts
+++ b/src/server.ts
@@ -592,10 +592,16 @@ class MicrosoftGraphServer {
       );
 
       // Microsoft Graph MCP endpoints with bearer token auth
-      // Handle both GET and POST methods as required by MCP Streamable HTTP specification
+      // Handle both GET and POST methods as required by MCP Streamable HTTP specification.
+      // --trust-proxy-auth removes the bearer check so an upstream reverse proxy can
+      // authenticate the caller; in that case the local AuthManager (MSAL refresh token
+      // cache) supplies Graph API tokens, matching stdio-mode behaviour.
+      const mcpAuth = this.options.trustProxyAuth
+        ? (_req: Request, _res: Response, next: (err?: unknown) => void) => next()
+        : microsoftBearerTokenAuthMiddleware;
       app.get(
         '/mcp',
-        microsoftBearerTokenAuthMiddleware,
+        mcpAuth,
         async (req: Request & { microsoftAuth?: { accessToken: string } }, res: Response) => {
           const handler = async () => {
             const server = this.createMcpServer();
@@ -640,7 +646,7 @@ class MicrosoftGraphServer {
 
       app.post(
         '/mcp',
-        microsoftBearerTokenAuthMiddleware,
+        mcpAuth,
         async (req: Request & { microsoftAuth?: { accessToken: string } }, res: Response) => {
           const handler = async () => {
             const server = this.createMcpServer();

--- a/src/server.ts
+++ b/src/server.ts
@@ -597,7 +597,7 @@ class MicrosoftGraphServer {
       // authenticate the caller; in that case the local AuthManager (MSAL refresh token
       // cache) supplies Graph API tokens, matching stdio-mode behaviour.
       const mcpAuth = this.options.trustProxyAuth
-        ? (_req: Request, _res: Response, next: (err?: unknown) => void) => next()
+        ? (_req: Request, _res: Response, next: express.NextFunction) => next()
         : microsoftBearerTokenAuthMiddleware;
       app.get(
         '/mcp',

--- a/src/server.ts
+++ b/src/server.ts
@@ -591,14 +591,12 @@ class MicrosoftGraphServer {
         })
       );
 
-      // Microsoft Graph MCP endpoints with bearer token auth
-      // Handle both GET and POST methods as required by MCP Streamable HTTP specification.
-      // --trust-proxy-auth removes the bearer check so an upstream reverse proxy can
-      // authenticate the caller; in that case the local AuthManager (MSAL refresh token
-      // cache) supplies Graph API tokens, matching stdio-mode behaviour.
-      const mcpAuth = this.options.trustProxyAuth
-        ? (_req: Request, _res: Response, next: express.NextFunction) => next()
-        : microsoftBearerTokenAuthMiddleware;
+      // Microsoft Graph MCP endpoints with bearer token auth (or pass-through
+      // when --trust-proxy-auth is set; see microsoftBearerTokenAuthMiddleware
+      // for the AuthManager fallback that makes that mode work).
+      const mcpAuth = microsoftBearerTokenAuthMiddleware({
+        trustProxyAuth: this.options.trustProxyAuth,
+      });
       app.get(
         '/mcp',
         mcpAuth,


### PR DESCRIPTION
## Summary
Adds an opt-in `--trust-proxy-auth` CLI flag that disables the in-process Bearer-token middleware on `GET/POST /mcp` so the server can run unauthenticated behind a reverse proxy that has already authenticated the caller.

When the flag is set, Microsoft Graph API access still flows through the locally cached MSAL refresh token via `AuthManager` — the same path stdio mode uses today — so a one-time device-code login still bootstraps the token cache. The OAuth metadata endpoints (`/register`, `/token`, `/authorize`, `/.well-known/*`) are unchanged; they simply go unused when nothing reaches them through the proxy.

The flag is **off by default**. The README guidance ("HTTP mode requires authentication") still holds for any deployment that is reachable from anything other than a trusted proxy.

## Motivation
Self-hosted multi-backend MCP setups (claude.ai → gateway → N MCP backends) typically authenticate at the gateway. Today the only way to put ms-365-mcp-server behind such a gateway is to wrap stdio in supergateway, which has been observed to crash on mid-request client disconnects under recent SDK versions. A documented opt-out lets the gateway own auth and ms-365-mcp-server stay native HTTP.

## Changes
- src/cli.ts: new --trust-proxy-auth option; CommandOptions.trustProxyAuth.
- src/server.ts: when the flag is set, substitute a pass-through middleware for microsoftBearerTokenAuthMiddleware on the two /mcp routes. The existing if (req.microsoftAuth) { ... } else { await handler(); } branch already handles the no-bearer case, so the handler body itself does not change.

## Test plan
- [x] npm install && npm run generate && npm run build
- [x] node dist/index.js --http :3001 --trust-proxy-auth listens on 3001 with no MSAL login required at startup
- [x] POST /mcp tools/list returns 200 + tool list without an Authorization header
- [x] node dist/index.js --http :3001 (no flag) still returns 401 + WWW-Authenticate on the same request
- [x] Docker image built from the branch successfully fronts ToDo tool calls via an external reverse proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)