### PR TITLE
feat: add Planner task chat message tools

### DIFF
--- a/bin/modules/simplified-openapi.mjs
+++ b/bin/modules/simplified-openapi.mjs
@@ -145,6 +145,10 @@ export function createAndSaveSimplifiedOpenAPI(
     }
   }
 
+  if (apiVersion === 'beta') {
+    normalizeWildcardSuccessResponses(openApiSpec.paths);
+  }
+
   if (openApiSpec.components && openApiSpec.components.schemas) {
     removeODataTypeRecursively(openApiSpec.components.schemas);
     flattenComplexSchemasRecursively(openApiSpec.components.schemas);
@@ -160,6 +164,29 @@ export function createAndSaveSimplifiedOpenAPI(
   pruneUnusedSchemas(openApiSpec, usedSchemas);
 
   fs.writeFileSync(openapiTrimmedFile, yaml.dump(openApiSpec));
+}
+
+function normalizeWildcardSuccessResponses(paths) {
+  Object.values(paths || {}).forEach((pathItem) => {
+    if (!pathItem || typeof pathItem !== 'object') return;
+
+    Object.entries(pathItem).forEach(([method, operation]) => {
+      if (!operation || typeof operation !== 'object') return;
+      if (!operation.responses || !operation.responses['2XX']) return;
+
+      const hasConcreteSuccess = Object.keys(operation.responses).some((statusCode) =>
+        /^2\d\d$/.test(statusCode)
+      );
+      if (hasConcreteSuccess) {
+        delete operation.responses['2XX'];
+        return;
+      }
+
+      const successStatus = method === 'post' ? '201' : method === 'delete' ? '204' : '200';
+      operation.responses[successStatus] = operation.responses['2XX'];
+      delete operation.responses['2XX'];
+    });
+  });
 }
 
 function removeODataTypeRecursively(obj) {

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1168,6 +1168,30 @@
     "llmTip": "CRITICAL: Requires If-Match header with ETag from get-planner-bucket (use includeHeaders=true)."
   },
   {
+    "pathPattern": "/planner/tasks/{plannerTask-id}/messages",
+    "method": "get",
+    "toolName": "list-planner-task-messages",
+    "scopes": ["Tasks.Read"],
+    "apiVersion": "beta",
+    "llmTip": "Lists messages in a Planner task's chat — the modern Planner 'task chat', distinct from the legacy conversationThreadId comments (which live in the M365 group conversation thread). Each message has id, content (HTML), createdBy, createdDateTime, mentions, reactions. BETA Graph API: subject to change; delegated work/school accounts only — no application permissions, no personal Microsoft accounts, global cloud only (not GCC/DoD/21Vianet)."
+  },
+  {
+    "pathPattern": "/planner/tasks/{plannerTask-id}/messages",
+    "method": "post",
+    "toolName": "create-planner-task-message",
+    "scopes": ["Tasks.ReadWrite"],
+    "apiVersion": "beta",
+    "llmTip": "Posts a message to a Planner task's chat (the modern 'task chat', not the legacy conversationThreadId comment). Microsoft is retiring the classic task comments experience and hiding it from the task (Planner 2026 update), so task chat is the current supported way to post per-task updates teammates will see, with @mentions. Body: { content: 'plain text or sanitized HTML', mentions?: [{ mentioned: 'user-id', position: 0, mentionType: 'user' }] } (mentions optional). No ETag/If-Match required. BETA Graph API: subject to change; delegated work/school accounts only — no application permissions, no personal Microsoft accounts, global cloud only (not GCC/DoD/21Vianet)."
+  },
+  {
+    "pathPattern": "/planner/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}",
+    "method": "delete",
+    "toolName": "delete-planner-task-message",
+    "scopes": ["Tasks.ReadWrite"],
+    "apiVersion": "beta",
+    "llmTip": "Deletes a message from a Planner task's chat. No request body; If-Match is optional if you want conditional deletion; returns 204. BETA Graph API: subject to change; delegated work/school accounts only — no application permissions, no personal Microsoft accounts, global cloud only (not GCC/DoD/21Vianet)."
+  },
+  {
     "pathPattern": "/me/contacts",
     "method": "get",
     "toolName": "list-outlook-contacts",

--- a/src/generated/client-beta.ts
+++ b/src/generated/client-beta.ts
@@ -1302,6 +1302,107 @@ const microsoft_graph_ODataErrors_MainError = z
 const microsoft_graph_ODataErrors_ODataError = z
   .object({ error: microsoft_graph_ODataErrors_MainError })
   .passthrough();
+const microsoft_graph_plannerTaskChatMentionType = z.enum([
+  'user',
+  'application',
+  'unknownFutureValue',
+]);
+const microsoft_graph_plannerTaskChatMention = z
+  .object({
+    mentioned: z.string().describe('The ID of the mentioned user.').nullish(),
+    mentionType: microsoft_graph_plannerTaskChatMentionType.optional(),
+    position: z
+      .number()
+      .gte(-2147483648)
+      .lte(2147483647)
+      .describe('The zero-based position of the mention in the message content.')
+      .optional(),
+  })
+  .passthrough();
+const microsoft_graph_plannerTaskChatMessageType = z.enum([
+  'richTextHtml',
+  'plainText',
+  'unknownFutureValue',
+]);
+const microsoft_graph_plannerTaskChatReactionEvent = z
+  .object({
+    createdBy: microsoft_graph_identitySet.optional(),
+    createdDateTime: z
+      .string()
+      .regex(
+        /^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$/
+      )
+      .datetime({ offset: true })
+      .describe(
+        'The date and time when the reaction was added. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+      )
+      .optional(),
+  })
+  .passthrough();
+const microsoft_graph_plannerTaskChatReaction = z
+  .object({
+    reactionEvents: z.array(microsoft_graph_plannerTaskChatReactionEvent).optional(),
+    reactionType: z
+      .string()
+      .describe('The type of reaction, such as like, heart, or emoji characters.')
+      .nullish(),
+  })
+  .passthrough();
+const microsoft_graph_plannerTaskChatMessage = z
+  .object({
+    id: z.string().describe('The unique identifier for an entity. Read-only.').optional(),
+    content: z
+      .string()
+      .describe('The content of the chat message. Supports plain text and sanitized HTML.')
+      .nullish(),
+    createdBy: microsoft_graph_identitySet.optional(),
+    createdDateTime: z
+      .string()
+      .regex(
+        /^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$/
+      )
+      .datetime({ offset: true })
+      .describe(
+        'The date and time when the message was created. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+      )
+      .optional(),
+    deletedDateTime: z
+      .string()
+      .regex(
+        /^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$/
+      )
+      .datetime({ offset: true })
+      .nullish(),
+    editedDateTime: z
+      .string()
+      .regex(
+        /^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$/
+      )
+      .datetime({ offset: true })
+      .nullish(),
+    mentions: z
+      .array(microsoft_graph_plannerTaskChatMention)
+      .describe('The list of mentions in the message.')
+      .optional(),
+    messageType: microsoft_graph_plannerTaskChatMessageType.optional(),
+    parentEntityId: z
+      .string()
+      .describe('The ID of the parent plannerTask that this message belongs to.')
+      .nullish(),
+    reactions: z
+      .array(microsoft_graph_plannerTaskChatReaction)
+      .describe('The reactions on the message.')
+      .optional(),
+  })
+  .passthrough();
+const microsoft_graph_plannerTaskChatMessageCollectionResponse = z
+  .object({
+    '@odata.count': z.number().int().nullable(),
+    '@odata.nextLink': z.string().nullable(),
+    value: z.array(microsoft_graph_plannerTaskChatMessage),
+  })
+  .partial()
+  .passthrough();
 
 export const schemas = {
   microsoft_graph_allowedAudiences,
@@ -1355,6 +1456,13 @@ export const schemas = {
   microsoft_graph_ODataErrors_InnerError,
   microsoft_graph_ODataErrors_MainError,
   microsoft_graph_ODataErrors_ODataError,
+  microsoft_graph_plannerTaskChatMentionType,
+  microsoft_graph_plannerTaskChatMention,
+  microsoft_graph_plannerTaskChatMessageType,
+  microsoft_graph_plannerTaskChatReactionEvent,
+  microsoft_graph_plannerTaskChatReaction,
+  microsoft_graph_plannerTaskChatMessage,
+  microsoft_graph_plannerTaskChatMessageCollectionResponse,
 };
 
 const endpoints = makeApi([
@@ -1374,6 +1482,87 @@ const endpoints = makeApi([
         name: '$expand',
         type: 'Query',
         schema: z.array(z.string()).describe('Expand related entities').optional(),
+      },
+    ],
+    response: microsoft_graph_profile,
+  },
+  {
+    method: 'get',
+    path: '/planner/tasks/:plannerTaskId/messages',
+    alias: 'list-planner-task-messages',
+    description: `Retrieve a list of plannerTaskChatMessage objects associated with a plannerTask.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: '$top',
+        type: 'Query',
+        schema: z.number().int().gte(0).describe('Show only the first n items').optional(),
+      },
+      {
+        name: '$skip',
+        type: 'Query',
+        schema: z.number().int().gte(0).describe('Skip the first n items').optional(),
+      },
+      {
+        name: '$search',
+        type: 'Query',
+        schema: z.string().describe('Search items by search phrases').optional(),
+      },
+      {
+        name: '$filter',
+        type: 'Query',
+        schema: z.string().describe('Filter items by property values').optional(),
+      },
+      {
+        name: '$count',
+        type: 'Query',
+        schema: z.boolean().describe('Include count of items').optional(),
+      },
+      {
+        name: '$orderby',
+        type: 'Query',
+        schema: z.array(z.string()).describe('Order items by property values').optional(),
+      },
+      {
+        name: '$select',
+        type: 'Query',
+        schema: z.array(z.string()).describe('Select properties to be returned').optional(),
+      },
+      {
+        name: '$expand',
+        type: 'Query',
+        schema: z.array(z.string()).describe('Expand related entities').optional(),
+      },
+    ],
+    response: microsoft_graph_plannerTaskChatMessageCollectionResponse,
+  },
+  {
+    method: 'post',
+    path: '/planner/tasks/:plannerTaskId/messages',
+    alias: 'create-planner-task-message',
+    description: `Create a new plannerTaskChatMessage on a plannerTask.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'body',
+        description: `New navigation property`,
+        type: 'Body',
+        schema: microsoft_graph_plannerTaskChatMessage,
+      },
+    ],
+    response: microsoft_graph_plannerTaskChatMessage,
+  },
+  {
+    method: 'delete',
+    path: '/planner/tasks/:plannerTaskId/messages/:plannerTaskChatMessageId',
+    alias: 'delete-planner-task-message',
+    description: `Delete a plannerTaskChatMessage object.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'If-Match',
+        type: 'Header',
+        schema: z.string().describe('ETag').optional(),
       },
     ],
     response: z.void(),

--- a/test/endpoints-validation.test.ts
+++ b/test/endpoints-validation.test.ts
@@ -110,4 +110,17 @@ describe('endpoints.json validation', () => {
       );
     }
   });
+
+  it('should generate non-void response schemas for Planner task chat read/create tools', () => {
+    const plannerChatTools = ['list-planner-task-messages', 'create-planner-task-message'];
+
+    for (const toolName of plannerChatTools) {
+      const endpoint = betaApi.endpoints.find((e) => e.alias === toolName);
+      expect(endpoint, `${toolName} should exist in the beta generated client`).toBeDefined();
+      expect(
+        endpoint?.response.safeParse(undefined).success,
+        `${toolName} should parse the Graph response body instead of z.void()`
+      ).toBe(false);
+    }
+  });
 });


### PR DESCRIPTION
## Why this matters now

Microsoft is retiring the classic Planner task "comments" experience and replacing it with task chat as part of the early-2026 Planner update (Message Center post MC1193421). The old comments UI is being hidden from the task details pane, while task chat becomes the supported in-task collaboration surface.

For an MCP client that needs to post per-task updates teammates will actually see, Planner task chat is the current surface. Today this server can only reach the legacy `plannerTask.conversationThreadId` comments indirectly through generic group-thread tools, and it has no task-chat tools.

## What this adds

Adds three Planner task chat tools backed by the Graph beta Planner messages API:

| Tool | Method + path | Scope |
| --- | --- | --- |
| `list-planner-task-messages` | `GET /planner/tasks/{id}/messages` | `Tasks.Read` |
| `create-planner-task-message` | `POST /planner/tasks/{id}/messages` | `Tasks.ReadWrite` |
| `delete-planner-task-message` | `DELETE /planner/tasks/{id}/messages/{messageId}` | `Tasks.ReadWrite` |

The implementation now builds on the generator beta support merged upstream, rather than carrying the older per-endpoint beta-routing implementation from the original PR.

## Generator note

While rebasing onto the new beta generator path, the generated beta client was still emitting `z.void()` for these successful Planner message responses because the beta OpenAPI metadata uses wildcard `2XX` response codes. This PR normalizes wildcard success responses in the simplified OpenAPI output so `openapi-zod-client` generates usable response schemas for the selected beta endpoints.

## Beta caveats

The tool tips call out the Graph beta constraints:

- beta APIs are subject to change
- delegated work/school accounts only
- global cloud only

## Tests

- `test/endpoints-validation.test.ts` confirms the Planner task chat tools are generated and that list/create have non-void beta response schemas.
- Full `npm run verify` passes: generate, lint, format check, build, and tests.