### PR TITLE
fix: log unhandled rejections and stdio transport errors (#486)

### DIFF
--- a/src/crash-logging.ts
+++ b/src/crash-logging.ts
@@ -1,0 +1,54 @@
+/**
+ * Helpers for diagnosing silent stdio crashes. The goal is one log dump per
+ * crash that is actually useful: real cause chain, all own properties, and a
+ * snapshot of what was keeping the event loop alive.
+ */
+
+type ErrorDump = {
+  name?: string;
+  constructor?: string;
+  message?: string;
+  stack?: string;
+  cause?: unknown;
+  properties?: Record<string, unknown>;
+};
+
+export function dumpError(reason: unknown, depth = 0): unknown {
+  if (depth > 5) {
+    return { truncated: true };
+  }
+  if (reason instanceof Error) {
+    const dump: ErrorDump = {
+      name: reason.name,
+      constructor: reason.constructor?.name,
+      message: reason.message,
+      stack: reason.stack,
+    };
+    const properties: Record<string, unknown> = {};
+    for (const key of Object.getOwnPropertyNames(reason)) {
+      if (key === 'name' || key === 'message' || key === 'stack' || key === 'cause') continue;
+      properties[key] = (reason as unknown as Record<string, unknown>)[key];
+    }
+    if (Object.keys(properties).length > 0) {
+      dump.properties = properties;
+    }
+    if ('cause' in reason && reason.cause !== undefined) {
+      dump.cause = dumpError(reason.cause, depth + 1);
+    }
+    return dump;
+  }
+  return { type: typeof reason, value: reason };
+}
+
+export function getActiveResources(): string[] | string {
+  const fn = (process as unknown as { getActiveResourcesInfo?: () => string[] })
+    .getActiveResourcesInfo;
+  if (typeof fn !== 'function') {
+    return 'unavailable (node < 17.3)';
+  }
+  try {
+    return fn.call(process);
+  } catch (err) {
+    return `error: ${(err as Error).message}`;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,32 @@ import {
   shouldUseLocalAuthStorage,
 } from './startup-pinning.js';
 import { createTokenCacheStorage } from './token-cache-storage.js';
+import { dumpError, getActiveResources } from './crash-logging.js';
 import { version } from './version.js';
+
+// Global crash handlers. Without these, an unhandled rejection from a dependency
+// (MSAL HTTP, keytar native, fetch in node) kills the stdio process silently
+// before winston can flush. Log to stderr synchronously so the dump survives.
+process.on('unhandledRejection', (reason) => {
+  const dump = {
+    kind: 'unhandledRejection',
+    reason: dumpError(reason),
+    activeResources: getActiveResources(),
+  };
+  console.error('[ms365-mcp] unhandledRejection', JSON.stringify(dump));
+  logger.error('unhandledRejection', dump);
+});
+
+process.on('uncaughtException', (err, origin) => {
+  const dump = {
+    kind: 'uncaughtException',
+    origin,
+    error: dumpError(err),
+    activeResources: getActiveResources(),
+  };
+  console.error('[ms365-mcp] uncaughtException', JSON.stringify(dump));
+  logger.error('uncaughtException', dump);
+});
 
 async function main(): Promise<void> {
   try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,6 +26,7 @@ import type { CommandOptions } from './cli.ts';
 import { getSecrets, type AppSecrets } from './secrets.js';
 import { getCloudEndpoints } from './cloud-config.js';
 import { requestContext } from './request-context.js';
+import { dumpError } from './crash-logging.js';
 import crypto from 'node:crypto';
 import OboClient from './obo-client.js';
 
@@ -727,6 +728,9 @@ class MicrosoftGraphServer {
       }
     } else {
       const transport = new StdioServerTransport();
+      transport.onerror = (error) => {
+        logger.error('Stdio transport error', { error: dumpError(error) });
+      };
       await this.server!.connect(transport);
       logger.info('Server connected to stdio transport');
     }


### PR DESCRIPTION
Adds process-level unhandledRejection/uncaughtException handlers and wires StdioServerTransport.onerror to the logger so silent stdio crashes leave a diagnostic dump (recursive cause walk, own properties, active event-loop resources) on stderr before the process exits.

Note for #486 reporter: the proposed root cause (MSAL background token refresh during idle) is not accurate. @azure/msal-node has no background refresh timer; tokens are only refreshed on-demand via acquireTokenSilent from MCP tool calls. The silent-death symptom is real, but the trigger is elsewhere. These handlers give us the first actual stack trace next time it happens.