### PR TITLE
fix: refuse account parameter in HTTP/OAuth mode instead of silently …

### DIFF
--- a/src/auth-tools.ts
+++ b/src/auth-tools.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import AuthManager from './auth.js';
+import { getRequestTokens } from './request-context.js';
 
 export function registerAuthTools(server: McpServer, authManager: AuthManager): void {
   server.tool(
@@ -130,6 +131,9 @@ export function registerAuthTools(server: McpServer, authManager: AuthManager): 
         const accounts = await authManager.listAccounts();
         const selectedAccountId = authManager.getSelectedAccountId();
         const pinnedMode = authManager.hasExpectedAccount();
+        // OAuth bearer requests always use the connecting client's identity, so
+        // cached accounts are not reachable via the account parameter (discussion #467).
+        const oauthBearerMode = authManager.isOAuthModeEnabled() || Boolean(getRequestTokens());
         const result = accounts.map((account) => ({
           email: account.username || 'unknown',
           name: account.name,
@@ -145,7 +149,9 @@ export function registerAuthTools(server: McpServer, authManager: AuthManager): 
                 count: result.length,
                 tip: pinnedMode
                   ? 'Expected account pinning is configured; account parameters are disabled.'
-                  : "Pass the 'email' value as the 'account' parameter in any tool call to target a specific account.",
+                  : oauthBearerMode
+                    ? "This server is in HTTP/OAuth mode: every request uses the identity of the connecting client's bearer token. The cached accounts listed here cannot be targeted via the 'account' parameter; reconnect the MCP client as the desired account instead."
+                    : "Pass the 'email' value as the 'account' parameter in any tool call to target a specific account.",
               }),
             },
           ],

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -975,6 +975,16 @@ class AuthManager {
    */
   async getTokenForAccount(identifier?: string): Promise<string> {
     if (this.isOAuthMode && this.oauthToken) {
+      // Refuse instead of silently returning the bearer's identity (discussion #467):
+      // in OAuth mode the token comes from the connecting client and cannot be
+      // switched to a cached MSAL account.
+      if (identifier) {
+        throw new Error(
+          `Cannot switch to account '${identifier}': the server is in OAuth mode and always uses ` +
+            `the identity of the supplied bearer token. Account switching requires stdio mode ` +
+            `(or HTTP with --trust-proxy-auth).`
+        );
+      }
       return this.oauthToken;
     }
 

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -158,6 +158,35 @@ function formatDisabledToolsForLog(disabledTools: DisabledToolScope[]): string {
   return `${shown.join('; ')}${suffix}`;
 }
 
+/**
+ * In OAuth/HTTP bearer mode the `account` parameter cannot switch identities —
+ * every Graph call uses the connecting client's bearer token. Previously a
+ * provided `account` was silently ignored and the bearer user's data returned
+ * (discussion #467). Returns an error message when an `account` param is
+ * provided that the bearer identity cannot honor; a param matching the bearer's
+ * own identity passes through. Returns null when account routing via the MSAL
+ * cache is available (stdio mode, or HTTP with --trust-proxy-auth).
+ */
+async function checkAccountParamInBearerMode(
+  accountParam: string | undefined,
+  authManager?: AuthManager
+): Promise<string | null> {
+  if (!accountParam || !authManager) return null;
+  const contextToken = getRequestTokens()?.accessToken;
+  if (!contextToken && !authManager.isOAuthModeEnabled()) return null;
+  const bearerToken = contextToken ?? (await authManager.getToken().catch(() => null)) ?? undefined;
+  const bearerIdentity = getUserIdentityForAudit(bearerToken);
+  if (bearerIdentity && bearerIdentity.toLowerCase() === accountParam.toLowerCase()) return null;
+  return (
+    `The 'account' parameter is not supported in HTTP/OAuth mode: every request uses the identity ` +
+    `of the connecting client's bearer token` +
+    (bearerIdentity ? ` ('${bearerIdentity}')` : '') +
+    `, so account switching is not possible. To act as '${accountParam}', reconnect the MCP client ` +
+    `authenticated as that account, or run the server in stdio mode (or HTTP with --trust-proxy-auth) ` +
+    `where cached accounts are available.`
+  );
+}
+
 export const UTILITY_TOOLS: readonly UtilityTool[] = [
   {
     name: 'parse-teams-url',
@@ -250,6 +279,13 @@ export const UTILITY_TOOLS: readonly UtilityTool[] = [
         };
       }
       try {
+        const accountModeError = await checkAccountParamInBearerMode(accountParam, authManager);
+        if (accountModeError) {
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: accountModeError }) }],
+            isError: true,
+          };
+        }
         let accountAccessToken: string | undefined;
         if (authManager && !authManager.isOAuthModeEnabled() && !getRequestTokens()) {
           accountAccessToken = await authManager.getTokenForAccount(accountParam);
@@ -298,12 +334,23 @@ async function executeGraphTool(
   const httpMethod = tool.method.toUpperCase();
 
   try {
+    const accountParam = params.account as string | undefined;
+
+    // In OAuth/HTTP bearer mode, refuse an `account` param that doesn't match the bearer
+    // identity instead of silently returning the bearer user's data (discussion #467).
+    const accountModeError = await checkAccountParamInBearerMode(accountParam, authManager);
+    if (accountModeError) {
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ error: accountModeError }) }],
+        isError: true,
+      };
+    }
+
     // Resolve account-specific token if `account` parameter is provided (or auto-resolve for single account).
     // Skip in OAuth/HTTP mode — let the request context drive token selection via GraphClient.
     // Also skip when a request-context token exists (HTTP/OAuth flow where token comes from middleware).
     let accountAccessToken: string | undefined;
     if (authManager && !authManager.isOAuthModeEnabled() && !getRequestTokens()) {
-      const accountParam = params.account as string | undefined;
       try {
         accountAccessToken = await authManager.getTokenForAccount(accountParam);
       } catch (err) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -141,18 +141,31 @@ class MicrosoftGraphServer {
     this.secrets = await getSecrets();
     this.version = version;
 
-    // Detect multi-account mode and cache account names for schema enum
-    try {
-      this.multiAccount = await this.authManager.isMultiAccount();
-      if (this.multiAccount) {
-        const accounts = await this.authManager.listAccounts();
-        this.accountNames = accounts.map((a) => a.username).filter((u): u is string => !!u);
-        logger.info(
-          `Multi-account mode detected (${this.accountNames.length} accounts): "account" parameter will be injected into all tool schemas`
-        );
+    // Detect multi-account mode and cache account names for schema enum.
+    // Skip in HTTP bearer mode and BYOT: those requests are authenticated by the
+    // client's OAuth bearer token, so MSAL-cached accounts can never serve them and
+    // advertising an `account` parameter would be misleading (discussion #467).
+    // HTTP with --trust-proxy-auth falls back to the MSAL cache, so account
+    // routing stays available there.
+    const accountRoutingAvailable =
+      (!this.options.http || this.options.trustProxyAuth) && !this.authManager.isOAuthModeEnabled();
+    if (accountRoutingAvailable) {
+      try {
+        this.multiAccount = await this.authManager.isMultiAccount();
+        if (this.multiAccount) {
+          const accounts = await this.authManager.listAccounts();
+          this.accountNames = accounts.map((a) => a.username).filter((u): u is string => !!u);
+          logger.info(
+            `Multi-account mode detected (${this.accountNames.length} accounts): "account" parameter will be injected into all tool schemas`
+          );
+        }
+      } catch (err) {
+        logger.warn(`Failed to detect multi-account mode: ${(err as Error).message}`);
       }
-    } catch (err) {
-      logger.warn(`Failed to detect multi-account mode: ${(err as Error).message}`);
+    } else {
+      logger.info(
+        'Account routing disabled: requests use the OAuth bearer identity, so the "account" parameter is not injected into tool schemas'
+      );
     }
 
     if (this.options.obo) {

--- a/test/auth-pinning.test.ts
+++ b/test/auth-pinning.test.ts
@@ -198,7 +198,12 @@ describe('strict expected account pinning', () => {
       isOAuthMode: true,
     });
 
-    await expect(auth.getTokenForAccount('personal@example.com')).resolves.toBe('byot-token');
+    // Account switching is refused in OAuth/BYOT mode (discussion #467), and the
+    // pinning logic stays inert: the MSAL cache is never consulted.
+    await expect(auth.getTokenForAccount('personal@example.com')).rejects.toThrow(
+      /Cannot switch to account 'personal@example.com'/
+    );
+    await expect(auth.getTokenForAccount()).resolves.toBe('byot-token');
     expect(tokenCache.getAllAccounts).not.toHaveBeenCalled();
   });
 });

--- a/test/http-account-param.test.ts
+++ b/test/http-account-param.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Regression tests for discussion #467:
+ * "account parameter ignored in HTTP mode — always returns data for authenticated user"
+ *
+ * In HTTP/OAuth mode the Graph token is the connecting client's bearer; MSAL-cached
+ * accounts cannot serve those requests. Previously a provided `account` parameter was
+ * silently ignored and the bearer user's data returned. Now:
+ *  - an `account` that doesn't match the bearer identity is refused with a clear error
+ *  - an `account` matching the bearer's own identity passes through
+ *  - AuthManager.getTokenForAccount throws on an identifier in OAuth mode
+ *  - stdio / --trust-proxy-auth account routing is unchanged
+ */
+import type { AccountInfo, Configuration } from '@azure/msal-node';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerGraphTools } from '../src/graph-tools.js';
+import GraphClient from '../src/graph-client.js';
+import AuthManager from '../src/auth.js';
+import { requestContext } from '../src/request-context.js';
+
+vi.mock('../src/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('../src/generated/client.js', () => ({
+  api: {
+    endpoints: [
+      {
+        alias: 'list-mail-messages',
+        method: 'GET',
+        path: '/me/messages',
+        description: 'List mail messages',
+        parameters: [],
+      },
+    ],
+  },
+}));
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `header.${body}.signature`;
+}
+
+const mockSecrets = {
+  clientId: 'test-client',
+  tenantId: 'common',
+  cloudType: 'global' as const,
+};
+
+describe('Discussion #467: account parameter in HTTP/OAuth mode', () => {
+  let server: McpServer;
+  let originalFetch: typeof global.fetch;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let capturedHandler: ((...args: any[]) => any) | undefined;
+
+  beforeEach(() => {
+    server = new McpServer({ name: 'test', version: '1.0.0' });
+    originalFetch = global.fetch;
+    capturedHandler = undefined;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(server, 'tool').mockImplementation(((...args: any[]) => {
+      const name = args[0];
+      const handler = args[args.length - 1];
+      if (name === 'list-mail-messages' && typeof handler === 'function') {
+        capturedHandler = handler;
+      }
+    }) as any);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function setup(authManagerOverrides: Record<string, unknown> = {}) {
+    const fetchSpy = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ value: [] }),
+      headers: new Headers(),
+    }));
+    global.fetch = fetchSpy;
+
+    const mockAuthManager = {
+      isOAuthModeEnabled: vi.fn().mockReturnValue(false),
+      getTokenForAccount: vi.fn().mockResolvedValue('msal-token'),
+      getToken: vi.fn().mockResolvedValue(null),
+      ...authManagerOverrides,
+    };
+
+    const graphClient = new GraphClient(mockAuthManager as any, mockSecrets);
+    registerGraphTools(server, graphClient, false, undefined, false, mockAuthManager as any, true, [
+      'user1@domain.com',
+      'user2@domain.com',
+    ]);
+    expect(capturedHandler).toBeDefined();
+    return { fetchSpy, mockAuthManager };
+  }
+
+  it('refuses account param that does not match the bearer identity', async () => {
+    const { fetchSpy } = setup();
+    const bearer = makeJwt({ upn: 'user1@domain.com' });
+
+    const result = await requestContext.run({ accessToken: bearer }, () =>
+      capturedHandler!({ account: 'user2@domain.com' })
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("'account' parameter is not supported");
+    expect(result.content[0].text).toContain('user1@domain.com');
+    // No Graph call was made with the wrong identity
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('allows account param that matches the bearer identity (case-insensitive)', async () => {
+    const { fetchSpy } = setup();
+    const bearer = makeJwt({ upn: 'User1@Domain.com' });
+
+    const result = await requestContext.run({ accessToken: bearer }, () =>
+      capturedHandler!({ account: 'user1@domain.com' })
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it('refuses account param when the bearer identity cannot be determined (opaque token)', async () => {
+    const { fetchSpy } = setup();
+
+    const result = await requestContext.run({ accessToken: 'opaque-token' }, () =>
+      capturedHandler!({ account: 'user2@domain.com' })
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("'account' parameter is not supported");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('refuses mismatched account param in BYOT mode (no request context)', async () => {
+    const byotToken = makeJwt({ upn: 'byot-user@domain.com' });
+    const { fetchSpy } = setup({
+      isOAuthModeEnabled: vi.fn().mockReturnValue(true),
+      getToken: vi.fn().mockResolvedValue(byotToken),
+    });
+
+    const result = await capturedHandler!({ account: 'user2@domain.com' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("'account' parameter is not supported");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps MSAL account routing working without request context (stdio mode)', async () => {
+    const { fetchSpy, mockAuthManager } = setup();
+
+    const result = await capturedHandler!({ account: 'user2@domain.com' });
+
+    expect(mockAuthManager.getTokenForAccount).toHaveBeenCalledWith('user2@domain.com');
+    expect(result.isError).toBeUndefined();
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+});
+
+describe('Discussion #467: list-accounts tip in OAuth bearer mode', () => {
+  it('explains that cached accounts are not reachable via the account parameter', async () => {
+    const { registerAuthTools } = await import('../src/auth-tools.js');
+    const server = new McpServer({ name: 'test', version: '1.0.0' });
+    const mockAuthManager = {
+      listAccounts: vi
+        .fn()
+        .mockResolvedValue([
+          { username: 'cached@domain.com', name: 'Cached', homeAccountId: 'cached.home' },
+        ]),
+      getSelectedAccountId: vi.fn().mockReturnValue(null),
+      hasExpectedAccount: vi.fn().mockReturnValue(false),
+      isOAuthModeEnabled: vi.fn().mockReturnValue(true),
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let listAccountsHandler: ((...args: any[]) => any) | undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(server, 'tool').mockImplementation(((...args: any[]) => {
+      const name = args[0];
+      const handler = args[args.length - 1];
+      if (name === 'list-accounts' && typeof handler === 'function') {
+        listAccountsHandler = handler;
+      }
+    }) as any);
+
+    registerAuthTools(server, mockAuthManager as any);
+    expect(listAccountsHandler).toBeDefined();
+
+    const result = await listAccountsHandler!({});
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.tip).toContain('HTTP/OAuth mode');
+    expect(parsed.tip).not.toContain("'account' parameter in any tool call");
+  });
+});
+
+describe('Discussion #467: AuthManager.getTokenForAccount in OAuth mode', () => {
+  const msalConfig: Configuration = {
+    auth: {
+      clientId: 'test-client',
+      authority: 'https://login.microsoftonline.com/common',
+    },
+  };
+
+  function createAuth(accounts: AccountInfo[]) {
+    const tokenCache = {
+      getAllAccounts: vi.fn().mockResolvedValue(accounts),
+      removeAccount: vi.fn().mockResolvedValue(undefined),
+    };
+    const msalApp = {
+      getTokenCache: vi.fn(() => tokenCache),
+      acquireTokenSilent: vi.fn().mockResolvedValue({
+        accessToken: 'silent-token',
+        expiresOn: new Date(Date.now() + 60_000),
+      }),
+    };
+    const auth = new AuthManager(msalConfig, ['User.Read']);
+    Object.assign(auth as unknown as Record<string, unknown>, {
+      msalApp,
+      saveTokenCache: vi.fn(),
+    });
+    return auth;
+  }
+
+  it('throws when an identifier is provided in OAuth mode', async () => {
+    const auth = createAuth([
+      { username: 'cached@domain.com', homeAccountId: 'cached.home' } as AccountInfo,
+    ]);
+    await auth.setOAuthToken('bearer-token');
+
+    await expect(auth.getTokenForAccount('cached@domain.com')).rejects.toThrow(
+      /Cannot switch to account 'cached@domain.com'/
+    );
+  });
+
+  it('still returns the bearer when no identifier is provided in OAuth mode', async () => {
+    const auth = createAuth([]);
+    await auth.setOAuthToken('bearer-token');
+
+    await expect(auth.getTokenForAccount()).resolves.toBe('bearer-token');
+  });
+});

--- a/test/multi-account.test.ts
+++ b/test/multi-account.test.ts
@@ -145,6 +145,7 @@ describe('Multi-account support', () => {
         selectAccount: vi.fn(),
         removeAccount: vi.fn(),
         hasExpectedAccount: vi.fn().mockReturnValue(false),
+        isOAuthModeEnabled: vi.fn().mockReturnValue(false),
       };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- handler type varies across McpServer.tool() overloads
@@ -195,6 +196,7 @@ describe('Multi-account support', () => {
         selectAccount: vi.fn(),
         removeAccount: vi.fn(),
         hasExpectedAccount: vi.fn().mockReturnValue(true),
+        isOAuthModeEnabled: vi.fn().mockReturnValue(false),
       };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- handler type varies across McpServer.tool() overloads


### PR DESCRIPTION
…ignoring it

In HTTP/OAuth bearer mode the account parameter was silently ignored and the bearer user's data returned, making multi-account switching appear broken (discussion #467). Now:

- Tool calls with an account that doesn't match the bearer identity return a clear error explaining account switching is unavailable in this mode (an account matching the bearer's own identity passes through)
- AuthManager.getTokenForAccount throws on an identifier in OAuth mode instead of silently returning the bearer token
- The account parameter is no longer injected into tool schemas in HTTP bearer/BYOT mode, where cached accounts can never serve requests
- list-accounts explains that cached accounts are not reachable via the account parameter when serving OAuth-authenticated requests

stdio mode and HTTP with --trust-proxy-auth keep full account routing.