### PR TITLE
feat(endpoints): add site-scoped OneNote section group tools

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -945,6 +945,27 @@
     "workScopes": ["Notes.Read"]
   },
   {
+    "pathPattern": "/sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups",
+    "method": "get",
+    "toolName": "list-sharepoint-site-onenote-notebook-section-groups",
+    "presets": ["onenote", "work"],
+    "workScopes": ["Notes.Read"]
+  },
+  {
+    "pathPattern": "/sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections",
+    "method": "get",
+    "toolName": "list-sharepoint-site-onenote-section-group-sections",
+    "presets": ["onenote", "work"],
+    "workScopes": ["Notes.Read"]
+  },
+  {
+    "pathPattern": "/sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sectionGroups",
+    "method": "get",
+    "toolName": "list-sharepoint-site-onenote-section-group-section-groups",
+    "presets": ["onenote", "work"],
+    "workScopes": ["Notes.Read"]
+  },
+  {
     "pathPattern": "/sites/{site-id}/onenote/pages/{onenotePage-id}/content",
     "method": "get",
     "toolName": "get-sharepoint-site-onenote-page-content",


### PR DESCRIPTION
Adds list tools for section groups under a SharePoint site notebook, and for the sections and nested section groups inside a section group, so the full OneNote hierarchy on a site is traversable without falling back to raw graph-batch calls.

Closes #529