### PR TITLE
fix(obo): advertise GUID-form scope in authorization-server metadata

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -280,7 +280,12 @@ class MicrosoftGraphServer {
         const requestOrigin = `${protocol}://${req.get('host')}`;
         const browserBase = publicBase ?? requestOrigin;
 
-        const scopes = resolveAuthScopes(this.options);
+        // Mirror the protected-resource handler below: in OBO mode both discovery
+        // docs must advertise the GUID-form resource scope, else RFC 8414 clients
+        // request raw Graph scopes and get a token the OBO exchange rejects (#516).
+        const scopes = this.options.obo
+          ? [`${this.secrets!.clientId}/access_as_user`]
+          : resolveAuthScopes(this.options);
 
         const metadata: Record<string, unknown> = {
           issuer: browserBase,

--- a/test/allowed-scopes.test.ts
+++ b/test/allowed-scopes.test.ts
@@ -178,6 +178,20 @@ describe('allowed scope HTTP behavior', () => {
     );
   });
 
+  it('advertises OBO scope in authorization-server metadata', async () => {
+    process.env.MS365_MCP_CLIENT_SECRET = 'secret';
+    clearSecretsCache();
+    await startHttpServer({ allowedScopes: 'Mail.Read', obo: true });
+    const handler = expressMocks.routes.get('/.well-known/oauth-authorization-server')!;
+    const res = mockResponse();
+
+    await handler(mockRequest('/.well-known/oauth-authorization-server'), res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ scopes_supported: ['test-client-id/access_as_user'] })
+    );
+  });
+
   it('passes allowed scopes to tool registration', () => {
     const server = new MicrosoftGraphServer(mockAuthManager(), {
       allowedScopes: 'Mail.Read',


### PR DESCRIPTION
The oauth-authorization-server discovery handler returned raw Graph scopes unconditionally while its oauth-protected-resource sibling advertised the GUID-form resource scope in OBO mode (since #508). RFC 8414 clients (e.g. OpenAI Codex) followed the AS metadata, requested the Graph scopes, and got a token with aud=Microsoft Graph that the OBO exchange rejects, failing at initialize. Give the AS handler the same OBO branch so both discovery docs agree.

Closes #516