### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -19,6 +20,7 @@ jobs:
         with:
           node-version: 22
           cache: 'npm'
+      - run: npm install -g npm@latest
       - run: npm i -D patch-package
       - run: npm ci
       - run: npm run generate
@@ -29,4 +31,3 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.npm_token }}


### PR DESCRIPTION
Drops the long-lived NPM_TOKEN secret in favor of npm's trusted publisher flow. Adds id-token: write permission and bumps the runner's npm to >= 11.5.1 (required for OIDC publishing).