### PR TITLE
fix(config): hide fetchAllPages when pagination is disabled and refle…

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ Environment variables:
 - `MS365_MCP_MAX_TOP=<n>`: Hard cap for Graph `$top` / `top` on list requests (positive integer). When the model passes a larger value, the server clamps it to `n` so responses stay smaller. Example: `MS365_MCP_MAX_TOP=15`
 - `MS365_MCP_MAX_PAGES=<n>`: Maximum number of pages followed when a tool is called with `fetchAllPages: true` (positive integer, default `100`). Bounds memory and latency for large result sets.
 - `MS365_MCP_MAX_ITEMS=<n>`: Maximum number of items accumulated when `fetchAllPages: true` (positive integer, default `10000`). Pagination stops and the response is truncated once this many items are collected.
-- `MS365_MCP_ALLOW_PAGINATION=0|false|no`: Disable multi-page following entirely. When set, `fetchAllPages: true` returns only the first page (default: pagination enabled).
+- `MS365_MCP_ALLOW_PAGINATION=0|false|no`: Disable multi-page following entirely. When set, the `fetchAllPages` parameter is not advertised on tools, and any request that still passes it returns only the first page (default: pagination enabled).
 - `MS365_MCP_BODY_FORMAT=html`: Return email bodies as HTML instead of plain text (default: text)
 - `MS365_MCP_CLOUD_TYPE=global|china`: Microsoft cloud environment (alternative to --cloud flag)
 - `LOG_LEVEL`: Set logging level (default: 'info')

--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -337,6 +337,21 @@ describe('graph-tools', () => {
 
         // Disabled → first page only, no nextLink following
         expect(graphClient.graphRequest).toHaveBeenCalledTimes(1);
+        // Disabled → the parameter is not advertised to the model at all
+        expect(server.tools.get('test-tool')!.schema.fetchAllPages).toBeUndefined();
+      });
+
+      it('should reflect MS365_MCP_MAX_PAGES in the fetchAllPages description', async () => {
+        process.env.MS365_MCP_MAX_PAGES = '7';
+        mockEndpoints.push(makeEndpoint());
+        mockEndpointsJson = [makeConfig()];
+
+        const server = createMockServer();
+        const { registerGraphTools } = await loadModule();
+        registerGraphTools(server as any, createMockGraphClient() as any);
+
+        const schema = server.tools.get('test-tool')!.schema.fetchAllPages;
+        expect(schema.description).toContain('up to 7 pages');
       });
     });
   });

--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -341,6 +341,18 @@ describe('graph-tools', () => {
         expect(server.tools.get('test-tool')!.schema.fetchAllPages).toBeUndefined();
       });
 
+      it('should advertise fetchAllPages when pagination is enabled', async () => {
+        delete process.env.MS365_MCP_ALLOW_PAGINATION;
+        mockEndpoints.push(makeEndpoint());
+        mockEndpointsJson = [makeConfig()];
+
+        const server = createMockServer();
+        const { registerGraphTools } = await loadModule();
+        registerGraphTools(server as any, createMockGraphClient() as any);
+
+        expect(server.tools.get('test-tool')!.schema.fetchAllPages).toBeDefined();
+      });
+
       it('should reflect MS365_MCP_MAX_PAGES in the fetchAllPages description', async () => {
         process.env.MS365_MCP_MAX_PAGES = '7';
         mockEndpoints.push(makeEndpoint());

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -849,11 +849,12 @@ export function registerGraphTools(
       }
     }
 
-    if (tool.method.toUpperCase() === 'GET' && tool.path.includes('/')) {
+    if (tool.method.toUpperCase() === 'GET' && tool.path.includes('/') && paginationAllowed()) {
+      const maxPages = positiveIntFromEnv('MS365_MCP_MAX_PAGES', DEFAULT_MAX_PAGES);
       paramSchema['fetchAllPages'] = z
         .boolean()
         .describe(
-          'Follow @odata.nextLink and merge up to 100 pages into one response. ' +
+          `Follow @odata.nextLink and merge up to ${maxPages} pages into one response. ` +
             'Can return enormous payloads—only when the user explicitly needs a full export. ' +
             'Prefer a small $top first, then paginate or narrow with $filter/$search.'
         )


### PR DESCRIPTION
…ct MS365_MCP_MAX_PAGES in its description

When MS365_MCP_ALLOW_PAGINATION disables multi-page following, the fetchAllPages parameter was still advertised to the model and silently ignored, with only a server-side log explaining why. Skip registering the parameter instead. Also interpolate the configured page cap into the parameter description rather than hardcoding 100 (follow-up to #519).