### PR TITLE
fix(release): use canonical Softeria casing in repository.url - ffs

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/softeria/ms-365-mcp-server.git"
+    "url": "https://github.com/Softeria/ms-365-mcp-server.git"
   }
 }


### PR DESCRIPTION
Sigstore provenance signed during OIDC publishing carries the GitHub repo claim with its canonical casing ("Softeria"), and npm rejects the package if package.json's repository.url differs. The mismatched lowercase URL was blocking the 0.112.0 publish.