### PR TITLE
ci: use Node 24 on release runner to fix broken npm self-upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
-      - run: npm install -g npm@latest
       - run: npm i -D patch-package
       - run: npm ci
       - run: npm run generate


### PR DESCRIPTION
Node 22 ships with npm 10.9.7, and `npm install -g npm@latest` was crashing mid-upgrade (MODULE_NOT_FOUND: promise-retry), blocking every release since #487. Node 24 ships with npm 11.5.x already, so the explicit upgrade step is no longer needed for OIDC trusted publishing.