### PR TITLE
feat(auth): add --extra-scopes to append Graph scopes to the token re…

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,18 @@ Scope coverage is hierarchy-aware: for example, `Mail.ReadWrite` covers tools th
 
 In HTTP mode, OAuth discovery advertises the effective filtered permissions so clients request the same consent surface. On-Behalf-Of mode (`--obo`) still advertises `api://<clientId>/access_as_user` for protected-resource metadata; `--allowed-scopes` does not override OBO.
 
+### Requesting extra scopes
+
+`--allowed-scopes` only ever _narrows_ the token request. To request a Graph scope that no bundled tool needs — for example to drive an endpoint via `graph-batch` — use `--extra-scopes` (or `MS365_MCP_EXTRA_SCOPES`). These scopes are appended verbatim to the token request, on top of the tool-derived scopes.
+
+```bash
+npx @softeria/ms-365-mcp-server \
+  --org-mode \
+  --extra-scopes 'CopilotPackages.ReadWrite.All'
+```
+
+This is for use with your own Azure app registration (`MS365_MCP_CLIENT_ID` / `MS365_MCP_CLIENT_SECRET`): the default Softeria app only declares a lean, fixed permission set, so request additional scopes against an app you control (your tenant admin consents to them there). CLI value takes precedence over the env var; an empty value fails at startup.
+
 ## Organization/Work Mode
 
 To access work/school features (Teams, SharePoint, etc.), enable organization mode using any of these flags:
@@ -542,6 +554,7 @@ The following options can be used when running ms-365-mcp-server directly from t
 --force-work-scopes Backwards compatibility alias for --org-mode (deprecated)
 --cloud <type>    Microsoft cloud environment: global (default) or china (21Vianet)
 --allowed-scopes <scopes> Limit exposed tools to Graph scopes covered by this allowlist
+--extra-scopes <scopes> Append additional Graph scopes to the token request (for use with your own app registration + graph-batch)
 --expected-username <username> Require local MSAL auth to use this account username
 --expected-home-account-id <id> Require local MSAL auth to use this exact homeAccountId
 ```

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -69,6 +69,7 @@ interface AllowedScopeOptions {
   enabledTools?: string;
   readOnly?: boolean;
   allowedScopes?: string;
+  extraScopes?: string;
 }
 
 interface DisabledToolScope {
@@ -326,7 +327,16 @@ function buildAllowedScopeDiagnostics(options: AllowedScopeOptions = {}): ScopeD
 }
 
 function resolveAuthScopes(options: AllowedScopeOptions = {}): string[] {
-  return buildAllowedScopeDiagnostics(options).effectivePermissions;
+  const toolScopes = buildAllowedScopeDiagnostics(options).effectivePermissions;
+  // Extra scopes are appended verbatim to the token request, independent of the tool
+  // surface and the allowed-scopes filter. They let a user on their own app registration
+  // request scopes no bundled tool needs (e.g. CopilotPackages.ReadWrite.All) and then
+  // drive the matching endpoints via graph-batch.
+  const extraScopes = parseAllowedScopes(options.extraScopes);
+  if (!extraScopes || extraScopes.length === 0) {
+    return toolScopes;
+  }
+  return Array.from(new Set([...toolScopes, ...extraScopes]));
 }
 
 function buildScopeDiagnostics(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,6 +48,10 @@ program
     'Limit exposed tools to Graph scopes covered by this whitespace-separated allowlist'
   )
   .option(
+    '--extra-scopes <scopes>',
+    'Append additional Graph scopes (whitespace-separated) to the token request, beyond those derived from enabled tools. Use with your own app registration (MS365_MCP_CLIENT_ID/SECRET) to request scopes the default app does not declare, then call the endpoints via graph-batch.'
+  )
+  .option(
     '--preset <names>',
     'Use preset tool categories (comma-separated). Available: mail, calendar, files, personal, work, excel, contacts, tasks, onenote, search, users, all'
   )
@@ -112,6 +116,7 @@ export interface CommandOptions {
   enableAuthTools?: boolean;
   enabledTools?: string;
   allowedScopes?: string;
+  extraScopes?: string;
   preset?: string;
   listPresets?: boolean;
   listPermissions?: boolean;
@@ -177,6 +182,18 @@ export function parseArgs(): CommandOptions {
     console.error(
       'Error: --allowed-scopes / MS365_MCP_ALLOWED_SCOPES was provided but is empty. ' +
         'Provide one or more whitespace-separated scopes, or omit it to use tool-derived scopes.'
+    );
+    process.exit(1);
+  }
+
+  if (options.extraScopes === undefined && process.env.MS365_MCP_EXTRA_SCOPES !== undefined) {
+    options.extraScopes = process.env.MS365_MCP_EXTRA_SCOPES;
+  }
+
+  if (options.extraScopes !== undefined && options.extraScopes.trim() === '') {
+    console.error(
+      'Error: --extra-scopes / MS365_MCP_EXTRA_SCOPES was provided but is empty. ' +
+        'Provide one or more whitespace-separated scopes, or omit it.'
     );
     process.exit(1);
   }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -51,6 +51,7 @@ describe('CLI Module', () => {
     vi.clearAllMocks();
     commanderMocks.mockCommand.opts.mockReturnValue({ file: 'test.xlsx' });
     delete process.env.MS365_MCP_ALLOWED_SCOPES;
+    delete process.env.MS365_MCP_EXTRA_SCOPES;
     delete process.env.MS365_MCP_EXPECTED_USERNAME;
     delete process.env.MS365_MCP_EXPECTED_HOME_ACCOUNT_ID;
     delete process.env.MS365_MCP_AUTH_CACHE_COMMAND;
@@ -58,6 +59,7 @@ describe('CLI Module', () => {
 
   afterEach(() => {
     delete process.env.MS365_MCP_ALLOWED_SCOPES;
+    delete process.env.MS365_MCP_EXTRA_SCOPES;
     delete process.env.MS365_MCP_EXPECTED_USERNAME;
     delete process.env.MS365_MCP_EXPECTED_HOME_ACCOUNT_ID;
     delete process.env.MS365_MCP_AUTH_CACHE_COMMAND;
@@ -113,6 +115,43 @@ describe('CLI Module', () => {
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('MS365_MCP_ALLOWED_SCOPES')
       );
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('should parse --extra-scopes from CLI options', () => {
+      commanderMocks.mockCommand.opts.mockReturnValue({
+        extraScopes: 'CopilotPackages.ReadWrite.All',
+      });
+
+      const result = parseArgs();
+
+      expect(result.extraScopes).toBe('CopilotPackages.ReadWrite.All');
+    });
+
+    it('should use MS365_MCP_EXTRA_SCOPES as a fallback', () => {
+      process.env.MS365_MCP_EXTRA_SCOPES = 'CopilotPackages.ReadWrite.All';
+      commanderMocks.mockCommand.opts.mockReturnValue({});
+
+      const result = parseArgs();
+
+      expect(result.extraScopes).toBe('CopilotPackages.ReadWrite.All');
+    });
+
+    it('should prefer CLI extra scopes over environment extra scopes', () => {
+      process.env.MS365_MCP_EXTRA_SCOPES = 'Foo.Read';
+      commanderMocks.mockCommand.opts.mockReturnValue({ extraScopes: 'Bar.Read' });
+
+      const result = parseArgs();
+
+      expect(result.extraScopes).toBe('Bar.Read');
+    });
+
+    it('should fail closed when extra scopes are supplied empty', () => {
+      commanderMocks.mockCommand.opts.mockReturnValue({ extraScopes: '   ' });
+
+      parseArgs();
+
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--extra-scopes'));
       expect(process.exit).toHaveBeenCalledWith(1);
     });
 

--- a/test/scope-derivation.test.ts
+++ b/test/scope-derivation.test.ts
@@ -110,6 +110,39 @@ describe('allowed scope helpers', () => {
 
       expect(scopes).toEqual(['Mail.Read']);
     });
+
+    it('appends extra scopes to the tool-derived scopes', () => {
+      const base = resolveAuthScopes({ enabledTools: 'list-mail-messages', readOnly: true });
+      const withExtra = resolveAuthScopes({
+        enabledTools: 'list-mail-messages',
+        readOnly: true,
+        extraScopes: 'CopilotPackages.ReadWrite.All',
+      });
+
+      expect(withExtra).toEqual([...base, 'CopilotPackages.ReadWrite.All']);
+    });
+
+    it('appends extra scopes even when an allowed-scopes filter is applied', () => {
+      const scopes = resolveAuthScopes({
+        enabledTools: 'list-mail-messages',
+        allowedScopes: 'Mail.Read',
+        readOnly: true,
+        extraScopes: 'CopilotPackages.ReadWrite.All',
+      });
+
+      expect(scopes).toContain('Mail.Read');
+      expect(scopes).toContain('CopilotPackages.ReadWrite.All');
+    });
+
+    it('deduplicates an extra scope already derived from a tool', () => {
+      const scopes = resolveAuthScopes({
+        enabledTools: 'list-mail-messages',
+        readOnly: true,
+        extraScopes: 'Mail.Read Mail.Read',
+      });
+
+      expect(scopes.filter((s) => s === 'Mail.Read')).toHaveLength(1);
+    });
   });
 
   describe('collapseScopeHierarchy', () => {


### PR DESCRIPTION
…quest

Adds --extra-scopes / MS365_MCP_EXTRA_SCOPES to request additional Graph scopes beyond those derived from the enabled tools. Scopes are appended verbatim to the token request, independent of the tool surface and the --allowed-scopes filter. Intended for use with a custom app registration so users can request scopes the default app does not declare (e.g. CopilotPackages.ReadWrite.All) and call the endpoints via graph-batch, without expanding the shared app's permission set.

Closes #505