### PR TITLE
feat(security): helmet headers and per-IP rate limiting for HTTP mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,8 @@ Environment variables:
 - `MS365_MCP_OUTPUT_FORMAT=toon`: Enable TOON output format (alternative to --toon flag)
 - `MS365_MCP_MAX_TOP=<n>`: Hard cap for Graph `$top` / `top` on list requests (positive integer). When the model passes a larger value, the server clamps it to `n` so responses stay smaller. Example: `MS365_MCP_MAX_TOP=15`
 - `MS365_MCP_BODY_FORMAT=html`: Return email bodies as HTML instead of plain text (default: text)
+- `MS365_MCP_RATE_LIMIT_DISABLED=true|1`: Disable per-IP rate limiting in HTTP mode (default: enabled — 30 req/min on `/authorize`, `/token`, `/register`; 120 req/min on `/mcp`)
+- `MS365_MCP_TRUST_PROXY_HOPS=<n>`: Number of trusted reverse-proxy hops in HTTP mode (default `1`). Accurate per-IP rate limiting depends on this matching your deployment — set to the number of proxies in front of the server, `0` to use the raw socket peer IP, or a comma-separated subnet list
 - `MS365_MCP_CLOUD_TYPE=global|china`: Microsoft cloud environment (alternative to --cloud flag)
 - `LOG_LEVEL`: Set logging level (default: 'info')
 - `SILENT=true|1`: Disable console output

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "commander": "^11.1.0",
         "dotenv": "^17.0.1",
         "express": "^5.2.1",
+        "express-rate-limit": "^7.5.1",
+        "helmet": "^8.1.0",
         "js-yaml": "^4.1.0",
         "open": "^11.0.0",
         "winston": "^3.17.0",
@@ -1427,6 +1429,24 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -5848,13 +5868,10 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
       "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.2.0"
-      },
       "engines": {
         "node": ">= 16"
       },
@@ -6462,6 +6479,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/highlight.js": {
@@ -13305,6 +13334,24 @@
         "node": ">= 12"
       }
     },
+    "node_modules/tsup/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -13788,6 +13835,24 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/web-worker": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "commander": "^11.1.0",
     "dotenv": "^17.0.1",
     "express": "^5.2.1",
+    "express-rate-limit": "^7.5.1",
+    "helmet": "^8.1.0",
     "js-yaml": "^4.1.0",
     "open": "^11.0.0",
     "winston": "^3.17.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,8 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js';
 import express, { Request, Response } from 'express';
+import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
 import logger, { enableConsoleLogging } from './logger.js';
 import { registerAuthTools } from './auth-tools.js';
 import { registerGraphTools, registerDiscoveryTools } from './graph-tools.js';
@@ -221,7 +223,32 @@ class MicrosoftGraphServer {
       const { host, port } = parseHttpOption(this.options.http);
 
       const app = express();
-      app.set('trust proxy', true);
+
+      // Trust-proxy configuration. `true` (trust every hop) is too permissive
+      // once per-IP rate limiting is in play: a client can spoof the leftmost
+      // X-Forwarded-For entry and bypass the limiter
+      // (express-rate-limit ERR_ERL_PERMISSIVE_TRUST_PROXY). Default to a single
+      // upstream hop, which fits the common reverse-proxy deployment. Override
+      // with MS365_MCP_TRUST_PROXY_HOPS=<n> for multi-hop chains, 0 to disable
+      // proxy trust, or a comma-separated subnet list for explicit ranges.
+      const trustProxyEnv = process.env.MS365_MCP_TRUST_PROXY_HOPS;
+      if (trustProxyEnv !== undefined && trustProxyEnv !== '') {
+        const asNum = Number(trustProxyEnv);
+        app.set('trust proxy', Number.isFinite(asNum) ? asNum : trustProxyEnv);
+      } else {
+        app.set('trust proxy', 1);
+      }
+
+      // Security headers. CSP is disabled because this server returns JSON and
+      // OAuth metadata, not HTML; HSTS assumes TLS is terminated upstream.
+      app.use(
+        helmet({
+          contentSecurityPolicy: false,
+          crossOriginEmbedderPolicy: false,
+          hsts: { maxAge: 31536000, includeSubDomains: true, preload: true },
+        })
+      );
+
       app.use(express.json());
       app.use(express.urlencoded({ extended: true }));
 
@@ -243,6 +270,32 @@ class MicrosoftGraphServer {
 
         next();
       });
+
+      // Per-IP rate limiting (opt out with MS365_MCP_RATE_LIMIT_DISABLED=true).
+      // Defense-in-depth for the OAuth surface (/authorize, /token, /register)
+      // and the MCP endpoint (/mcp). Limits are generous for normal usage and
+      // only fire on abuse patterns.
+      const rateLimitDisabled =
+        process.env.MS365_MCP_RATE_LIMIT_DISABLED === 'true' ||
+        process.env.MS365_MCP_RATE_LIMIT_DISABLED === '1';
+      if (!rateLimitDisabled) {
+        const authLimiter = rateLimit({
+          windowMs: 60_000,
+          max: 30,
+          standardHeaders: 'draft-7',
+          legacyHeaders: false,
+        });
+        const mcpLimiter = rateLimit({
+          windowMs: 60_000,
+          max: 120,
+          standardHeaders: 'draft-7',
+          legacyHeaders: false,
+        });
+        app.use('/authorize', authLimiter);
+        app.use('/token', authLimiter);
+        app.use('/register', authLimiter);
+        app.use('/mcp', mcpLimiter);
+      }
 
       const oauthProvider = new MicrosoftOAuthProvider(this.authManager, this.secrets!);
 

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+/**
+ * Smoke tests for the express-rate-limit middleware wired into src/server.ts.
+ *
+ * server.ts instantiates two limiters with the same shape
+ * (windowMs: 60_000 + max: {30, 120}) and mounts them on
+ * /authorize, /token, /register (auth surface) and /mcp respectively.
+ * The library itself is well-tested upstream; we only assert the behaviour
+ * that matters for this integration:
+ *
+ *  - The 30/min auth-surface limit returns 429 after 30 requests.
+ *  - The auth limiter is one shared per-IP bucket across the three routes.
+ *  - The 120/min MCP limit is more permissive and uses a separate bucket.
+ *  - Per-IP isolation holds (different X-Forwarded-For → fresh budget).
+ *  - IETF draft-7 RateLimit-* headers are emitted, legacy headers are not.
+ */
+
+function buildApp(): express.Express {
+  const app = express();
+  // Trust a single upstream hop, mirroring server.ts. The test client
+  // connects over loopback (the one trusted hop), so an X-Forwarded-For
+  // header acts as the client IP — the same semantic as a reverse proxy.
+  app.set('trust proxy', 1);
+
+  const authLimiter = rateLimit({
+    windowMs: 60_000,
+    max: 30,
+    standardHeaders: 'draft-7',
+    legacyHeaders: false,
+  });
+  const mcpLimiter = rateLimit({
+    windowMs: 60_000,
+    max: 120,
+    standardHeaders: 'draft-7',
+    legacyHeaders: false,
+  });
+  app.use('/authorize', authLimiter);
+  app.use('/token', authLimiter);
+  app.use('/register', authLimiter);
+  app.use('/mcp', mcpLimiter);
+
+  app.get('/authorize', (_req, res) => res.send('ok'));
+  app.post('/token', (_req, res) => res.send('ok'));
+  app.post('/register', (_req, res) => res.send('ok'));
+  app.post('/mcp', (_req, res) => res.send('ok'));
+  app.get('/public', (_req, res) => res.send('ok'));
+  return app;
+}
+
+describe('rate-limit middleware', () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    server = await new Promise<Server>((resolve) => {
+      const s = buildApp().listen(0, '127.0.0.1', () => resolve(s));
+    });
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  const hit = (path: string, ip: string, method = 'GET') =>
+    fetch(`${baseUrl}${path}`, { method, headers: { 'X-Forwarded-For': ip } });
+
+  it('returns 429 on the 31st /authorize hit within a minute', async () => {
+    for (let i = 0; i < 30; i++) {
+      expect((await hit('/authorize', '1.2.3.4')).status).toBe(200);
+    }
+    expect((await hit('/authorize', '1.2.3.4')).status).toBe(429);
+  });
+
+  it('shares one per-IP bucket across all auth-surface routes', async () => {
+    for (let i = 0; i < 30; i++) {
+      await hit('/authorize', '5.6.7.8');
+    }
+    expect((await hit('/authorize', '5.6.7.8')).status).toBe(429);
+    // Sibling auth route, same IP → same bucket, also blocked
+    expect((await hit('/token', '5.6.7.8', 'POST')).status).toBe(429);
+    // Separate limiter instance still has fresh budget
+    expect((await hit('/mcp', '5.6.7.8', 'POST')).status).toBe(200);
+  });
+
+  it('keeps separate buckets per IP', async () => {
+    for (let i = 0; i < 30; i++) {
+      await hit('/authorize', '9.9.9.9');
+    }
+    expect((await hit('/authorize', '9.9.9.9')).status).toBe(429);
+    expect((await hit('/authorize', '8.8.8.8')).status).toBe(200);
+  });
+
+  it('does not rate-limit routes without a limiter', async () => {
+    for (let i = 0; i < 50; i++) {
+      expect((await hit('/public', '6.6.6.6')).status).toBe(200);
+    }
+  });
+
+  it('emits IETF draft-7 RateLimit headers and no legacy headers', async () => {
+    const r = await hit('/authorize', '4.4.4.4');
+    expect(r.headers.get('ratelimit')).toMatch(/limit=30, remaining=\d+, reset=\d+/);
+    expect(r.headers.get('ratelimit-policy')).toMatch(/30;w=60/);
+    expect(r.headers.get('x-ratelimit-limit')).toBeNull();
+    expect(r.headers.get('x-ratelimit-remaining')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What
Add `helmet` security headers and per-IP `express-rate-limit` to the HTTP-mode Express app.

## Why
HTTP mode exposes the OAuth surface (`/authorize`, `/token`, `/register`) and the `/mcp` endpoint with no security headers and no flood protection.

## How
- **helmet** — security headers on every response. CSP disabled (this server returns JSON / OAuth metadata, not HTML), HSTS enabled (TLS terminated upstream).
- **express-rate-limit** (opt out with `MS365_MCP_RATE_LIMIT_DISABLED=true`) — 30 req/min per IP on the auth surface (one shared bucket across the three routes), 120 req/min on `/mcp`. IETF draft-7 RateLimit headers.

## Behavioural note — `trust proxy`
The previous `trust proxy: true` trusts every hop, which lets a client spoof the leftmost `X-Forwarded-For` entry and bypass per-IP limiting (`express-rate-limit` `ERR_ERL_PERMISSIVE_TRUST_PROXY`). The default is now a single hop. `MS365_MCP_TRUST_PROXY_HOPS=<n>` covers multi-hop chains, `0` disables proxy trust, and a comma-separated subnet list is accepted. **Single-proxy deployments (the common case) are unaffected; multi-hop deployments must now set this var.**

## Backward compatibility
helmet + rate-limit are additive (rate-limit opt-out via env). The `trust proxy` default change is the one behavioural shift — called out above for review. Adds dependencies `helmet ^8.1.0` and `express-rate-limit ^7.5.1`, a rate-limit smoke test (no new test dependency — native `fetch`), and README docs.
