### PR TITLE
fix: remove duplicate get-drive-root-item endpoint, guard against dup…

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -490,12 +490,6 @@
     "scopes": ["Files.Read"]
   },
   {
-    "pathPattern": "/drives/{drive-id}/root",
-    "method": "get",
-    "toolName": "get-drive-root-item",
-    "scopes": ["Files.Read"]
-  },
-  {
     "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/children",
     "method": "get",
     "toolName": "list-folder-files",

--- a/test/endpoints-validation.test.ts
+++ b/test/endpoints-validation.test.ts
@@ -43,6 +43,25 @@ describe('endpoints.json validation', () => {
     }
   });
 
+  it('should not have duplicate tool names', () => {
+    const seen = new Set<string>();
+    const duplicates = endpoints.filter((e) => {
+      if (seen.has(e.toolName)) return true;
+      seen.add(e.toolName);
+      return false;
+    });
+
+    if (duplicates.length > 0) {
+      const details = duplicates
+        .map((e) => `  ${e.toolName} (${e.method.toUpperCase()} ${e.pathPattern})`)
+        .join('\n');
+      expect.fail(
+        `${duplicates.length} duplicate toolName(s) in endpoints.json. ` +
+          `Each tool must be defined exactly once.\n${details}`
+      );
+    }
+  });
+
   it('should have a matching generated client endpoint for every entry', () => {
     const generatedTools = new Set(api.endpoints.map((e) => e.alias));
     const orphans = endpoints.filter((e) => !generatedTools.has(e.toolName));


### PR DESCRIPTION
…licate tool names

endpoints.json contained two identical get-drive-root-item entries (introduced by the get-root-folder rename in dafb435). Harmless at runtime since generation dedupes, but confusing to read. Removed one and added a validation test so duplicate toolNames fail CI.

Regenerating produces no diff in src/generated/, confirming no behavior change.

Noted in #507.