### PR TITLE
fix(logging): stop PII redaction from scrubbing status and error codes

### DIFF
--- a/src/lib/log-redactor.ts
+++ b/src/lib/log-redactor.ts
@@ -31,10 +31,18 @@ const REDACTIONS: RedactionPattern[] = [
     replacement: '$1[REDACTED]',
   },
   // OAuth token fields in query strings or JSON bodies:
-  // refresh_token=..., "access_token": "...", code=..., client_secret=...
+  // refresh_token=..., "access_token": "...", client_secret=...
+  // The \b keeps composite keys like `statusCode` from matching via a substring.
   {
     pattern:
-      /(["']?(?:refresh_token|access_token|id_token|client_secret|code|assertion)["']?\s*[=:]\s*["']?)[A-Za-z0-9._~+/-]+=*/gi,
+      /(["']?\b(?:refresh_token|access_token|id_token|client_secret|assertion)["']?\s*[=:]\s*["']?)[A-Za-z0-9._~+/-]+=*/gi,
+    replacement: '$1[REDACTED]',
+  },
+  // OAuth authorization codes, query-string form only (?code=... / &code=...).
+  // `code:` in JSON or prose is an error/status code (ECONNRESET, AADSTS...),
+  // which must stay readable for diagnostics.
+  {
+    pattern: /([?&]code=)[^&\s"']+/gi,
     replacement: '$1[REDACTED]',
   },
   // Email addresses / UPNs

--- a/test/log-redactor.test.ts
+++ b/test/log-redactor.test.ts
@@ -45,6 +45,22 @@ describe('redactSensitive', () => {
     expect(redactSensitive(msg)).toBe(msg);
   });
 
+  it('leaves HTTP status codes and error codes untouched', () => {
+    const statusMsg = 'Graph API request failed: statusCode: 401';
+    expect(redactSensitive(statusMsg)).toBe(statusMsg);
+
+    const errMsg = 'fetch failed { code: ENOTFOUND }';
+    expect(redactSensitive(errMsg)).toBe(errMsg);
+
+    const jsonErr = '{"statusCode":401,"code":"ECONNRESET"}';
+    expect(redactSensitive(jsonErr)).toBe(jsonErr);
+  });
+
+  it('still redacts authorization codes in query strings', () => {
+    const out = redactSensitive('redirect to /callback?code=AQABAAIAAAD.0.abc-123&state=xyz');
+    expect(out).toBe('redirect to /callback?code=[REDACTED]&state=xyz');
+  });
+
   it('handles multiple secrets in one message', () => {
     const out = redactSensitive(`Bearer ${'x'.repeat(20)} for user bob@example.org`);
     expect(out).toBe('Bearer [REDACTED] for user [REDACTED_EMAIL]');


### PR DESCRIPTION
The OAuth-field pattern matched any `code` substring followed by = or :, so diagnostics like `statusCode: 401` and `"code":"ECONNRESET"` were redacted when MS365_MCP_REDACT_PII was enabled. Anchor the field names with a word boundary and only redact `code` in its query-string form (?code=... / &code=...), where OAuth authorization codes actually appear.