### PR TITLE
fix(auth): log MSAL error code when silent token acquisition fails

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,5 @@
 import type { AccountInfo, Configuration } from '@azure/msal-node';
-import { PublicClientApplication } from '@azure/msal-node';
+import { AuthError, PublicClientApplication } from '@azure/msal-node';
 import logger from './logger.js';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -370,6 +370,20 @@ interface AuthManagerCreateOptions {
   storage?: TokenCacheStorage;
 }
 
+/**
+ * Summarises a silent-acquire failure for logging. MSAL throws AuthError subclasses
+ * (e.g. InteractionRequiredAuthError) whose errorCode, subError and correlationId pin
+ * the cause, such as invalid_grant from the token endpoint or interaction_required.
+ * The log formatter only emits `message`, so the codes are folded into the string here.
+ */
+export function describeAuthError(error: unknown): string {
+  if (error instanceof AuthError) {
+    const suberror = error.subError ? ` / ${error.subError}` : '';
+    return `${error.errorCode}${suberror} (correlationId: ${error.correlationId || 'none'}): ${error.errorMessage}`;
+  }
+  return (error as Error).message;
+}
+
 class AuthManager {
   private config: Configuration;
   private scopes: string[];
@@ -651,8 +665,8 @@ class AuthManager {
         this.tokenExpiry = response.expiresOn ? new Date(response.expiresOn).getTime() : null;
         await this.saveTokenCache();
         return this.accessToken;
-      } catch {
-        logger.error('Silent token acquisition failed');
+      } catch (error) {
+        logger.error(`Silent token acquisition failed: ${describeAuthError(error)}`);
         throw new Error('Silent token acquisition failed');
       }
     }
@@ -1042,7 +1056,8 @@ class AuthManager {
       const response = await this.msalApp.acquireTokenSilent(silentRequest);
       await this.saveTokenCache();
       return response.accessToken;
-    } catch {
+    } catch (error) {
+      logger.error(`Silent token acquisition failed: ${describeAuthError(error)}`);
       throw new Error(
         `Failed to acquire token for account '${targetAccount.username || targetAccount.name || 'unknown'}'. ` +
           `The token may have expired. Please re-login with: --login`

--- a/test/auth-silent-error.test.ts
+++ b/test/auth-silent-error.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { AuthError } from '@azure/msal-node';
+import { describeAuthError } from '../src/auth.js';
+
+describe('describeAuthError', () => {
+  it('summarises an MSAL AuthError with code, suberror and correlation id', () => {
+    const error = new AuthError('invalid_grant', 'AADSTS70000: the grant is expired', 'bad_token');
+    error.correlationId = 'abc-123';
+
+    const summary = describeAuthError(error);
+
+    expect(summary).toContain('invalid_grant');
+    expect(summary).toContain('bad_token');
+    expect(summary).toContain('abc-123');
+    expect(summary).toContain('AADSTS70000');
+  });
+
+  it('omits the suberror segment when the AuthError has none', () => {
+    const error = new AuthError('interaction_required', 'sign in again');
+
+    const summary = describeAuthError(error);
+
+    expect(summary).toContain('interaction_required');
+    expect(summary).not.toContain(' / ');
+  });
+
+  it('falls back to the plain message for non-AuthError values', () => {
+    expect(describeAuthError(new Error('socket hang up'))).toBe('socket hang up');
+  });
+});


### PR DESCRIPTION
Both `acquireTokenSilent` call sites in `AuthManager` (`getToken` and `getTokenForAccount`) caught the MSAL failure with a bare `catch {}` and rethrew a generic message, discarding the `AuthError`. That makes the most common production failure (#522, and the silent-death symptom behind #486) undiagnosable from logs: there is no way to tell an upstream `invalid_grant` from `interaction_required` or a local cache miss.

Bind the error and log its `errorCode`, `subError` and `correlationId` via a small `describeAuthError` helper. The process-level handlers added in #493 do not cover this path, because the error is caught rather than thrown unhandled.

Example output on the stdio device-code path with a personal Microsoft account:

```
Silent token acquisition failed: invalid_grant / bad_token (correlationId: ...): AADSTS70000: The user could not be authenticated as the grant is expired.
```

Diagnostics only; no change to token behaviour. Refs #522.
