### PR TITLE
feat(http): allow MCP discovery requests without a bearer token

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,6 +86,10 @@ program
     '--trust-proxy-auth',
     'In HTTP mode, skip the built-in Bearer-token check on /mcp and ignore any forwarded Authorization header. All callers share the locally cached MSAL identity (same path stdio mode uses). Use only when an upstream reverse proxy has already authenticated the caller.'
   )
+  .option(
+    '--allow-unauthenticated-discovery',
+    'In HTTP mode, allow MCP discovery requests (initialize, tools/list, prompts/list, resources/list, ping) without a bearer token, so a gateway can enumerate the tool catalog before any user has authenticated. Non-discovery requests (e.g. tools/call) still require a token. Off by default.'
+  )
   .addOption(
     // DEPRECATED: kept only so existing deployments that set --base-url or
     // MS365_MCP_BASE_URL do not crash at startup. Use --public-url /
@@ -122,6 +126,7 @@ export interface CommandOptions {
   authBrowser?: boolean;
   obo?: boolean;
   trustProxyAuth?: boolean;
+  allowUnauthenticatedDiscovery?: boolean;
   publicUrl?: string;
   /** @deprecated use publicUrl */
   baseUrl?: string;
@@ -266,6 +271,13 @@ export function parseArgs(): CommandOptions {
     process.env.MS365_MCP_TRUST_PROXY_AUTH === '1'
   ) {
     options.trustProxyAuth = true;
+  }
+
+  if (
+    process.env.MS365_MCP_ALLOW_UNAUTHENTICATED_DISCOVERY === 'true' ||
+    process.env.MS365_MCP_ALLOW_UNAUTHENTICATED_DISCOVERY === '1'
+  ) {
+    options.allowUnauthenticatedDiscovery = true;
   }
 
   // Handle cloud type - CLI option takes precedence over environment variable

--- a/src/lib/microsoft-auth.ts
+++ b/src/lib/microsoft-auth.ts
@@ -24,6 +24,24 @@ function isJwtExpired(token: string): boolean {
   }
 }
 
+const DISCOVERY_METHODS = new Set([
+  'initialize',
+  'notifications/initialized',
+  'tools/list',
+  'prompts/list',
+  'resources/list',
+  'ping',
+]);
+
+function isDiscoveryRequest(req: Request): boolean {
+  if (req.method !== 'POST' || !req.body) return false;
+  const body = req.body;
+  if (Array.isArray(body)) {
+    return body.every((item) => DISCOVERY_METHODS.has(item?.method));
+  }
+  return DISCOVERY_METHODS.has(body?.method);
+}
+
 /**
  * Microsoft Bearer Token Auth Middleware validates that the request has a valid Microsoft access token.
  * Returns HTTP 401 + WWW-Authenticate on missing or expired tokens so spec-compliant MCP clients
@@ -33,9 +51,14 @@ function isJwtExpired(token: string): boolean {
  * reverse proxy is presumed to have authenticated the caller, and Microsoft
  * Graph access falls back to the locally cached MSAL refresh token via
  * AuthManager (the same path stdio mode uses).
+ *
+ * When `allowUnauthenticatedDiscovery` is true, discovery requests (initialize,
+ * tools/list, etc.) are allowed without a token so that MCP gateways can
+ * register the available tools before any user has authenticated. It is off by
+ * default; non-discovery requests (e.g. tools/call) always still require a token.
  */
 export const microsoftBearerTokenAuthMiddleware =
-  (opts: { trustProxyAuth?: boolean } = {}) =>
+  (opts: { trustProxyAuth?: boolean; allowUnauthenticatedDiscovery?: boolean } = {}) =>
   (
     req: Request & { microsoftAuth?: { accessToken: string } },
     res: Response,
@@ -49,6 +72,10 @@ export const microsoftBearerTokenAuthMiddleware =
     const authHeader = req.headers.authorization;
 
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      if (opts.allowUnauthenticatedDiscovery && isDiscoveryRequest(req)) {
+        next();
+        return;
+      }
       res
         .status(401)
         .set(

--- a/src/server.ts
+++ b/src/server.ts
@@ -628,6 +628,7 @@ class MicrosoftGraphServer {
       // for the AuthManager fallback that makes that mode work).
       const mcpAuth = microsoftBearerTokenAuthMiddleware({
         trustProxyAuth: this.options.trustProxyAuth,
+        allowUnauthenticatedDiscovery: this.options.allowUnauthenticatedDiscovery,
       });
       app.get(
         '/mcp',

--- a/test/discovery-auth.test.ts
+++ b/test/discovery-auth.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression test for the --allow-unauthenticated-discovery feature: when the
+ * flag is set, MCP discovery requests (initialize, tools/list, etc.) are allowed
+ * through the HTTP bearer-token middleware WITHOUT a token, so an MCP gateway can
+ * enumerate the tool catalog before any user has authenticated. Non-discovery
+ * requests (e.g. tools/call) still require a valid bearer token, and with the
+ * flag off (the default) discovery requests are rejected like any other.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { microsoftBearerTokenAuthMiddleware } from '../src/lib/microsoft-auth.js';
+
+function makeRes() {
+  const res: any = { statusCode: undefined };
+  res.status = vi.fn((c: number) => {
+    res.statusCode = c;
+    return res;
+  });
+  res.set = vi.fn(() => res);
+  res.json = vi.fn(() => res);
+  return res;
+}
+
+function makeReq(method: string, headers: Record<string, string> = {}) {
+  return {
+    method: 'POST',
+    headers,
+    body: { jsonrpc: '2.0', method },
+    secure: false,
+    get: (h: string) => (h.toLowerCase() === 'host' ? 'localhost:3000' : undefined),
+  } as any;
+}
+
+describe('discovery requests bypass bearer auth when --allow-unauthenticated-discovery is set', () => {
+  const mw = microsoftBearerTokenAuthMiddleware({ allowUnauthenticatedDiscovery: true });
+
+  for (const method of ['initialize', 'tools/list', 'prompts/list', 'resources/list', 'ping']) {
+    it(`allows ${method} with no token`, () => {
+      const req = makeReq(method);
+      const res = makeRes();
+      const next = vi.fn();
+      mw(req, res, next);
+      expect(next).toHaveBeenCalledOnce();
+      expect(res.status).not.toHaveBeenCalled();
+      expect(req.microsoftAuth).toBeUndefined();
+    });
+  }
+
+  it('rejects tools/call with no token (401)', () => {
+    const req = makeReq('tools/call');
+    const res = makeRes();
+    const next = vi.fn();
+    mw(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('passes through the per-user token on tools/call when a bearer is present', () => {
+    const req = makeReq('tools/call', { authorization: 'Bearer opaque-user-token' });
+    const res = makeRes();
+    const next = vi.fn();
+    mw(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(req.microsoftAuth).toEqual({ accessToken: 'opaque-user-token' });
+  });
+});
+
+describe('discovery requests require a token by default (flag off)', () => {
+  const mw = microsoftBearerTokenAuthMiddleware();
+
+  for (const method of ['initialize', 'tools/list', 'prompts/list', 'resources/list', 'ping']) {
+    it(`rejects ${method} with no token (401)`, () => {
+      const req = makeReq(method);
+      const res = makeRes();
+      const next = vi.fn();
+      mw(req, res, next);
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(401);
+    });
+  }
+});
+
+describe('trustProxyAuth', () => {
+  it('skips the check entirely', () => {
+    const proxyMw = microsoftBearerTokenAuthMiddleware({ trustProxyAuth: true });
+    const req = makeReq('tools/call');
+    const res = makeRes();
+    const next = vi.fn();
+    proxyMw(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Lets the HTTP bearer-token middleware pass **MCP discovery requests** through without a token, so an MCP gateway can enumerate a backend's tool catalog before any user has authenticated. `tools/call` still requires a valid bearer, which is passed through per-request to Graph as today.

Tokenless allow-list (`isDiscoveryRequest`): `initialize`, `notifications/initialized`, `tools/list`, `prompts/list`, `resources/list`, `ping`.

## Motivation

Running behind an MCP gateway (one backend per app via `--preset`), we need to:
1. **List tools right after deploy, pre-auth** — the gateway syncs the catalog and applies its own secondary policy on which tools to expose.
2. **Inject a per-user identity on calls** — after the gateway authenticates the user, it injects that user's managed OAuth Microsoft token into the request.

Neither existing mode does both: default HTTP `401`s `tools/list` without a token; `--trust-proxy-auth` allows tokenless requests but ignores the per-request bearer and uses a single cached MSAL identity. This change is complementary to `--trust-proxy-auth`. See #513.

## Changes

- `src/lib/microsoft-auth.ts`: add `isDiscoveryRequest()` and let discovery methods skip the missing-bearer `401` in `microsoftBearerTokenAuthMiddleware`. Non-discovery requests are unchanged; a present bearer is still parsed/validated and passed through.
- `test/discovery-auth.test.ts`: covers discovery-allowed, `tools/call` `401` without token, per-user passthrough with a bearer, and `trustProxyAuth` short-circuit.

## Notes

This is **on by default** (discovery only ever exposes tool schemas, never data; calls still require auth). If you'd rather it be opt-in, I'm happy to gate it behind a flag like `--allow-unauthenticated-discovery` — just say the word.

Closes #513
