### PR TITLE
feat(security): optional PII/secret redaction for log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,7 @@ Environment variables:
 - `MS365_MCP_CLOUD_TYPE=global|china`: Microsoft cloud environment (alternative to --cloud flag)
 - `LOG_LEVEL`: Set logging level (default: 'info')
 - `SILENT=true|1`: Disable console output
+- `MS365_MCP_REDACT_PII=true|1`: Scrub JWTs, Bearer headers, OAuth token fields, and email addresses from log messages before they are written (default: disabled). Useful when logs are shipped to a central store or shared host.
 - `MS365_MCP_CLIENT_ID`: Custom Azure app client ID (defaults to built-in app)
 - `MS365_MCP_TENANT_ID`: Custom tenant ID (defaults to 'common' for multi-tenant)
 - `MS365_MCP_OAUTH_TOKEN`: Pre-existing OAuth token for Microsoft Graph API (BYOT method)

--- a/src/lib/log-redactor.ts
+++ b/src/lib/log-redactor.ts
@@ -1,0 +1,60 @@
+/**
+ * Opt-in redaction of sensitive material from log output.
+ *
+ * Error messages bubbled up from upstream libraries (MSAL, fetch, the Graph
+ * SDK) routinely interpolate request URLs, Authorization headers, and token
+ * payloads into their message strings. When those land in a log file or the
+ * console they expose bearer/refresh tokens and user identifiers. Enabling
+ * `MS365_MCP_REDACT_PII` runs each log message through the patterns below.
+ *
+ * Patterns are intentionally generic (JWTs, Bearer headers, OAuth token
+ * fields, email addresses) — no jurisdiction-specific identifiers — so the
+ * filter is useful to any operator without locale assumptions.
+ */
+
+interface RedactionPattern {
+  pattern: RegExp;
+  replacement: string;
+}
+
+// Ordered most-specific first. JWTs are matched before generic token fields so
+// a `access_token=eyJ...` collapses to a single JWT marker rather than nesting.
+const REDACTIONS: RedactionPattern[] = [
+  // JSON Web Tokens (header.payload.signature) — access_token, id_token, etc.
+  {
+    pattern: /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+    replacement: '[REDACTED_JWT]',
+  },
+  // Authorization: Bearer <token>
+  {
+    pattern: /(Bearer\s+)[A-Za-z0-9._~+/-]+=*/gi,
+    replacement: '$1[REDACTED]',
+  },
+  // OAuth token fields in query strings or JSON bodies:
+  // refresh_token=..., "access_token": "...", code=..., client_secret=...
+  {
+    pattern:
+      /(["']?(?:refresh_token|access_token|id_token|client_secret|code|assertion)["']?\s*[=:]\s*["']?)[A-Za-z0-9._~+/-]+=*/gi,
+    replacement: '$1[REDACTED]',
+  },
+  // Email addresses / UPNs
+  {
+    pattern: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
+    replacement: '[REDACTED_EMAIL]',
+  },
+];
+
+/** Whether opt-in PII redaction is enabled via MS365_MCP_REDACT_PII=true|1. */
+export function redactionEnabled(): boolean {
+  const raw = process.env.MS365_MCP_REDACT_PII;
+  return raw === 'true' || raw === '1';
+}
+
+/** Applies every redaction pattern to `input` and returns the scrubbed string. */
+export function redactSensitive(input: string): string {
+  let out = input;
+  for (const { pattern, replacement } of REDACTIONS) {
+    out = out.replace(pattern, replacement);
+  }
+  return out;
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,6 +3,18 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
 import os from 'os';
+import { redactionEnabled, redactSensitive } from './lib/log-redactor.js';
+
+// Opt-in PII/secret redaction (MS365_MCP_REDACT_PII). Runs before the printf
+// so both file and console transports emit scrubbed messages. No-op unless
+// enabled, so default behaviour is unchanged.
+const redactFormat = winston.format((info) => {
+  if (!redactionEnabled()) return info;
+  if (typeof info.message === 'string') {
+    info.message = redactSensitive(info.message);
+  }
+  return info;
+});
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const logsDir =
@@ -45,6 +57,7 @@ ensureFileMode(serverLogPath);
 const logger = winston.createLogger({
   level: process.env.LOG_LEVEL || 'info',
   format: winston.format.combine(
+    redactFormat(),
     winston.format.timestamp({
       format: 'YYYY-MM-DD HH:mm:ss',
     }),
@@ -68,7 +81,11 @@ const logger = winston.createLogger({
 export const enableConsoleLogging = (): void => {
   logger.add(
     new winston.transports.Console({
-      format: winston.format.combine(winston.format.colorize(), winston.format.simple()),
+      format: winston.format.combine(
+        redactFormat(),
+        winston.format.colorize(),
+        winston.format.simple()
+      ),
       silent: process.env.SILENT === 'true' || process.env.SILENT === '1',
     })
   );

--- a/test/log-redactor.test.ts
+++ b/test/log-redactor.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { redactSensitive, redactionEnabled } from '../src/lib/log-redactor.js';
+
+describe('redactSensitive', () => {
+  const JWT =
+    'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.s9Zf-dummy_signature123';
+
+  it('redacts JWTs', () => {
+    const out = redactSensitive(`token acquired: ${JWT} done`);
+    expect(out).toBe('token acquired: [REDACTED_JWT] done');
+    expect(out).not.toContain('eyJ');
+  });
+
+  it('redacts Bearer authorization headers', () => {
+    expect(redactSensitive('Authorization: Bearer abc.DEF-123_xyz=')).toBe(
+      'Authorization: Bearer [REDACTED]'
+    );
+  });
+
+  it('redacts OAuth token fields in query strings', () => {
+    const out = redactSensitive('POST /token?code=A1b2C3&client_secret=sup3r-s3cret');
+    expect(out).toContain('code=[REDACTED]');
+    expect(out).toContain('client_secret=[REDACTED]');
+    expect(out).not.toContain('A1b2C3');
+    expect(out).not.toContain('sup3r-s3cret');
+  });
+
+  it('redacts OAuth token fields in JSON bodies', () => {
+    const out = redactSensitive('{"refresh_token": "0.AAA-refresh-value", "expires_in": 3600}');
+    expect(out).toContain('[REDACTED]');
+    expect(out).not.toContain('0.AAA-refresh-value');
+    // Non-sensitive fields survive
+    expect(out).toContain('expires_in');
+    expect(out).toContain('3600');
+  });
+
+  it('redacts email addresses / UPNs', () => {
+    expect(redactSensitive('login failed for alice.smith@contoso.com')).toBe(
+      'login failed for [REDACTED_EMAIL]'
+    );
+  });
+
+  it('leaves non-sensitive text untouched', () => {
+    const msg = 'Microsoft 365 MCP Server starting on port 3000';
+    expect(redactSensitive(msg)).toBe(msg);
+  });
+
+  it('handles multiple secrets in one message', () => {
+    const out = redactSensitive(`Bearer ${'x'.repeat(20)} for user bob@example.org`);
+    expect(out).toBe('Bearer [REDACTED] for user [REDACTED_EMAIL]');
+  });
+});
+
+describe('redactionEnabled', () => {
+  const prev = process.env.MS365_MCP_REDACT_PII;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.MS365_MCP_REDACT_PII;
+    else process.env.MS365_MCP_REDACT_PII = prev;
+  });
+
+  it('is off by default', () => {
+    delete process.env.MS365_MCP_REDACT_PII;
+    expect(redactionEnabled()).toBe(false);
+  });
+
+  it('is on for "true" and "1"', () => {
+    process.env.MS365_MCP_REDACT_PII = 'true';
+    expect(redactionEnabled()).toBe(true);
+    process.env.MS365_MCP_REDACT_PII = '1';
+    expect(redactionEnabled()).toBe(true);
+  });
+
+  it('is off for any other value', () => {
+    process.env.MS365_MCP_REDACT_PII = 'yes';
+    expect(redactionEnabled()).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
Add an opt-in filter that redacts secrets and PII from log output.

## Why
Error messages bubbled up from MSAL, fetch, and the Graph SDK routinely interpolate request URLs, Authorization headers, and token payloads into their message strings. When those reach a log file or the console they expose bearer/refresh tokens and user identifiers.

## How
Set `MS365_MCP_REDACT_PII=true|1` to scrub each log message before it is written, on both the file and console transports. Patterns are generic — JWTs, `Bearer` headers, OAuth token fields (`refresh_token` / `access_token` / `id_token` / `client_secret` / `code` / `assertion`), and email addresses — with no jurisdiction-specific identifiers.

## Backward compatibility
Disabled by default — the winston format is a no-op unless the env var is set, so existing log output is unchanged. New module `src/lib/log-redactor.ts` with unit tests per pattern; documented in the README.
