### PR TITLE
fix(http): surface upstream OAuth errors from /token (#485)

### DIFF
--- a/src/lib/microsoft-auth.ts
+++ b/src/lib/microsoft-auth.ts
@@ -80,6 +80,68 @@ export const microsoftBearerTokenAuthMiddleware =
     next();
   };
 
+export interface UpstreamOAuthErrorBody {
+  error: string;
+  error_description?: string;
+  error_codes?: number[];
+  suberror?: string;
+  trace_id?: string;
+  correlation_id?: string;
+  timestamp?: string;
+}
+
+export class OAuthUpstreamError extends Error {
+  readonly status: number;
+  readonly body: UpstreamOAuthErrorBody;
+  readonly raw: string;
+
+  constructor(status: number, raw: string, body: UpstreamOAuthErrorBody) {
+    const suffix = body.error_description ? ` - ${body.error_description}` : '';
+    super(`OAuth upstream error: ${body.error}${suffix}`);
+    this.name = 'OAuthUpstreamError';
+    this.status = status;
+    this.body = body;
+    this.raw = raw;
+  }
+}
+
+function parseUpstreamOAuthError(raw: string): UpstreamOAuthErrorBody | null {
+  try {
+    const json = JSON.parse(raw) as unknown;
+    if (
+      json !== null &&
+      typeof json === 'object' &&
+      typeof (json as { error?: unknown }).error === 'string'
+    ) {
+      return json as UpstreamOAuthErrorBody;
+    }
+  } catch {
+    /* not JSON */
+  }
+  return null;
+}
+
+export function toOAuthErrorResponse(error: unknown): {
+  status: number;
+  body: { error: string; error_description?: string; suberror?: string };
+} {
+  if (error instanceof OAuthUpstreamError) {
+    const body: { error: string; error_description?: string; suberror?: string } = {
+      error: error.body.error,
+    };
+    if (error.body.error_description) body.error_description = error.body.error_description;
+    if (error.body.suberror) body.suberror = error.body.suberror;
+    return { status: 400, body };
+  }
+  return {
+    status: 500,
+    body: {
+      error: 'server_error',
+      error_description: 'Internal server error during token exchange',
+    },
+  };
+}
+
 /**
  * Exchange authorization code for access token
  */
@@ -125,9 +187,20 @@ export async function exchangeCodeForToken(
   });
 
   if (!response.ok) {
-    const error = await response.text();
-    logger.error(`Failed to exchange code for token: ${error}`);
-    throw new Error(`Failed to exchange code for token: ${error}`);
+    const raw = await response.text();
+    const parsed = parseUpstreamOAuthError(raw);
+    if (parsed) {
+      logger.warn(`Token endpoint upstream OAuth error: ${parsed.error}`, {
+        status: response.status,
+        error: parsed.error,
+        suberror: parsed.suberror,
+        error_codes: parsed.error_codes,
+        correlation_id: parsed.correlation_id,
+      });
+      throw new OAuthUpstreamError(response.status, raw, parsed);
+    }
+    logger.error(`Failed to exchange code for token: ${raw}`);
+    throw new Error(`Failed to exchange code for token: ${raw}`);
   }
 
   return response.json();
@@ -169,9 +242,20 @@ export async function refreshAccessToken(
   });
 
   if (!response.ok) {
-    const error = await response.text();
-    logger.error(`Failed to refresh token: ${error}`);
-    throw new Error(`Failed to refresh token: ${error}`);
+    const raw = await response.text();
+    const parsed = parseUpstreamOAuthError(raw);
+    if (parsed) {
+      logger.warn(`Token endpoint upstream OAuth error: ${parsed.error}`, {
+        status: response.status,
+        error: parsed.error,
+        suberror: parsed.suberror,
+        error_codes: parsed.error_codes,
+        correlation_id: parsed.correlation_id,
+      });
+      throw new OAuthUpstreamError(response.status, raw, parsed);
+    }
+    logger.error(`Failed to refresh token: ${raw}`);
+    throw new Error(`Failed to refresh token: ${raw}`);
   }
 
   return response.json();

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,9 @@ import { MicrosoftOAuthProvider } from './oauth-provider.js';
 import {
   exchangeCodeForToken,
   microsoftBearerTokenAuthMiddleware,
+  OAuthUpstreamError,
   refreshAccessToken,
+  toOAuthErrorResponse,
 } from './lib/microsoft-auth.js';
 import { isAllowedRedirectUri, parseAllowlist } from './lib/redirect-uri-validation.js';
 import type { CommandOptions } from './cli.ts';
@@ -581,11 +583,18 @@ class MicrosoftGraphServer {
             });
           }
         } catch (error) {
-          logger.error('Token endpoint error:', error);
-          res.status(500).json({
-            error: 'server_error',
-            error_description: 'Internal server error during token exchange',
-          });
+          if (error instanceof OAuthUpstreamError) {
+            logger.warn('Token endpoint: upstream OAuth error surfaced to client', {
+              upstream_status: error.status,
+              error: error.body.error,
+              suberror: error.body.suberror,
+              error_codes: error.body.error_codes,
+            });
+          } else {
+            logger.error('Token endpoint error:', error);
+          }
+          const { status, body } = toOAuthErrorResponse(error);
+          res.status(status).json(body);
         }
       });
 

--- a/test/token-upstream-errors.test.ts
+++ b/test/token-upstream-errors.test.ts
@@ -1,0 +1,172 @@
+// Regression test for issue #485: /token used to flatten every Entra error to
+// HTTP 500, so OAuth clients couldn't distinguish a recoverable invalid_grant
+// (e.g. AADSTS70043 from a Conditional Access sign-in frequency lapse) from a
+// genuine server bug, and never retried with prompt=login.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  exchangeCodeForToken,
+  OAuthUpstreamError,
+  refreshAccessToken,
+  toOAuthErrorResponse,
+} from '../src/lib/microsoft-auth.js';
+
+vi.mock('../src/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('Issue #485: upstream OAuth error surfacing', () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function mockEntraResponse(status: number, body: string): void {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => body,
+      json: async () => JSON.parse(body),
+    } as Response);
+  }
+
+  describe('refreshAccessToken', () => {
+    it('throws OAuthUpstreamError with parsed body on AADSTS70043 invalid_grant', async () => {
+      mockEntraResponse(
+        400,
+        JSON.stringify({
+          error: 'invalid_grant',
+          error_description:
+            'AADSTS70043: The refresh token has expired or is invalid due to sign-in frequency checks by conditional access. The token was issued on 2026-05-07 and the maximum allowed lifetime for this request is 1209600.',
+          error_codes: [70043],
+          suberror: 'token_expired',
+          trace_id: 'trace-abc',
+          correlation_id: 'corr-xyz',
+        })
+      );
+
+      await expect(refreshAccessToken('rt', 'client-id', undefined)).rejects.toMatchObject({
+        name: 'OAuthUpstreamError',
+        status: 400,
+        body: {
+          error: 'invalid_grant',
+          suberror: 'token_expired',
+          error_codes: [70043],
+        },
+      });
+    });
+
+    it('falls back to generic Error when upstream body is not JSON', async () => {
+      mockEntraResponse(502, '<html>Bad Gateway</html>');
+
+      let caught: unknown;
+      try {
+        await refreshAccessToken('rt', 'client-id', undefined);
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      expect(caught).not.toBeInstanceOf(OAuthUpstreamError);
+      expect((caught as Error).message).toContain('Failed to refresh token');
+    });
+
+    it('falls back to generic Error when JSON body lacks `error` field', async () => {
+      mockEntraResponse(400, JSON.stringify({ something_else: 'value' }));
+
+      let caught: unknown;
+      try {
+        await refreshAccessToken('rt', 'client-id', undefined);
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      expect(caught).not.toBeInstanceOf(OAuthUpstreamError);
+    });
+  });
+
+  describe('exchangeCodeForToken', () => {
+    it('throws OAuthUpstreamError when Entra rejects the code', async () => {
+      mockEntraResponse(
+        400,
+        JSON.stringify({
+          error: 'invalid_grant',
+          error_description: 'AADSTS70008: The provided authorization code has expired.',
+          error_codes: [70008],
+        })
+      );
+
+      await expect(
+        exchangeCodeForToken('code', 'http://localhost/cb', 'client-id', undefined)
+      ).rejects.toMatchObject({
+        name: 'OAuthUpstreamError',
+        status: 400,
+        body: { error: 'invalid_grant', error_codes: [70008] },
+      });
+    });
+  });
+
+  describe('toOAuthErrorResponse', () => {
+    it('maps OAuthUpstreamError to HTTP 400 with passthrough fields', () => {
+      const err = new OAuthUpstreamError(400, 'raw', {
+        error: 'invalid_grant',
+        error_description: 'AADSTS70043: ...',
+        suberror: 'token_expired',
+        error_codes: [70043],
+        trace_id: 'trace-abc',
+        correlation_id: 'corr-xyz',
+      });
+
+      const { status, body } = toOAuthErrorResponse(err);
+      expect(status).toBe(400);
+      expect(body).toEqual({
+        error: 'invalid_grant',
+        error_description: 'AADSTS70043: ...',
+        suberror: 'token_expired',
+      });
+    });
+
+    it('omits suberror and error_description when upstream did not supply them', () => {
+      const err = new OAuthUpstreamError(400, 'raw', { error: 'invalid_request' });
+      const { status, body } = toOAuthErrorResponse(err);
+      expect(status).toBe(400);
+      expect(body).toEqual({ error: 'invalid_request' });
+    });
+
+    it('does not leak trace_id / correlation_id in response body', () => {
+      const err = new OAuthUpstreamError(400, 'raw', {
+        error: 'invalid_grant',
+        trace_id: 'sensitive-trace',
+        correlation_id: 'sensitive-corr',
+      });
+      const { body } = toOAuthErrorResponse(err);
+      expect(body).not.toHaveProperty('trace_id');
+      expect(body).not.toHaveProperty('correlation_id');
+    });
+
+    it('maps non-OAuth errors to HTTP 500 generic server_error', () => {
+      const { status, body } = toOAuthErrorResponse(new Error('network down'));
+      expect(status).toBe(500);
+      expect(body).toEqual({
+        error: 'server_error',
+        error_description: 'Internal server error during token exchange',
+      });
+    });
+
+    it('maps non-Error throws (string, undefined, object) to HTTP 500 generic', () => {
+      expect(toOAuthErrorResponse('oops').status).toBe(500);
+      expect(toOAuthErrorResponse(undefined).status).toBe(500);
+      expect(toOAuthErrorResponse({ random: 'thing' }).status).toBe(500);
+    });
+  });
+});


### PR DESCRIPTION
The /token catch block used to flatten every Entra response to HTTP 500 with "Internal server error during token exchange", so OAuth clients could not see invalid_grant / AADSTS70043 from a Conditional Access sign-in frequency lapse and never restarted with prompt=login.

Parse the upstream OAuth error body and re-emit it as a spec-compliant 400 with error / error_description / suberror per RFC 6749 §5.2. Non-OAuth-shaped errors still fall through to the generic 500.