### PR TITLE
feat(http): trust-proxy-auth follow-ups

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,7 +84,7 @@ program
   )
   .option(
     '--trust-proxy-auth',
-    'In HTTP mode, skip the built-in Bearer-token check on /mcp. Use only when an upstream reverse proxy has already authenticated the caller.'
+    'In HTTP mode, skip the built-in Bearer-token check on /mcp and ignore any forwarded Authorization header. All callers share the locally cached MSAL identity (same path stdio mode uses). Use only when an upstream reverse proxy has already authenticated the caller.'
   )
   .addOption(
     // DEPRECATED: kept only so existing deployments that set --base-url or
@@ -259,6 +259,13 @@ export function parseArgs(): CommandOptions {
 
   if (process.env.MS365_MCP_OBO === 'true' || process.env.MS365_MCP_OBO === '1') {
     options.obo = true;
+  }
+
+  if (
+    process.env.MS365_MCP_TRUST_PROXY_AUTH === 'true' ||
+    process.env.MS365_MCP_TRUST_PROXY_AUTH === '1'
+  ) {
+    options.trustProxyAuth = true;
   }
 
   // Handle cloud type - CLI option takes precedence over environment variable

--- a/src/server.ts
+++ b/src/server.ts
@@ -161,6 +161,11 @@ class MicrosoftGraphServer {
           '--obo requires MS365_MCP_CLIENT_SECRET to be set (confidential client required for On-Behalf-Of flow).'
         );
       }
+      if (this.options.trustProxyAuth) {
+        throw new Error(
+          '--obo cannot be combined with --trust-proxy-auth: the proxy-auth pass-through skips the incoming bearer token that OBO would exchange.'
+        );
+      }
       this.oboClient = new OboClient(this.secrets);
       logger.info('On-Behalf-Of (OBO) flow enabled');
     }


### PR DESCRIPTION
- Expand --trust-proxy-auth help to note that forwarded Authorization headers are ignored and all callers share the locally cached identity.
- Error at startup on --obo + --trust-proxy-auth (the pass-through skips the incoming bearer token that OBO would exchange).
- Add MS365_MCP_TRUST_PROXY_AUTH env var, matching the other deployment flags.