### PR TITLE
feat: add get-download-url tool for drive downloads

### DIFF
--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -128,6 +128,11 @@ function createMockServer() {
   };
 }
 
+function makeJwt(payload: Record<string, unknown>): string {
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `header.${body}.signature`;
+}
+
 // ========== TESTS ==========
 
 describe('graph-tools', () => {
@@ -861,6 +866,422 @@ describe('graph-tools', () => {
     });
   });
 
+  // ---- 9b. get-download-url utility tool ----
+  describe('get-download-url', () => {
+    it('strips /content, fetches item metadata, and returns the pre-authed downloadUrl', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const downloadUrl = 'https://contoso.sharepoint.com/download.aspx?tempauth=abc';
+      const graphClient = {
+        graphRequest: vi.fn().mockResolvedValue({
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                id: 'item1',
+                name: 'report.pdf',
+                size: 12727,
+                file: { mimeType: 'application/pdf' },
+                '@microsoft.graph.downloadUrl': downloadUrl,
+              }),
+            },
+          ],
+        }),
+      };
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('get-download-url');
+      expect(tool).toBeDefined();
+
+      const result = await tool!.handler({
+        target: '/drives/d1/items/item1/content',
+      });
+
+      // /content is stripped before fetching the item metadata.
+      const [requestedPath] = graphClient.graphRequest.mock.calls[0];
+      expect(requestedPath).toBe('/drives/d1/items/item1');
+
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.downloadUrl).toBe(downloadUrl);
+      expect(payload.name).toBe('report.pdf');
+      expect(payload.size).toBe(12727);
+      expect(payload.contentType).toBe('application/pdf');
+    });
+
+    it('rejects query-shaped targets instead of silently changing request semantics', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = { graphRequest: vi.fn() };
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('get-download-url');
+      const result = await tool!.handler({
+        target: '/drives/d1/items/item1/content?$select=id,name',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(graphClient.graphRequest).not.toHaveBeenCalled();
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toContain('must not include query parameters');
+    });
+
+    it('rejects non-drive Graph targets before making an authenticated request', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = { graphRequest: vi.fn() };
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('get-download-url');
+      const result = await tool!.handler({
+        target: '/me/messages/m1',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(graphClient.graphRequest).not.toHaveBeenCalled();
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toContain('target must identify a driveItem');
+    });
+
+    it('rejects mail attachment $value paths (no pre-authed URL exists)', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = { graphRequest: vi.fn() };
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('get-download-url');
+      const result = await tool!.handler({
+        target: '/me/messages/m1/attachments/a1/$value',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(graphClient.graphRequest).not.toHaveBeenCalled();
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toMatch(/do not expose a pre-authenticated download URL/);
+    });
+
+    it('rejects calendar event attachment $value paths (no pre-authed URL exists)', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = { graphRequest: vi.fn() };
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('get-download-url');
+      const result = await tool!.handler({
+        target: '/me/events/e1/attachments/a1/$value',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(graphClient.graphRequest).not.toHaveBeenCalled();
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toMatch(/Mail and calendar event attachments/);
+    });
+
+    it('rejects group mailbox attachment paths (no pre-authed URL exists)', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = { graphRequest: vi.fn() };
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('get-download-url');
+      const result = await tool!.handler({
+        target: '/groups/g1/messages/m1/attachments/a1/$value',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(graphClient.graphRequest).not.toHaveBeenCalled();
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toMatch(/Mail and calendar event attachments/);
+    });
+
+    it('rejects list-item driveItem relationships until callers provide a drive item path', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = { graphRequest: vi.fn() };
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('get-download-url');
+      const result = await tool!.handler({
+        target: '/sites/site1/lists/list1/items/item1/driveItem',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(graphClient.graphRequest).not.toHaveBeenCalled();
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toContain('target must identify a driveItem');
+    });
+
+    it('errors when the resource exposes no downloadUrl', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = {
+        graphRequest: vi.fn().mockResolvedValue({
+          content: [{ type: 'text', text: JSON.stringify({ id: 'item1', name: 'x' }) }],
+        }),
+      };
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('get-download-url');
+      const result = await tool!.handler({ target: '/drives/d1/items/item1' });
+
+      expect(result.isError).toBe(true);
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toMatch(/No pre-authenticated download URL/);
+    });
+
+    it('surfaces the underlying Graph error instead of masking it as no-downloadUrl', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      // graphRequest catches Graph HTTP errors internally and returns { isError: true }.
+      const graphClient = {
+        graphRequest: vi.fn().mockResolvedValue({
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ error: 'Microsoft Graph API error: 403 Forbidden' }),
+            },
+          ],
+        }),
+      };
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('get-download-url');
+      const result = await tool!.handler({ target: '/drives/d1/items/item1/content' });
+
+      expect(result.isError).toBe(true);
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toMatch(/403 Forbidden/);
+      expect(payload.error).not.toMatch(/No pre-authenticated download URL/);
+    });
+
+    it('does not falsely reject drive folders literally named "attachments"', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const downloadUrl = 'https://contoso.sharepoint.com/download.aspx?tempauth=xyz';
+      const graphClient = {
+        graphRequest: vi.fn().mockResolvedValue({
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                name: 'report.pdf',
+                '@microsoft.graph.downloadUrl': downloadUrl,
+              }),
+            },
+          ],
+        }),
+      };
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('get-download-url');
+      const result = await tool!.handler({
+        target: '/me/drive/root:/Project/attachments/report.pdf:/content',
+      });
+
+      expect(result.isError).toBeFalsy();
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.downloadUrl).toBe(downloadUrl);
+    });
+
+    it('does not falsely reject drive item paths containing messages and attachments folders', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const downloadUrl = 'https://contoso.sharepoint.com/download.aspx?tempauth=folders';
+      const graphClient = {
+        graphRequest: vi.fn().mockResolvedValue({
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                name: 'report.pdf',
+                '@microsoft.graph.downloadUrl': downloadUrl,
+              }),
+            },
+          ],
+        }),
+      };
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('get-download-url');
+      const result = await tool!.handler({
+        target: '/me/drive/root:/messages/m1/attachments/a1/report.pdf:/content',
+      });
+
+      expect(result.isError).toBeFalsy();
+      const [requestedPath] = graphClient.graphRequest.mock.calls[0];
+      expect(requestedPath).toBe('/me/drive/root:/messages/m1/attachments/a1/report.pdf:');
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.downloadUrl).toBe(downloadUrl);
+    });
+
+    it('allows SharePoint site drive item paths', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const downloadUrl = 'https://contoso.sharepoint.com/download.aspx?tempauth=site-drive';
+      const graphClient = {
+        graphRequest: vi.fn().mockResolvedValue({
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                name: 'site-report.pdf',
+                '@microsoft.graph.downloadUrl': downloadUrl,
+              }),
+            },
+          ],
+        }),
+      };
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('get-download-url');
+      const result = await tool!.handler({
+        target: '/sites/site1/drive/items/item1/content',
+      });
+
+      expect(result.isError).toBeFalsy();
+      const [requestedPath] = graphClient.graphRequest.mock.calls[0];
+      expect(requestedPath).toBe('/sites/site1/drive/items/item1');
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.downloadUrl).toBe(downloadUrl);
+    });
+
+    it('does not strip a drive item path whose item name is content', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const downloadUrl = 'https://contoso.sharepoint.com/download.aspx?tempauth=content-file';
+      const graphClient = {
+        graphRequest: vi.fn().mockResolvedValue({
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                name: 'content',
+                '@microsoft.graph.downloadUrl': downloadUrl,
+              }),
+            },
+          ],
+        }),
+      };
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('get-download-url');
+      const result = await tool!.handler({
+        target: '/me/drive/root:/Project/content:',
+      });
+
+      expect(result.isError).toBeFalsy();
+      const [requestedPath] = graphClient.graphRequest.mock.calls[0];
+      expect(requestedPath).toBe('/me/drive/root:/Project/content:');
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.downloadUrl).toBe(downloadUrl);
+    });
+
+    it('rejects meeting recording content paths because Graph returns authenticated bytes', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = { graphRequest: vi.fn() };
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('get-download-url');
+      const result = await tool!.handler({
+        target: '/me/onlineMeetings/meeting1/recordings/recording1/content',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(graphClient.graphRequest).not.toHaveBeenCalled();
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toMatch(/Meeting recordings do not expose/);
+    });
+
+    it('refuses mismatched account param in bearer mode before resolving download URL', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = { graphRequest: vi.fn() };
+      const authManager = {
+        isOAuthModeEnabled: vi.fn().mockReturnValue(false),
+        getToken: vi.fn().mockResolvedValue(null),
+        getTokenForAccount: vi.fn(),
+      };
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(
+        server as any,
+        graphClient as any,
+        false,
+        undefined,
+        false,
+        authManager as any,
+        true,
+        ['user1@domain.com', 'user2@domain.com']
+      );
+      const { requestContext } = await import('../request-context.js');
+
+      const tool = server.tools.get('get-download-url');
+      const bearer = makeJwt({ upn: 'user1@domain.com' });
+      const result = await requestContext.run({ accessToken: bearer }, () =>
+        tool!.handler({
+          target: '/drives/d1/items/item1/content',
+          account: 'user2@domain.com',
+        })
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("'account' parameter is not supported");
+      expect(graphClient.graphRequest).not.toHaveBeenCalled();
+      expect(authManager.getTokenForAccount).not.toHaveBeenCalled();
+    });
+  });
+
   // ---- 10. Utility tools surface in --discovery mode ----
   describe('allowed scopes filtering', () => {
     it('registerGraphTools hides Graph tools outside the allowed scopes', async () => {
@@ -999,6 +1420,9 @@ describe('graph-tools', () => {
       const targetParam = schema.parameters.find((p: any) => p.name === 'target');
       expect(targetParam).toBeDefined();
       expect(targetParam.required).toBe(true);
+      expect(targetParam.description).toContain('authenticated recording bytes');
+      expect(targetParam.description).not.toContain('returns a URL');
+      expect(schema.description).toContain('For large drive/SharePoint file content');
     });
 
     it('execute-tool dispatches to download-bytes for a Graph path', async () => {

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -594,7 +594,7 @@
     "toolName": "get-drive-item",
     "presets": ["files", "onedrive", "personal"],
     "scopes": ["Files.Read"],
-    "llmTip": "Gets metadata for a file or folder: name, size, lastModifiedDateTime, createdBy, webUrl, file (mimeType, hashes), folder (childCount), parentReference, and @microsoft.graph.downloadUrl. For the bytes, call download-bytes with target=/drives/{drive-id}/items/{driveItem-id}/content (Graph redirects to the same downloadUrl)."
+    "llmTip": "Gets metadata for a file or folder: name, size, lastModifiedDateTime, createdBy, webUrl, file (mimeType, hashes), folder (childCount), parentReference, and @microsoft.graph.downloadUrl. For large drive/SharePoint files, call get-download-url with target=/drives/{drive-id}/items/{driveItem-id}/content to fetch out-of-band with no Authorization header. For small files where base64 in the tool response is acceptable, call download-bytes with the same /content target."
   },
   {
     "pathPattern": "/drives/{drive-id}/items/{driveItem-id}",
@@ -1904,8 +1904,7 @@
     "toolName": "get-meeting-recording-content",
     "presets": ["teams", "work"],
     "workScopes": ["OnlineMeetingRecording.Read.All"],
-    "returnDownloadUrl": true,
-    "llmTip": "Returns a temporary download URL for the meeting recording in MP4 format. Use the download URL to access the video file. The recording may be large — do not attempt to stream it inline."
+    "llmTip": "Returns the authenticated meeting recording video bytes in MP4 format. The recording may be large; prefer out-of-band handling by the client when possible, but Microsoft Graph does not expose a pre-authenticated download URL for this resource."
   },
   {
     "pathPattern": "/me/onlineMeetings/{onlineMeeting-id}/attendanceReports",

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -196,6 +196,7 @@ interface UtilityTool {
   method: string;
   path: string;
   description: string;
+  searchKeywords?: string;
   buildSchema: (ctx: UtilityToolContext) => Record<string, z.ZodTypeAny>;
   execute: (params: Record<string, unknown>, ctx: UtilityToolContext) => Promise<CallToolResult>;
   readOnlyHint?: boolean;
@@ -281,7 +282,7 @@ export const UTILITY_TOOLS: readonly UtilityTool[] = [
     method: 'GET',
     path: 'tool:download-bytes',
     description:
-      'Download binary content from Microsoft Graph and return it as base64. Single tool for any binary read: drive file content, mail attachment, profile photo, Teams hosted content, meeting recording. Returns { contentType, encoding: "base64", contentLength, contentBytes }.',
+      'Download binary content from Microsoft Graph and return it as base64. Single tool for any binary read: drive file content, mail attachment, profile photo, Teams hosted content, meeting recording. Returns { contentType, encoding: "base64", contentLength, contentBytes }. For large drive/SharePoint file content, prefer get-download-url, which returns a pre-authenticated URL to stream bytes out-of-band instead of base64 through the agent context.',
     readOnlyHint: true,
     openWorldHint: true,
     buildSchema: (ctx) => {
@@ -295,7 +296,7 @@ export const UTILITY_TOOLS: readonly UtilityTool[] = [
               '/me/photo/$value or /users/{user-id}/photo/$value (profile photo); ' +
               '/chats/{chat-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}/$value (Teams chat hosted content, list-chat-message-hosted-contents returns the IDs); ' +
               '/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}/$value (Teams channel hosted content). ' +
-              'For meeting recordings (often large), use get-meeting-recording-content which returns a URL for out-of-band download by the client.'
+              'For meeting recordings, use get-meeting-recording-content where available; Microsoft Graph returns authenticated recording bytes, not a pre-authenticated download URL.'
           ),
       };
       if (ctx.multiAccount) {
@@ -349,6 +350,246 @@ export const UTILITY_TOOLS: readonly UtilityTool[] = [
           accountAccessToken = await authManager.getTokenForAccount(accountParam);
         }
         return await graphClient.graphRequest(target, { accessToken: accountAccessToken });
+      } catch (error) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: (error as Error).message }) }],
+          isError: true,
+        };
+      }
+    },
+  },
+  {
+    name: 'get-download-url',
+    method: 'GET',
+    path: 'tool:get-download-url',
+    searchKeywords:
+      'download file download drive file download onedrive file sharepoint file download large drive file large sharepoint file large file out-of-band download pre-authenticated url',
+    description:
+      'Resolve a short-lived, pre-authenticated download URL for Microsoft Graph binary content that exposes one (drive/SharePoint file content). The returned URL streams the bytes with NO Authorization header, so the client can fetch it straight to disk (e.g. curl) without round-tripping base64 through the agent context. Prefer this over download-bytes for any file above a few KB or any bulk download. Returns { downloadUrl, name?, size?, contentType? }. NOTE: mail file attachments (/messages/{id}/attachments/{id}/$value) and meeting recordings do NOT expose a pre-authenticated URL — Graph offers no such link for them; use download-bytes for small ones.',
+    readOnlyHint: true,
+    openWorldHint: true,
+    buildSchema: (ctx) => {
+      const schema: Record<string, z.ZodTypeAny> = {
+        target: z
+          .string()
+          .describe(
+            'Relative Microsoft Graph path starting with "/". Either a driveItem content path or the item path itself, e.g. ' +
+              '/drives/{drive-id}/items/{driveItem-id}/content, /me/drive/items/{driveItem-id}/content, ' +
+              'or /sites/{site-id}/drive/items/{driveItem-id}. ' +
+              'A trailing /content is optional and is stripped automatically for drive items. Mail attachment $value paths and meeting recordings are not supported (Graph exposes no pre-authenticated URL for them).'
+          ),
+      };
+      if (ctx.multiAccount) {
+        schema['account'] = z
+          .string()
+          .optional()
+          .describe(
+            'Account to use when multiple Microsoft accounts are configured. Required when multiple accounts exist (see list-accounts).'
+          );
+      }
+      return schema;
+    },
+    execute: async (params, { graphClient, authManager }) => {
+      const target = params.target;
+      const accountParam = params.account as string | undefined;
+      if (typeof target !== 'string' || target.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ error: 'target is required and must be a non-empty string.' }),
+            },
+          ],
+          isError: true,
+        };
+      }
+      if (!target.startsWith('/')) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                error:
+                  'target must be a relative Microsoft Graph path starting with "/", e.g. /drives/{drive-id}/items/{driveItem-id}/content.',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+      // Normalize: separate any query string and strip trailing slashes so the /content and
+      // /$value suffix checks are robust to e.g. "/content/" or "/content?select=id".
+      const queryIdx = target.indexOf('?');
+      if (queryIdx >= 0) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                error:
+                  'target must not include query parameters. Pass the drive item /content path or item metadata path without $select, $expand, or other query options.',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+      const pathPart = target.replace(/\/+$/, '');
+      // Mail/event attachments expose no pre-authenticated download URL in Graph; bytes come
+      // only from base64 contentBytes or the authenticated /$value endpoint (use download-bytes).
+      // Match only real Graph mail/calendar attachment resources so driveItem path addressing
+      // with folders named messages/events/attachments is not falsely rejected.
+      if (
+        /^(\/me|\/users\/[^/]+)\/messages\/[^/]+\/attachments\//.test(pathPart) ||
+        /^(\/me|\/users\/[^/]+)\/events\/[^/]+\/attachments\//.test(pathPart) ||
+        /^\/groups\/[^/]+\/messages\/[^/]+\/attachments\//.test(pathPart) ||
+        /^\/groups\/[^/]+\/events\/[^/]+\/attachments\//.test(pathPart)
+      ) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                error:
+                  'Mail and calendar event attachments do not expose a pre-authenticated download URL. Use download-bytes for small attachments.',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+      // Recording content endpoints return authenticated bytes, not a pre-authenticated URL.
+      if (
+        /^(\/me|\/users\/[^/]+)\/onlineMeetings\/[^/]+\/recordings\/[^/]+(?:\/content)?$/.test(
+          pathPart
+        ) ||
+        /^\/communications\/calls\/[^/]+\/recordings\/[^/]+(?:\/content)?$/.test(pathPart)
+      ) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                error:
+                  'Meeting recordings do not expose a pre-authenticated download URL. Use download-bytes for small recordings or get-meeting-recording-content where available.',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+      // Other /$value byte endpoints (profile photo, Teams hosted content) likewise have no URL.
+      if (pathPart.endsWith('/$value')) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                error:
+                  '$value byte endpoints do not expose a pre-authenticated download URL. Use download-bytes to read these bytes.',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+      const isDriveItemById =
+        /^\/drives\/[^/]+\/items\/[^/]+(?:\/content)?$/.test(pathPart) ||
+        /^\/(?:me|users\/[^/]+|groups\/[^/]+|sites\/[^/]+)\/drive\/items\/[^/]+(?:\/content)?$/.test(
+          pathPart
+        ) ||
+        /^\/(?:groups\/[^/]+|sites\/[^/]+)\/drives\/[^/]+\/items\/[^/]+(?:\/content)?$/.test(
+          pathPart
+        );
+      const isDriveItemByPath =
+        /^\/drives\/[^/]+\/root:\/.+:(?:\/content)?$/.test(pathPart) ||
+        /^\/(?:me|users\/[^/]+|groups\/[^/]+|sites\/[^/]+)\/drive\/root:\/.+:(?:\/content)?$/.test(
+          pathPart
+        ) ||
+        /^\/(?:groups\/[^/]+|sites\/[^/]+)\/drives\/[^/]+\/root:\/.+:(?:\/content)?$/.test(
+          pathPart
+        );
+      if (!isDriveItemById && !isDriveItemByPath) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                error:
+                  'target must identify a driveItem in OneDrive or SharePoint. Use a drive item metadata path or /content path, such as /drives/{drive-id}/items/{driveItem-id}/content, /me/drive/items/{driveItem-id}, /sites/{site-id}/drive/items/{driveItem-id}, or /me/drive/root:/path/file.ext:/content. Other Graph byte resources must use download-bytes.',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+      // The downloadUrl lives on driveItem metadata, not the /content sub-resource.
+      // Only strip true Graph content endpoints: ID-addressed /items/{id}/content
+      // and path-addressed root:/path/file:/content. A drive item can itself be
+      // named "content", so a plain trailing /content is not enough.
+      const isDriveContentEndpoint =
+        /\/items\/[^/]+\/content$/.test(pathPart) || pathPart.endsWith(':/content');
+      const itemPath = isDriveContentEndpoint ? pathPart.slice(0, -'/content'.length) : pathPart;
+      try {
+        const accountModeError = await checkAccountParamInBearerMode(accountParam, authManager);
+        if (accountModeError) {
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: accountModeError }) }],
+            isError: true,
+          };
+        }
+
+        let accountAccessToken: string | undefined;
+        if (authManager && !authManager.isOAuthModeEnabled() && !getRequestTokens()) {
+          accountAccessToken = await authManager.getTokenForAccount(accountParam);
+        }
+        const response = await graphClient.graphRequest(itemPath, {
+          accessToken: accountAccessToken,
+        });
+        // graphRequest swallows Graph HTTP errors and returns { isError: true } (see
+        // graph-client.ts); surface the real error (401/403/404/429/...) instead of masking
+        // it as "no download URL available".
+        if (response?.isError) {
+          return response;
+        }
+        const text = response?.content?.[0]?.text;
+        let item: Record<string, unknown> | undefined;
+        if (typeof text === 'string') {
+          try {
+            item = JSON.parse(text);
+          } catch {
+            item = undefined;
+          }
+        }
+        const downloadUrl = item?.['@microsoft.graph.downloadUrl'] as string | undefined;
+        if (!downloadUrl) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  error:
+                    'No pre-authenticated download URL is available for this resource. It may not be a drive item, or it exposes bytes only via download-bytes.',
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
+        const file = item?.file as { mimeType?: string } | undefined;
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                downloadUrl,
+                name: item?.name,
+                size: item?.size,
+                contentType: file?.mimeType,
+              }),
+            },
+          ],
+        };
       } catch (error) {
         return {
           content: [{ type: 'text', text: JSON.stringify({ error: (error as Error).message }) }],
@@ -1208,8 +1449,20 @@ export function buildDiscoverySearchIndex(
     const nt = tokenize(utility.name);
     nameTokens.set(utility.name, new Set(nt));
     const pathTokens = tokenize(utility.path);
+    const keywordTokens = tokenize(utility.searchKeywords);
     const descTokens = tokenize(utility.description).slice(0, DESC_CAP_TOKENS);
-    const tokens = [...nt, ...nt, ...nt, ...nt, ...nt, ...pathTokens, ...pathTokens, ...descTokens];
+    const tokens = [
+      ...nt,
+      ...nt,
+      ...nt,
+      ...nt,
+      ...nt,
+      ...pathTokens,
+      ...pathTokens,
+      ...keywordTokens,
+      ...keywordTokens,
+      ...descTokens,
+    ];
     docs.push({ id: utility.name, tokens });
   }
   return { bm25: buildBM25Index(docs), nameTokens };

--- a/src/mcp-instructions.ts
+++ b/src/mcp-instructions.ts
@@ -13,7 +13,7 @@ function buildGeneralMcpInstructions(opts: McpInstructionsContext): string {
     'When you need an organizational user or recipient address, resolve it with list-users (or another directory tool); do not invent SMTP addresses.',
     'Directory $search on collections such as /users or /groups requires ConsistencyLevel: eventual when the tool exposes that header.',
     'Teams chat and channel messages: prefer HTML contentType in the body; plain text is often mangled by Graph.',
-    'Files / binary content: use download-bytes for any binary read (drive file content, mail attachments, profile photos, Teams hosted content, meeting recordings); pass it a Graph path or an absolute @microsoft.graph.downloadUrl from a metadata response. For uploads, upload-file-content takes a base64 string body up to 4MB; use create-upload-session above that.',
+    'Files / binary content: for large drive/SharePoint file content, prefer get-download-url to resolve a pre-authenticated URL for out-of-band download. Use download-bytes for authenticated byte reads such as mail attachments, profile photos, Teams hosted content, and meeting recordings. Both tools take relative Microsoft Graph paths, not absolute URLs. For uploads, upload-file-content takes a base64 string body up to 4MB; use create-upload-session above that.',
   ];
   if (opts.readOnly) parts.push('This server is read-only; write operations are disabled.');
   if (opts.multiAccount)

--- a/test/calendar-view.test.ts
+++ b/test/calendar-view.test.ts
@@ -138,8 +138,14 @@ describe('Calendar View Tools', () => {
 
       for (const call of mockServer.tool.mock.calls) {
         const toolName = call[0] as string;
-        // Skip utility tools that are not Graph API endpoints
-        if (toolName === 'parse-teams-url' || toolName === 'download-bytes') continue;
+        // Skip utilities and read-only POST query tools that are not GET Graph endpoints.
+        if (
+          toolName === 'parse-teams-url' ||
+          toolName === 'download-bytes' ||
+          toolName === 'copilot-retrieve' ||
+          toolName === 'get-download-url'
+        )
+          continue;
         const paramSchema = call[2] as Record<string, z.ZodTypeAny>;
         expect(paramSchema).toHaveProperty('fetchAllPages');
       }

--- a/test/discovery-search.test.ts
+++ b/test/discovery-search.test.ts
@@ -22,6 +22,10 @@ function topN(query: string, n: number): string[] {
     .map((r) => r.id);
 }
 
+function top1(query: string): string | undefined {
+  return topN(query, 1)[0];
+}
+
 type Case = { query: string; expect: string; inTop?: number };
 
 const cases: Case[] = [
@@ -51,6 +55,9 @@ const cases: Case[] = [
   { query: 'onedrive folder', expect: 'create-onedrive-folder', inTop: 10 },
   { query: 'upload file', expect: 'upload-file-content', inTop: 5 },
   { query: 'download file', expect: 'download-bytes', inTop: 5 },
+  { query: 'download drive file', expect: 'get-download-url', inTop: 1 },
+  { query: 'sharepoint file download', expect: 'get-download-url', inTop: 1 },
+  { query: 'large drive file', expect: 'get-download-url', inTop: 1 },
   { query: 'download bytes', expect: 'download-bytes', inTop: 5 },
   { query: 'profile photo', expect: 'download-bytes', inTop: 10 },
   { query: 'parse teams url', expect: 'parse-teams-url', inTop: 5 },
@@ -79,6 +86,12 @@ describe('discovery search (golden queries)', () => {
 
   it('returns empty for gibberish queries', () => {
     expect(scoreDiscoveryQuery('zzzqqqxxxfoobarbaz', index)).toEqual([]);
+  });
+
+  it('prefers out-of-band URLs for drive and SharePoint file download queries', () => {
+    expect(top1('download drive file')).toBe('get-download-url');
+    expect(top1('sharepoint file download')).toBe('get-download-url');
+    expect(top1('large drive file')).toBe('get-download-url');
   });
 
   it('covers at least 80% of golden queries in top 5', () => {

--- a/test/endpoints-validation.test.ts
+++ b/test/endpoints-validation.test.ts
@@ -20,6 +20,8 @@ interface Endpoint {
   method: string;
   scopes?: string[] | string[][];
   workScopes?: string[] | string[][];
+  returnDownloadUrl?: boolean;
+  llmTip?: string;
 }
 
 const endpoints: Endpoint[] = JSON.parse(
@@ -122,5 +124,23 @@ describe('endpoints.json validation', () => {
         `${toolName} should parse the Graph response body instead of z.void()`
       ).toBe(false);
     }
+  });
+
+  it('should treat meeting recording content as authenticated bytes, not a pre-authenticated URL', () => {
+    const endpoint = endpoints.find((e) => e.toolName === 'get-meeting-recording-content');
+
+    expect(endpoint, 'get-meeting-recording-content should exist').toBeDefined();
+    expect(endpoint?.returnDownloadUrl).toBeUndefined();
+    expect(endpoint?.llmTip).toContain('authenticated meeting recording video bytes');
+    expect(endpoint?.llmTip).toContain('does not expose a pre-authenticated download URL');
+  });
+
+  it('should prefer get-download-url for out-of-band drive file downloads', () => {
+    const endpoint = endpoints.find((e) => e.toolName === 'get-drive-item');
+
+    expect(endpoint, 'get-drive-item should exist').toBeDefined();
+    expect(endpoint?.llmTip).toContain('call get-download-url');
+    expect(endpoint?.llmTip).toContain('out-of-band');
+    expect(endpoint?.llmTip).toContain('call download-bytes');
   });
 });

--- a/test/mcp-instructions.test.ts
+++ b/test/mcp-instructions.test.ts
@@ -28,4 +28,15 @@ describe('buildMcpServerInstructions', () => {
     expect(s).not.toContain('Multiple accounts');
     expect(s).not.toContain('account parameter');
   });
+
+  it('routes drive file downloads to get-download-url and authenticated byte reads to download-bytes', () => {
+    const s = buildMcpServerInstructions({ ...baseCtx, discovery: false });
+    expect(s).toContain('large drive/SharePoint file content');
+    expect(s).toContain('prefer get-download-url');
+    expect(s).toContain('download-bytes for authenticated byte reads');
+    expect(s).toContain(
+      'mail attachments, profile photos, Teams hosted content, and meeting recordings'
+    );
+    expect(s).toContain('relative Microsoft Graph paths, not absolute URLs');
+  });
 });

--- a/test/read-only.test.ts
+++ b/test/read-only.test.ts
@@ -84,8 +84,8 @@ describe('Read-Only Mode', () => {
 
     registerGraphTools(mockServer, {} as GraphClient, options.readOnly);
 
-    // 1 GET endpoint + parse-teams-url + download-bytes utility tools
-    expect(mockServer.tool).toHaveBeenCalledTimes(3);
+    // 1 GET endpoint + parse-teams-url + download-bytes + get-download-url
+    expect(mockServer.tool).toHaveBeenCalledTimes(4);
 
     const toolCalls = mockServer.tool.mock.calls.map((call: unknown[]) => call[0]);
     expect(toolCalls).toContain('list-mail-messages');
@@ -101,8 +101,8 @@ describe('Read-Only Mode', () => {
 
     registerGraphTools(mockServer, {} as GraphClient, options.readOnly);
 
-    // 4 mocked endpoints (get-schedule skipped: workScopes only, no orgMode) + parse-teams-url + download-bytes
-    expect(mockServer.tool).toHaveBeenCalledTimes(6);
+    // 4 mocked endpoints (get-schedule skipped: workScopes only, no orgMode) + utilities
+    expect(mockServer.tool).toHaveBeenCalledTimes(7);
 
     const toolCalls = mockServer.tool.mock.calls.map((call: unknown[]) => call[0]);
     expect(toolCalls).toContain('list-mail-messages');
@@ -133,8 +133,8 @@ describe('Read-Only Mode', () => {
     // PATCH endpoint should still be skipped (readOnly bypass is POST-only)
     expect(toolCalls).not.toContain('update-mail-folder');
 
-    // 2 graph tools (list-mail-messages + get-schedule) + parse-teams-url + download-bytes
-    expect(mockServer.tool).toHaveBeenCalledTimes(4);
+    // 2 graph tools (list-mail-messages + get-schedule) + utilities
+    expect(mockServer.tool).toHaveBeenCalledTimes(5);
   });
 
   it('reports a readOnly POST endpoint as read-only, not destructive, in its hints', () => {

--- a/test/tool-filtering.test.ts
+++ b/test/tool-filtering.test.ts
@@ -52,8 +52,8 @@ describe('Tool Filtering', () => {
   it('should register all tools when no filter is provided', () => {
     registerGraphTools(server, graphClient, false);
 
-    // 5 mocked endpoints + parse-teams-url + download-bytes utility tools
-    expect(toolSpy).toHaveBeenCalledTimes(7);
+    // 5 mocked endpoints + parse-teams-url + download-bytes + get-download-url
+    expect(toolSpy).toHaveBeenCalledTimes(8);
     expect(toolSpy).toHaveBeenCalledWith(
       'list-mail-messages',
       expect.any(String),
@@ -134,8 +134,8 @@ describe('Tool Filtering', () => {
   it('should handle invalid regex patterns gracefully', () => {
     registerGraphTools(server, graphClient, false, '[invalid regex');
 
-    // 5 mocked endpoints + parse-teams-url + download-bytes (no filter applied on invalid regex)
-    expect(toolSpy).toHaveBeenCalledTimes(7);
+    // 5 mocked endpoints + utilities (no filter applied on invalid regex)
+    expect(toolSpy).toHaveBeenCalledTimes(8);
   });
 
   it('should combine read-only and filtering correctly', () => {


### PR DESCRIPTION
## Problem

`download-bytes` returns binary content as base64 inline in the tool response. For anything beyond small files, that is expensive and fragile: the bytes round-trip through the model or agent context and can be truncated by client output limits.

Drive and SharePoint files already expose Microsoft Graph's native short-lived `@microsoft.graph.downloadUrl`, which lets the client stream bytes directly to disk without an `Authorization` header and without base64 in the tool response.

## What this adds

Adds a read-only utility tool, `get-download-url`, that resolves `@microsoft.graph.downloadUrl` for OneDrive and SharePoint drive items.

Supported target shapes are explicit drive item metadata or content paths, for example:

- `/drives/{drive-id}/items/{driveItem-id}/content`
- `/me/drive/items/{driveItem-id}`
- `/sites/{site-id}/drive/items/{driveItem-id}`
- `/me/drive/root:/path/file.ext:/content`

The tool strips a true drive item `/content` suffix before reading item metadata, because `@microsoft.graph.downloadUrl` lives on the drive item metadata rather than the `/content` response.

## Guardrails

- Rejects query-shaped targets rather than silently changing request semantics.
- Rejects unsupported non-drive Graph paths before making an authenticated Graph request.
- Rejects mail/calendar attachment paths and other `/$value` byte endpoints with guidance to use `download-bytes`.
- Treats meeting recordings as authenticated byte reads, not pre-authenticated URL resources.
- Surfaces underlying Graph errors instead of masking them as "no download URL available."

## Notes

- Purely additive; no behavior change to existing tools.
- Read-only (`readOnlyHint: true`).
- Updates the `download-bytes` and initialization guidance so large drive/SharePoint file reads prefer `get-download-url`, while mail attachments, profile photos, Teams hosted content, and meeting recordings stay on authenticated byte reads.

## Tests

Adds coverage for successful drive/SharePoint URL resolution, `/content` normalization, query rejection, unsupported Graph path rejection, mail/calendar/group attachment rejection, meeting recording rejection, Graph error passthrough, bearer account mismatch handling, and the updated tool guidance.

Full `npm run verify` passes: generate, lint, format check, build, and tests.