### PR TITLE
fix(auth): suggest the consumers authority when an MSA refresh token is rejected on common

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ Environment variables:
 - `SILENT=true|1`: Disable console output
 - `MS365_MCP_REDACT_PII=true|1`: Scrub JWTs, Bearer headers, OAuth token fields, and email addresses from log messages before they are written (default: disabled). Useful when logs are shipped to a central store or shared host.
 - `MS365_MCP_CLIENT_ID`: Custom Azure app client ID (defaults to built-in app)
-- `MS365_MCP_TENANT_ID`: Custom tenant ID (defaults to 'common' for multi-tenant)
+- `MS365_MCP_TENANT_ID`: Custom tenant ID (defaults to 'common' for multi-tenant). **Personal Microsoft accounts should set this to `consumers`** - as of June 2026, refresh tokens issued via the default 'common' authority are rejected at the first refresh, so sessions die roughly an hour after login
 - `MS365_MCP_OAUTH_TOKEN`: Pre-existing OAuth token for Microsoft Graph API (BYOT method)
 - `MS365_MCP_KEYVAULT_URL`: Azure Key Vault URL for secrets management (see Azure Key Vault section)
 - `MS365_MCP_TOKEN_CACHE_PATH`: Custom file path for MSAL token cache (see Token Storage below)

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -384,6 +384,38 @@ export function describeAuthError(error: unknown): string {
   return (error as Error).message;
 }
 
+/** Home tenant id shared by all personal Microsoft accounts (MSA). */
+const MSA_HOME_TENANT_ID = '9188040d-6c67-4c5b-b112-36a304b66dad';
+
+/**
+ * Builds a remediation hint when a personal Microsoft account's refresh token is
+ * rejected on the default 'common' authority. As of June 2026 the token endpoint
+ * returns invalid_grant for MSA refresh tokens issued via /common, while the
+ * same login via /consumers refreshes fine - so the fix is a config change plus
+ * one re-login, which a generic "token may have expired" message does not
+ * convey. Returns null when the failure does not match that signature.
+ */
+export function consumersAuthorityHint(
+  error: unknown,
+  account: AccountInfo | null | undefined,
+  authority: string | undefined
+): string | null {
+  if (
+    error instanceof AuthError &&
+    error.errorCode === 'invalid_grant' &&
+    account?.tenantId === MSA_HOME_TENANT_ID &&
+    (!authority || /\/common\/?$/i.test(authority))
+  ) {
+    return (
+      `This looks like a known issue (June 2026) where Microsoft rejects refresh tokens ` +
+      `issued to personal accounts via the default 'common' authority. If this server is ` +
+      `used only with personal accounts, set MS365_MCP_TENANT_ID=consumers and re-login ` +
+      `with: --login`
+    );
+  }
+  return null;
+}
+
 class AuthManager {
   private config: Configuration;
   private scopes: string[];
@@ -666,8 +698,13 @@ class AuthManager {
         await this.saveTokenCache();
         return this.accessToken;
       } catch (error) {
-        logger.error(`Silent token acquisition failed: ${describeAuthError(error)}`);
-        throw new Error('Silent token acquisition failed');
+        const hint = consumersAuthorityHint(error, currentAccount, this.config.auth.authority);
+        logger.error(
+          `Silent token acquisition failed: ${describeAuthError(error)}${hint ? ` ${hint}` : ''}`
+        );
+        throw new Error(
+          hint ? `Silent token acquisition failed. ${hint}` : 'Silent token acquisition failed'
+        );
       }
     }
 
@@ -1057,10 +1094,13 @@ class AuthManager {
       await this.saveTokenCache();
       return response.accessToken;
     } catch (error) {
-      logger.error(`Silent token acquisition failed: ${describeAuthError(error)}`);
+      const hint = consumersAuthorityHint(error, targetAccount, this.config.auth.authority);
+      logger.error(
+        `Silent token acquisition failed: ${describeAuthError(error)}${hint ? ` ${hint}` : ''}`
+      );
       throw new Error(
         `Failed to acquire token for account '${targetAccount.username || targetAccount.name || 'unknown'}'. ` +
-          `The token may have expired. Please re-login with: --login`
+          (hint ?? 'The token may have expired. Please re-login with: --login')
       );
     }
   }

--- a/test/auth-silent-error.test.ts
+++ b/test/auth-silent-error.test.ts
@@ -1,6 +1,18 @@
-import { describe, it, expect } from 'vitest';
+import type { AccountInfo, Configuration } from '@azure/msal-node';
+import { describe, it, expect, vi } from 'vitest';
 import { AuthError } from '@azure/msal-node';
-import { describeAuthError } from '../src/auth.js';
+import AuthManager, { consumersAuthorityHint, describeAuthError } from '../src/auth.js';
+
+vi.mock('../src/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const MSA_TENANT = '9188040d-6c67-4c5b-b112-36a304b66dad';
+const COMMON_AUTHORITY = 'https://login.microsoftonline.com/common';
 
 describe('describeAuthError', () => {
   it('summarises an MSAL AuthError with code, suberror and correlation id', () => {
@@ -26,5 +38,122 @@ describe('describeAuthError', () => {
 
   it('falls back to the plain message for non-AuthError values', () => {
     expect(describeAuthError(new Error('socket hang up'))).toBe('socket hang up');
+  });
+});
+
+describe('consumersAuthorityHint', () => {
+  function msaAccount(tenantId: string = MSA_TENANT): AccountInfo {
+    return { tenantId } as AccountInfo;
+  }
+
+  // No subError on purpose: the guard must key on errorCode alone, because
+  // real-world invalid_grant responses do not always carry one.
+  function invalidGrant(): AuthError {
+    return new AuthError('invalid_grant', 'AADSTS70000: the grant is expired');
+  }
+
+  it('suggests the consumers authority for an MSA invalid_grant on common', () => {
+    const hint = consumersAuthorityHint(invalidGrant(), msaAccount(), COMMON_AUTHORITY);
+
+    expect(hint).toContain('MS365_MCP_TENANT_ID=consumers');
+    expect(hint).toContain('--login');
+  });
+
+  it('treats the authority as common when cased differently or absent', () => {
+    expect(
+      consumersAuthorityHint(
+        invalidGrant(),
+        msaAccount(),
+        'https://login.microsoftonline.com/Common'
+      )
+    ).not.toBeNull();
+    // MSAL itself defaults a missing authority to common.
+    expect(consumersAuthorityHint(invalidGrant(), msaAccount(), undefined)).not.toBeNull();
+  });
+
+  it('only matches the common tenant segment exactly', () => {
+    for (const tenant of ['commonish', 'organizations', 'consumers']) {
+      expect(
+        consumersAuthorityHint(
+          invalidGrant(),
+          msaAccount(),
+          `https://login.microsoftonline.com/${tenant}`
+        )
+      ).toBeNull();
+    }
+  });
+
+  it('returns null for a work or school account', () => {
+    const workTenant = '11111111-1111-1111-1111-111111111111';
+
+    expect(
+      consumersAuthorityHint(invalidGrant(), msaAccount(workTenant), COMMON_AUTHORITY)
+    ).toBeNull();
+  });
+
+  it('returns null for other error codes, non-AuthError values and missing accounts', () => {
+    expect(
+      consumersAuthorityHint(
+        new AuthError('no_tokens_found', 'no cached tokens'),
+        msaAccount(),
+        COMMON_AUTHORITY
+      )
+    ).toBeNull();
+    expect(
+      consumersAuthorityHint(new Error('socket hang up'), msaAccount(), COMMON_AUTHORITY)
+    ).toBeNull();
+    expect(consumersAuthorityHint(invalidGrant(), null, COMMON_AUTHORITY)).toBeNull();
+  });
+});
+
+describe('silent failure hints at the call sites', () => {
+  const msalConfig: Configuration = {
+    auth: {
+      clientId: 'test-client',
+      authority: COMMON_AUTHORITY,
+    },
+  };
+
+  const msaAccount = {
+    username: 'personal@example.com',
+    name: 'Personal User',
+    homeAccountId: 'personal.home',
+    tenantId: MSA_TENANT,
+  } as AccountInfo;
+
+  function createAuth() {
+    const tokenCache = {
+      getAllAccounts: vi.fn().mockResolvedValue([msaAccount]),
+      removeAccount: vi.fn().mockResolvedValue(undefined),
+    };
+    const msalApp = {
+      getTokenCache: vi.fn(() => tokenCache),
+      acquireTokenSilent: vi
+        .fn()
+        .mockRejectedValue(
+          new AuthError('invalid_grant', 'AADSTS70000: the grant is expired', 'bad_token')
+        ),
+    };
+    const auth = new AuthManager(msalConfig, ['User.Read']);
+
+    Object.assign(auth as unknown as Record<string, unknown>, {
+      msalApp,
+      saveTokenCache: vi.fn(),
+      saveSelectedAccount: vi.fn(),
+    });
+
+    return auth;
+  }
+
+  it('getToken appends the consumers hint to the generic failure', async () => {
+    await expect(createAuth().getToken()).rejects.toThrow(
+      /Silent token acquisition failed\. This looks like a known issue/
+    );
+  });
+
+  it('getTokenForAccount replaces the generic re-login advice with the hint', async () => {
+    await expect(createAuth().getTokenForAccount()).rejects.toThrow(
+      /personal@example\.com'\. This looks like a known issue/
+    );
   });
 });


### PR DESCRIPTION
## What

When silent token acquisition fails with `invalid_grant` for a personal Microsoft account on the default `common` authority, the error and log now tell the user to set `MS365_MCP_TENANT_ID=consumers` and re-login, instead of the generic "token may have expired". README documents the same on the env var.

## Why

Follow-up to #522. As of June 2026, MSA refresh tokens issued via `/common` are rejected at the first refresh (`invalid_grant` / AADSTS70000), so stdio sessions die roughly an hour after login - that's the access-token lifetime, with the refresh failing underneath. The same login via `/consumers` keeps refreshing fine: on the default bundled client, two cache-verified refreshes succeeded at 61 minutes and 2h14m post-login, where `common` failed at its first refresh.

The generic message sends affected users in circles: re-logging in via `common` just restarts the same one-hour clock.

(One subtlety for reviewers: MSAL's proactive-refresh path swallows 4xx refresh failures, so the failure - and therefore the hint - only surfaces at hard expiry. Consistent with the ~1h observed timing.)

## Scope

- Covers the two `acquireTokenSilent` catch sites in `src/auth.ts` - the only emitters of the generic advice. Everything user-visible in stdio mode (Graph calls, `--verify-login`, the login/verify-login tools) funnels through them.
- Known sibling not covered: the HTTP/OAuth `/token` refresh path (`src/lib/microsoft-auth.ts`) surfaces the same upstream failure as a raw RFC 6749 error body to machine clients; the README note applies to that mode too. Happy to follow up if wanted.
- Considered auto-switching MSA accounts to `/consumers` on the silent request, left out deliberately: I've only verified refreshing a token *issued* via `/consumers`; refreshing a `/common`-issued RT against `/consumers` is untested, and guessing wrong there would be worse than a hint. A proactive warning at login time (MSA + `common` detected) would prevent the hour of confusion rather than explain it afterwards - also happy to follow up with either shape if you'd prefer.

## Testing

- New tests in `test/auth-silent-error.test.ts`: the helper's guard conditions (authority anchoring, casing, MSA-vs-work tenant, error-code filtering) plus both call-site compositions, asserting the rendered error messages
- `npm run verify` green: generate, eslint, prettier --check, tsup, 422 tests
