### PR TITLE
fix(generator): trace nested anyOf refs in inline request/response bo…

### DIFF
--- a/bin/modules/simplified-openapi.mjs
+++ b/bin/modules/simplified-openapi.mjs
@@ -508,6 +508,14 @@ function findUsedSchemas(openApiSpec) {
             );
             schemasToProcess.push(schemaName);
           }
+          // Trace refs nested anywhere in an inline request body (e.g. a property's
+          // anyOf: [{$ref}, {nullable object}]). Without this they're pruned as unused,
+          // then stripped as a "broken reference", degrading the body to a bare object.
+          if (content.schema) {
+            findRefsInObject(content.schema, (ref) =>
+              schemasToProcess.push(ref.replace('#/components/schemas/', ''))
+            );
+          }
         });
       }
 
@@ -546,6 +554,12 @@ function findUsedSchemas(openApiSpec) {
                     schemasToProcess.push(schemaName);
                   }
                 });
+              }
+              // Trace refs nested anywhere in an inline response schema.
+              if (content.schema) {
+                findRefsInObject(content.schema, (ref) =>
+                  schemasToProcess.push(ref.replace('#/components/schemas/', ''))
+                );
               }
             });
           }

--- a/test/generator-schema-pruning.test.ts
+++ b/test/generator-schema-pruning.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+// The generated client is produced by `npm run generate` (run in CI before tests).
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const client = readFileSync(path.join(__dirname, '..', 'src', 'generated', 'client.ts'), 'utf8');
+
+// Regression guard for the nested-anyOf pruning fix (bin/modules/simplified-openapi.mjs).
+// These component schemas are referenced only via `anyOf: [{ $ref }, { nullable object }]`
+// nested inside an inline request body property. findUsedSchemas previously did not trace
+// those nested refs, so pruneUnusedSchemas removed them and the later pass stripped the
+// now-dangling reference as "broken" — degrading the request body to a bare object.
+// Each schema below corresponds to a real tool whose body would otherwise be untyped.
+const PRESERVED: Array<[string, string]> = [
+  ['microsoft_graph_driveRecipient', 'share-drive-item (invite) recipients'],
+  ['microsoft_graph_driveItemUploadableProperties', 'create-upload-session item'],
+  ['microsoft_graph_attachmentItem', 'create-mail-attachment-upload-session'],
+  ['microsoft_graph_teamworkActivityTopic', 'send-my-activity-notification topic'],
+];
+
+describe('generator preserves nested-anyOf request-body schemas', () => {
+  for (const [schema, usedBy] of PRESERVED) {
+    it(`keeps ${schema} typed (${usedBy})`, () => {
+      expect(client, `${schema} was pruned — nested-anyOf ref tracing regressed`).toContain(
+        `const ${schema} =`
+      );
+    });
+  }
+});


### PR DESCRIPTION
…dies

Schemas referenced only via anyOf: [{$ref}, {nullable object}] nested inside an inline request body were not traced by findUsedSchemas, so pruneUnusedSchemas removed them and the later pass stripped the dangling ref as "broken" — degrading the request body to a bare object.

Restores typed bodies for share-drive-item, create-upload-session, create-mail-attachment-upload-session and send-my-activity-notification. Adds a regression test asserting the rescued schemas survive in the generated client.