### PR TITLE
feat: add copilot-retrieve semantic search tool (Copilot Retrieval API)

### DIFF
--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -1031,4 +1031,143 @@ describe('graph-tools', () => {
       expect(server.tools.has('parse-teams-url')).toBe(true);
     });
   });
+
+  // ---- copilot-retrieve utility tool (Copilot Retrieval API) ----
+  describe('copilot-retrieve', () => {
+    const retrievalResponse = {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            retrievalHits: [
+              {
+                webUrl: 'https://contoso.sharepoint.com/sites/HR/VPNAccess.docx',
+                extracts: [{ text: 'To configure the VPN...', relevanceScore: 0.83 }],
+                resourceType: 'listItem',
+                resourceMetadata: { title: 'VPN Access' },
+              },
+            ],
+          }),
+        },
+      ],
+    };
+
+    it('POSTs queryString + dataSource to /copilot/retrieval on v1.0 and returns the hits', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = { graphRequest: vi.fn().mockResolvedValue(retrievalResponse) };
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('copilot-retrieve');
+      expect(tool).toBeDefined();
+
+      const result = await tool!.handler({
+        queryString: 'How to setup corporate VPN?',
+        dataSource: 'sharePoint',
+      });
+
+      expect(graphClient.graphRequest).toHaveBeenCalledTimes(1);
+      const [endpoint, options] = graphClient.graphRequest.mock.calls[0];
+      expect(endpoint).toBe('/copilot/retrieval');
+      expect(options.method).toBe('POST');
+      // v1.0 (GA) — apiVersion left at default
+      expect(options.apiVersion === undefined || options.apiVersion === 'v1.0').toBe(true);
+      const body = JSON.parse(options.body);
+      expect(body).toEqual({
+        queryString: 'How to setup corporate VPN?',
+        dataSource: 'sharePoint',
+      });
+
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.retrievalHits[0].webUrl).toBe(
+        'https://contoso.sharepoint.com/sites/HR/VPNAccess.docx'
+      );
+    });
+
+    it('includes optional filterExpression, resourceMetadata, and maximumNumberOfResults only when provided', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = { graphRequest: vi.fn().mockResolvedValue(retrievalResponse) };
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('copilot-retrieve');
+      await tool!.handler({
+        queryString: 'corporate VPN',
+        dataSource: 'sharePoint',
+        filterExpression: 'Author:"Megan Bowen"',
+        resourceMetadata: ['title', 'author'],
+        maximumNumberOfResults: 5,
+      });
+
+      const [, options] = graphClient.graphRequest.mock.calls[0];
+      const body = JSON.parse(options.body);
+      expect(body.filterExpression).toBe('Author:"Megan Bowen"');
+      expect(body.resourceMetadata).toEqual(['title', 'author']);
+      expect(body.maximumNumberOfResults).toBe(5);
+    });
+
+    it('requires a non-empty queryString', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = { graphRequest: vi.fn() };
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('copilot-retrieve');
+      const result = await tool!.handler({ queryString: '   ', dataSource: 'sharePoint' });
+
+      expect(result.isError).toBe(true);
+      expect(graphClient.graphRequest).not.toHaveBeenCalled();
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toMatch(/queryString/);
+    });
+
+    it('rejects an invalid dataSource', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = { graphRequest: vi.fn() };
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('copilot-retrieve');
+      const result = await tool!.handler({ queryString: 'vpn', dataSource: 'mailbox' });
+
+      expect(result.isError).toBe(true);
+      expect(graphClient.graphRequest).not.toHaveBeenCalled();
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toMatch(/dataSource/);
+    });
+
+    it('rejects maximumNumberOfResults outside the 1-25 range', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = { graphRequest: vi.fn() };
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('copilot-retrieve');
+      const result = await tool!.handler({
+        queryString: 'vpn',
+        dataSource: 'sharePoint',
+        maximumNumberOfResults: 50,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(graphClient.graphRequest).not.toHaveBeenCalled();
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toMatch(/maximumNumberOfResults/);
+    });
+  });
 });

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -262,6 +262,123 @@ export const UTILITY_TOOLS: readonly UtilityTool[] = [
       }
     },
   },
+  {
+    name: 'copilot-retrieve',
+    method: 'POST',
+    path: 'tool:copilot-retrieve',
+    description:
+      'Semantic search over Microsoft 365 content via the Copilot Retrieval API (POST /copilot/retrieval). Grounds a natural-language query against the same hybrid index that powers Microsoft 365 Copilot and returns relevant, permission-trimmed text extracts with their source URLs — unlike search-query/search-onedrive-files/search-sharepoint-sites, which are lexical KQL. Prefer this for paraphrase/intent queries (e.g. resolving an informal project nickname, or matching "packaging requirements" against text that never uses that phrase). Returns { retrievalHits: [{ webUrl, extracts: [{ text, relevanceScore }], resourceType, resourceMetadata, sensitivityLabel? }] }. Read-only. Requires delegated Files.Read.All + Sites.Read.All (SharePoint/OneDrive) or ExternalItem.Read.All (Copilot connectors); application-only auth is not supported.',
+    readOnlyHint: true,
+    openWorldHint: true,
+    buildSchema: (ctx) => {
+      const schema: Record<string, z.ZodTypeAny> = {
+        queryString: z
+          .string()
+          .min(1)
+          .max(1500)
+          .describe(
+            'Natural-language query (a single sentence works best; max 1500 characters). Avoid spelling errors in context-rich keywords.'
+          ),
+        dataSource: z
+          .enum(['sharePoint', 'oneDriveBusiness', 'externalItem'])
+          .describe(
+            'Which source to retrieve from — one at a time (interleaved results are not supported). "sharePoint", "oneDriveBusiness", or "externalItem" (Copilot connectors).'
+          ),
+        filterExpression: z
+          .string()
+          .optional()
+          .describe(
+            'Optional KQL expression to scope the retrieval before the query runs. Supported SharePoint/OneDrive properties: Author, FileExtension, Filename, FileType, InformationProtectionLabelId, LastModifiedTime, ModifiedBy, Path, SiteID, Title. Example: Author:"Megan Bowen" OR Path:"https://contoso.sharepoint.com/sites/HR/". Invalid KQL is ignored (query runs unscoped).'
+          ),
+        resourceMetadata: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Optional list of retrievable metadata fields to return per hit (e.g. ["title", "author"]). By default no metadata is returned.'
+          ),
+        maximumNumberOfResults: z
+          .number()
+          .int()
+          .min(1)
+          .max(25)
+          .optional()
+          .describe(
+            'Optional cap on the number of results (1-25). Best practice: leave unset unless your LLM has strict token limits — results are unordered.'
+          ),
+      };
+      if (ctx.multiAccount) {
+        schema['account'] = z
+          .string()
+          .optional()
+          .describe(
+            'Account to use when multiple Microsoft accounts are configured. Required when multiple accounts exist (see list-accounts).'
+          );
+      }
+      return schema;
+    },
+    execute: async (params, { graphClient, authManager }) => {
+      const err = (message: string): CallToolResult => ({
+        content: [{ type: 'text', text: JSON.stringify({ error: message }) }],
+        isError: true,
+      });
+
+      const queryString = typeof params.queryString === 'string' ? params.queryString : '';
+      if (queryString.trim().length === 0) {
+        return err('queryString is required and must be a non-empty string.');
+      }
+      if (queryString.length > 1500) {
+        return err('queryString must be 1500 characters or fewer.');
+      }
+
+      const dataSource = params.dataSource;
+      const allowedSources = ['sharePoint', 'oneDriveBusiness', 'externalItem'];
+      if (typeof dataSource !== 'string' || !allowedSources.includes(dataSource)) {
+        return err(`dataSource is required and must be one of: ${allowedSources.join(', ')}.`);
+      }
+
+      const body: Record<string, unknown> = { queryString, dataSource };
+
+      if (params.filterExpression !== undefined) {
+        if (typeof params.filterExpression !== 'string') {
+          return err('filterExpression must be a string (KQL expression).');
+        }
+        body.filterExpression = params.filterExpression;
+      }
+
+      if (params.resourceMetadata !== undefined) {
+        const rm = params.resourceMetadata;
+        if (!Array.isArray(rm) || rm.some((x) => typeof x !== 'string')) {
+          return err('resourceMetadata must be an array of strings.');
+        }
+        body.resourceMetadata = rm;
+      }
+
+      if (params.maximumNumberOfResults !== undefined) {
+        const n = params.maximumNumberOfResults;
+        if (typeof n !== 'number' || !Number.isInteger(n) || n < 1 || n > 25) {
+          return err('maximumNumberOfResults must be an integer between 1 and 25.');
+        }
+        body.maximumNumberOfResults = n;
+      }
+
+      try {
+        let accountAccessToken: string | undefined;
+        if (authManager && !authManager.isOAuthModeEnabled() && !getRequestTokens()) {
+          accountAccessToken = await authManager.getTokenForAccount(
+            params.account as string | undefined
+          );
+        }
+        // The Retrieval API is GA on v1.0; leave apiVersion at its default.
+        return await graphClient.graphRequest('/copilot/retrieval', {
+          method: 'POST',
+          body: JSON.stringify(body),
+          accessToken: accountAccessToken,
+        });
+      } catch (error) {
+        return err((error as Error).message);
+      }
+    },
+  },
 ];
 
 function registerUtilityToolWithMcp(

--- a/test/calendar-view.test.ts
+++ b/test/calendar-view.test.ts
@@ -138,7 +138,12 @@ describe('Calendar View Tools', () => {
       for (const call of mockServer.tool.mock.calls) {
         const toolName = call[0] as string;
         // Skip utility tools that are not Graph API endpoints
-        if (toolName === 'parse-teams-url' || toolName === 'download-bytes') continue;
+        if (
+          toolName === 'parse-teams-url' ||
+          toolName === 'download-bytes' ||
+          toolName === 'copilot-retrieve'
+        )
+          continue;
         const paramSchema = call[2] as Record<string, z.ZodTypeAny>;
         expect(paramSchema).toHaveProperty('fetchAllPages');
       }

--- a/test/read-only.test.ts
+++ b/test/read-only.test.ts
@@ -83,8 +83,8 @@ describe('Read-Only Mode', () => {
 
     registerGraphTools(mockServer, {} as GraphClient, options.readOnly);
 
-    // 1 GET endpoint + parse-teams-url + download-bytes utility tools
-    expect(mockServer.tool).toHaveBeenCalledTimes(3);
+    // 1 GET endpoint + parse-teams-url + download-bytes + copilot-retrieve utility tools
+    expect(mockServer.tool).toHaveBeenCalledTimes(4);
 
     const toolCalls = mockServer.tool.mock.calls.map((call: unknown[]) => call[0]);
     expect(toolCalls).toContain('list-mail-messages');
@@ -100,8 +100,8 @@ describe('Read-Only Mode', () => {
 
     registerGraphTools(mockServer, {} as GraphClient, options.readOnly);
 
-    // 4 mocked endpoints (get-schedule skipped: workScopes only, no orgMode) + parse-teams-url + download-bytes
-    expect(mockServer.tool).toHaveBeenCalledTimes(6);
+    // 4 mocked endpoints (get-schedule skipped: workScopes only, no orgMode) + parse-teams-url + download-bytes + copilot-retrieve
+    expect(mockServer.tool).toHaveBeenCalledTimes(7);
 
     const toolCalls = mockServer.tool.mock.calls.map((call: unknown[]) => call[0]);
     expect(toolCalls).toContain('list-mail-messages');
@@ -132,8 +132,8 @@ describe('Read-Only Mode', () => {
     // PATCH endpoint should still be skipped (readOnly bypass is POST-only)
     expect(toolCalls).not.toContain('update-mail-folder');
 
-    // 2 graph tools (list-mail-messages + get-schedule) + parse-teams-url + download-bytes
-    expect(mockServer.tool).toHaveBeenCalledTimes(4);
+    // 2 graph tools (list-mail-messages + get-schedule) + parse-teams-url + download-bytes + copilot-retrieve
+    expect(mockServer.tool).toHaveBeenCalledTimes(5);
   });
 
   it('should block PATCH and DELETE endpoints in read-only mode regardless of readOnly flag', () => {

--- a/test/tool-filtering.test.ts
+++ b/test/tool-filtering.test.ts
@@ -51,8 +51,8 @@ describe('Tool Filtering', () => {
   it('should register all tools when no filter is provided', () => {
     registerGraphTools(server, graphClient, false);
 
-    // 5 mocked endpoints + parse-teams-url + download-bytes utility tools
-    expect(toolSpy).toHaveBeenCalledTimes(7);
+    // 5 mocked endpoints + parse-teams-url + download-bytes + copilot-retrieve utility tools
+    expect(toolSpy).toHaveBeenCalledTimes(8);
     expect(toolSpy).toHaveBeenCalledWith(
       'list-mail-messages',
       expect.any(String),
@@ -133,8 +133,8 @@ describe('Tool Filtering', () => {
   it('should handle invalid regex patterns gracefully', () => {
     registerGraphTools(server, graphClient, false, '[invalid regex');
 
-    // 5 mocked endpoints + parse-teams-url + download-bytes (no filter applied on invalid regex)
-    expect(toolSpy).toHaveBeenCalledTimes(7);
+    // 5 mocked endpoints + parse-teams-url + download-bytes + copilot-retrieve (no filter applied on invalid regex)
+    expect(toolSpy).toHaveBeenCalledTimes(8);
   });
 
   it('should combine read-only and filtering correctly', () => {


### PR DESCRIPTION
## What

Adds a `copilot-retrieve` tool that wraps the Microsoft 365 **Copilot Retrieval API** (`POST /copilot/retrieval`), giving semantic / hybrid search over SharePoint, OneDrive, and Copilot connectors content — complementing the existing lexical KQL search tools (`search-query`, `search-onedrive-files`, `search-sharepoint-sites`).

The Retrieval API grounds a natural-language query against the same hybrid index that powers Microsoft 365 Copilot and returns permission-trimmed text extracts with their source URLs. It resolves paraphrases and entity references that lexical search misses (e.g. an informal project nickname, or "packaging requirements" matched against text that never literally uses that phrase). This is especially useful on platforms where the separate Work IQ connector is unavailable.

## Tool shape

- **Input:** `queryString` (required, ≤1500 chars), `dataSource` (`sharePoint` | `oneDriveBusiness` | `externalItem`), optional `filterExpression` (KQL), `resourceMetadata` (string[]), `maximumNumberOfResults` (1–25).
- **Output:** the API's `retrievalHits` (each with `webUrl`, `extracts[].text` + `relevanceScore`, `resourceType`, `resourceMetadata`, `sensitivityLabel?`).
- Read-only (`readOnlyHint: true`); registered as a utility tool alongside `parse-teams-url` / `download-bytes`.

## Auth

Targets the GA `v1.0` endpoint and reuses the existing delegated token. Requires delegated **Files.Read.All + Sites.Read.All** (SharePoint / OneDrive) or **ExternalItem.Read.All** (Copilot connectors). The Retrieval API does not support application-only auth.

## Tests

5 new tests cover the request shape + response passthrough, optional-field inclusion, and input validation (empty `queryString`, invalid `dataSource`, out-of-range `maximumNumberOfResults`). Utility-tool registration counts updated in the read-only / tool-filtering / calendar-view suites. `npm test`, lint, and build all pass.

Refs: https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/api/ai-services/retrieval/overview
