### PR TITLE
fix(docker): bump release stage to node:24-alpine so npm ci succeeds (#483)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 RUN npm run generate
 RUN npm run build
 
-FROM node:20-alpine AS release
+FROM node:24-alpine AS release
 
 WORKDIR /app
 


### PR DESCRIPTION
## Problem

The Docker image has not built since `v0.108.0`. The release stage fails:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and package-lock.json ... are in sync.
npm error Missing: yaml@2.9.0 from lock file   (x3)
```

This breaks any downstream consumer that builds the container on tag-push.

## Root cause

The committed `package-lock.json` is regenerated on **npm 11**, which produces a tree shape that **npm 10's** strict `npm ci` rejects but npm 11 accepts.

- The **builder** stage already runs `node:24-alpine` (npm 11) — fine.
- The **release** stage is still `node:20-alpine` (npm 10), and its `npm ci --ignore-scripts --omit=dev` is the only clean install against the committed lock — so it's the only place that fails.
- CI never catches it: `build.yml`/`release.yml` run `npm i -D patch-package` **before** `npm ci`, silently regenerating the lock on the runner's npm first.

This looks like the release stage was simply missed when the builder was bumped to `node:24`.

## Fix

```diff
-FROM node:20-alpine AS release
+FROM node:24-alpine AS release
```

One line. Aligns the release stage's npm with the one that generates the lock, so the build stops failing and stays robust against future dependabot lock regenerations (this is why the manual re-add in #484 was undone by the very next regen, #488). It also moves the shipped runtime off **Node 20, which reached end-of-security-support on 2026-04-30**, onto Active LTS — strictly better for a production image.

## Verification

Full `podman build` of this branch succeeds end-to-end (builder + release), and the image runs:

```
[2/2] STEP 6/7: RUN npm ci --ignore-scripts --omit=dev
added 207 packages, and audited 208 packages in 2s
Successfully tagged ms365-fix-test:local

$ podman run --rm ms365-fix-test:local --help   # exit 0
Usage: ms-365-mcp-server [options] ...
$ podman run --rm --entrypoint node ms365-fix-test:local -v
v24.16.0
```

## Note (separate, not addressed here)

npm 11 doesn't actually install `yaml@2.9.0` for the dev tools — it dedupes them to the hoisted `yaml@1.10.3` and flags it **invalid** against `^2.4.2` (`tsup`/`vite`/`vite-node`/`postcss-load-config`). So there's a latent `yaml` 1.x-vs-2.x conflict in the dev tree. It's **harmless to the published image** (release stage is `--omit=dev`), but worth resolving separately.

If you'd like belt-and-suspenders against this class of drift, I'm happy to add a small CI job that runs `npm ci --omit=dev` (or builds the image) against the committed lock — it would have caught #488 before tagging.

Closes #483.
