### PR TITLE
fix(obo): advertise GUID-form scope so silent token refresh works

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -294,8 +294,12 @@ class MicrosoftGraphServer {
         const requestOrigin = `${protocol}://${req.get('host')}`;
         const browserBase = publicBase ?? requestOrigin;
 
+        // OBO advertises the GUID-form scope (not api://...) — with a single
+        // app as both API and OBO client, the user token's aud is the app
+        // itself, and Azure only allows refreshing such self-tokens when the
+        // resource is the GUID-based App Identifier (AADSTS90009 otherwise).
         const scopes = this.options.obo
-          ? [`api://${this.secrets!.clientId}/access_as_user`]
+          ? [`${this.secrets!.clientId}/access_as_user`]
           : resolveAuthScopes(this.options);
 
         res.json({

--- a/test/allowed-scopes.test.ts
+++ b/test/allowed-scopes.test.ts
@@ -174,7 +174,7 @@ describe('allowed scope HTTP behavior', () => {
     await handler(mockRequest('/.well-known/oauth-protected-resource'), res);
 
     expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ scopes_supported: ['api://test-client-id/access_as_user'] })
+      expect.objectContaining({ scopes_supported: ['test-client-id/access_as_user'] })
     );
   });
 


### PR DESCRIPTION
In --obo mode the protected-resource metadata advertised the OBO scope as api://<clientId>/access_as_user. With a single Entra app acting as both the API and the OBO confidential client, the user token's aud is the app itself, and Azure rejects refreshing such self-tokens unless the resource is the GUID-based App Identifier (AADSTS90009). Sign-in tolerated the URI form, so this only surfaced when the access token expired ~60-90 minutes in.

Advertise <clientId>/access_as_user instead so refresh tokens bind to the GUID resource and silent refresh succeeds.

Fixes #502