### PR TITLE
feat(config): bound fetchAllPages with MS365_MCP_MAX_PAGES and MS365_MCP_MAX_ITEMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,9 @@ Environment variables:
 - `MS365_MCP_FORCE_WORK_SCOPES=true|1`: Backwards compatibility for MS365_MCP_ORG_MODE
 - `MS365_MCP_OUTPUT_FORMAT=toon`: Enable TOON output format (alternative to --toon flag)
 - `MS365_MCP_MAX_TOP=<n>`: Hard cap for Graph `$top` / `top` on list requests (positive integer). When the model passes a larger value, the server clamps it to `n` so responses stay smaller. Example: `MS365_MCP_MAX_TOP=15`
+- `MS365_MCP_MAX_PAGES=<n>`: Maximum number of pages followed when a tool is called with `fetchAllPages: true` (positive integer, default `100`). Bounds memory and latency for large result sets.
+- `MS365_MCP_MAX_ITEMS=<n>`: Maximum number of items accumulated when `fetchAllPages: true` (positive integer, default `10000`). Pagination stops and the response is truncated once this many items are collected.
+- `MS365_MCP_ALLOW_PAGINATION=0|false|no`: Disable multi-page following entirely. When set, `fetchAllPages: true` returns only the first page (default: pagination enabled).
 - `MS365_MCP_BODY_FORMAT=html`: Return email bodies as HTML instead of plain text (default: text)
 - `MS365_MCP_CLOUD_TYPE=global|china`: Microsoft cloud environment (alternative to --cloud flag)
 - `LOG_LEVEL`: Set logging level (default: 'info')

--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -248,6 +248,97 @@ describe('graph-tools', () => {
       // 1 initial + 99 pagination = 100 total requests (stops at pageCount=100)
       expect(graphClient.graphRequest).toHaveBeenCalledTimes(100);
     });
+
+    describe('pagination env caps', () => {
+      const prev = {
+        pages: process.env.MS365_MCP_MAX_PAGES,
+        items: process.env.MS365_MCP_MAX_ITEMS,
+        allow: process.env.MS365_MCP_ALLOW_PAGINATION,
+      };
+
+      afterEach(() => {
+        const restore = (name: string, value: string | undefined) =>
+          value === undefined ? delete process.env[name] : (process.env[name] = value);
+        restore('MS365_MCP_MAX_PAGES', prev.pages);
+        restore('MS365_MCP_MAX_ITEMS', prev.items);
+        restore('MS365_MCP_ALLOW_PAGINATION', prev.allow);
+      });
+
+      const paginatingResponses = (count: number) =>
+        Array.from({ length: count }, (_, i) => ({
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                value: [{ id: `item-${i}` }],
+                '@odata.nextLink': 'https://graph.microsoft.com/v1.0/me/messages?$skip=' + (i + 1),
+              }),
+            },
+          ],
+        }));
+
+      it('should honor MS365_MCP_MAX_PAGES below the default', async () => {
+        process.env.MS365_MCP_MAX_PAGES = '2';
+        mockEndpoints.push(makeEndpoint());
+        mockEndpointsJson = [makeConfig()];
+
+        const graphClient = createMockGraphClient(paginatingResponses(5));
+        const server = createMockServer();
+        const { registerGraphTools } = await loadModule();
+        registerGraphTools(server as any, graphClient as any);
+
+        await server.tools.get('test-tool')!.handler({ fetchAllPages: true });
+
+        // 1 initial + 1 pagination = 2 total requests (stops at pageCount=2)
+        expect(graphClient.graphRequest).toHaveBeenCalledTimes(2);
+      });
+
+      it('should honor MS365_MCP_MAX_ITEMS below the default', async () => {
+        process.env.MS365_MCP_MAX_ITEMS = '2';
+        mockEndpoints.push(makeEndpoint());
+        mockEndpointsJson = [makeConfig()];
+
+        // First page already carries 2 items → the while-loop guard stops it.
+        const graphClient = createMockGraphClient([
+          {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  value: [{ id: '1' }, { id: '2' }],
+                  '@odata.nextLink': 'https://graph.microsoft.com/v1.0/me/messages?$skip=2',
+                }),
+              },
+            ],
+          },
+          ...paginatingResponses(3),
+        ]);
+        const server = createMockServer();
+        const { registerGraphTools } = await loadModule();
+        registerGraphTools(server as any, graphClient as any);
+
+        const result = await server.tools.get('test-tool')!.handler({ fetchAllPages: true });
+
+        expect(graphClient.graphRequest).toHaveBeenCalledTimes(1);
+        expect(JSON.parse(result.content[0].text).value).toHaveLength(2);
+      });
+
+      it('should not follow nextLink when MS365_MCP_ALLOW_PAGINATION is disabled', async () => {
+        process.env.MS365_MCP_ALLOW_PAGINATION = '0';
+        mockEndpoints.push(makeEndpoint());
+        mockEndpointsJson = [makeConfig()];
+
+        const graphClient = createMockGraphClient(paginatingResponses(5));
+        const server = createMockServer();
+        const { registerGraphTools } = await loadModule();
+        registerGraphTools(server as any, graphClient as any);
+
+        await server.tools.get('test-tool')!.handler({ fetchAllPages: true });
+
+        // Disabled → first page only, no nextLink following
+        expect(graphClient.graphRequest).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
   // ---- 3. Parameter describe() overrides ----

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -70,6 +70,31 @@ function clampTopQueryParam(queryParams: Record<string, string>): void {
   queryParams['$top'] = String(cap);
 }
 
+const DEFAULT_MAX_PAGES = 100;
+const DEFAULT_MAX_ITEMS = 10_000;
+
+/** Reads a positive-integer env var, falling back to `defaultValue` when unset or invalid. */
+function positiveIntFromEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return defaultValue;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) {
+    logger.warn(`Ignoring invalid ${name}=${JSON.stringify(raw)} (use a positive integer)`);
+    return defaultValue;
+  }
+  return n;
+}
+
+/**
+ * Whether `fetchAllPages` is permitted. Defaults to true; set MS365_MCP_ALLOW_PAGINATION
+ * to 0/false/no to disable multi-page following entirely (returns the first page only).
+ */
+function paginationAllowed(): boolean {
+  const raw = process.env.MS365_MCP_ALLOW_PAGINATION;
+  if (raw === undefined || raw === '') return true;
+  return !/^(0|false|no)$/i.test(raw.trim());
+}
+
 type TextContent = {
   type: 'text';
   text: string;
@@ -612,14 +637,20 @@ async function executeGraphTool(
     let response = await graphClient.graphRequest(path, options);
 
     const fetchAllPages = params.fetchAllPages === true;
-    if (fetchAllPages && response?.content?.[0]?.text) {
+    const paginationEnabled = paginationAllowed();
+    if (fetchAllPages && !paginationEnabled) {
+      logger.info(
+        'fetchAllPages requested but MS365_MCP_ALLOW_PAGINATION is disabled; returning first page only'
+      );
+    }
+    if (fetchAllPages && paginationEnabled && response?.content?.[0]?.text) {
       try {
         let combinedResponse = JSON.parse(response.content[0].text);
         let allItems = combinedResponse.value || [];
         let nextLink = combinedResponse['@odata.nextLink'];
         let pageCount = 1;
-        const maxPages = 100;
-        const maxItems = 10_000;
+        const maxPages = positiveIntFromEnv('MS365_MCP_MAX_PAGES', DEFAULT_MAX_PAGES);
+        const maxItems = positiveIntFromEnv('MS365_MCP_MAX_ITEMS', DEFAULT_MAX_ITEMS);
 
         while (nextLink && pageCount < maxPages && allItems.length < maxItems) {
           logger.info(`Fetching page ${pageCount + 1} from: ${nextLink}`);


### PR DESCRIPTION
## What
Make the `fetchAllPages` pagination caps configurable and add an off switch.

## Why
When a tool is called with `fetchAllPages: true`, `graph-tools.ts` follows `@odata.nextLink` with hardcoded limits (`maxPages = 100`, `maxItems = 10_000`). Operators running this server with concurrent users may want a smaller per-request memory footprint (10K items × ~5KB ≈ 50MB), or to disable multi-page following entirely for security-conscious workloads. This mirrors the existing `MS365_MCP_MAX_TOP` pattern.

## How
Three new env vars (invalid values warn and fall back to the default):
- `MS365_MCP_MAX_PAGES` — default `100`
- `MS365_MCP_MAX_ITEMS` — default `10000`
- `MS365_MCP_ALLOW_PAGINATION=0|false|no` — disables nextLink following; `fetchAllPages: true` then returns the first page only

## Backward compatibility
Defaults match the previous hardcoded values — no behaviour change unless explicitly configured. Adds 3 unit tests and documents the vars in the README.
