### PR TITLE
feat(auth): support OR-group scopes for endpoints with permission alt…

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -21,8 +21,11 @@ interface EndpointConfig {
   pathPattern: string;
   method: string;
   toolName: string;
-  scopes?: string[];
-  workScopes?: string[];
+  // A flat string[] is a single AND-group (all scopes required). A nested string[][]
+  // expresses alternatives: the endpoint is satisfied if ALL scopes in ANY one group are
+  // held (e.g. copilot-retrieve needs Files.Read.All + Sites.Read.All, OR ExternalItem.Read.All).
+  scopes?: string[] | string[][];
+  workScopes?: string[] | string[][];
   llmTip?: string;
   readOnly?: boolean;
   presets?: string[]; // Presets this endpoint belongs to (mail, outlook, personal, ...)
@@ -105,13 +108,80 @@ function getEndpointRequiredScopes(
   }
 
   const scopes = new Set<string>();
-  if (endpoint.scopes && Array.isArray(endpoint.scopes)) {
-    endpoint.scopes.forEach((scope) => scopes.add(scope));
-  }
-  if (includeWorkAccountScopes && endpoint.workScopes && Array.isArray(endpoint.workScopes)) {
-    endpoint.workScopes.forEach((scope) => scopes.add(scope));
-  }
+  getEndpointScopeGroups(endpoint, includeWorkAccountScopes).forEach((group) =>
+    group.forEach((scope) => scopes.add(scope))
+  );
   return Array.from(scopes);
+}
+
+/**
+ * Normalizes a scopes/workScopes value into a list of alternative AND-groups.
+ * A flat string[] becomes a single group; a nested string[][] is already groups.
+ */
+function toScopeGroups(value?: string[] | string[][]): string[][] {
+  if (!value || value.length === 0) {
+    return [];
+  }
+  return Array.isArray(value[0]) ? (value as string[][]) : [value as string[]];
+}
+
+/**
+ * Returns the alternative scope groups for an endpoint. The endpoint is satisfied if ALL
+ * scopes in ANY single group are held. scopes and workScopes are mutually exclusive per
+ * endpoints.json validation, so in practice only one side contributes groups.
+ */
+function getEndpointScopeGroups(
+  endpoint: Pick<EndpointConfig, 'scopes' | 'workScopes'> | undefined,
+  includeWorkAccountScopes: boolean = false
+): string[][] {
+  if (!endpoint) {
+    return [];
+  }
+  const groups = [...toScopeGroups(endpoint.scopes)];
+  if (includeWorkAccountScopes) {
+    groups.push(...toScopeGroups(endpoint.workScopes));
+  }
+  return groups;
+}
+
+/**
+ * The scopes to request at login for an endpoint: the primary (first) group only.
+ * Microsoft's guidance is to consent to least-privileged scopes and add higher-privileged
+ * ones on demand, so for OR-group endpoints we request the first group and leave the rest
+ * to --extra-scopes. Flat (single-group) endpoints are unaffected.
+ */
+function getEndpointLoginScopes(
+  endpoint: Pick<EndpointConfig, 'scopes' | 'workScopes'> | undefined,
+  includeWorkAccountScopes: boolean = false
+): string[] {
+  const groups = getEndpointScopeGroups(endpoint, includeWorkAccountScopes);
+  return groups.length > 0 ? groups[0] : [];
+}
+
+/**
+ * Gate check for OR-group endpoints. Returns [] (allowed) if any group is fully covered by
+ * allowedScopes; otherwise the missing scopes of the closest group (fewest missing), for
+ * diagnostics. With a single group this matches getMissingAllowedScopes.
+ */
+function getMissingAllowedScopesForGroups(
+  scopeGroups: string[][],
+  allowedScopes?: string[]
+): string[] {
+  if (allowedScopes === undefined || scopeGroups.length === 0) {
+    return [];
+  }
+  const coveredAllowedScopes = new Set(collapseScopeHierarchy(allowedScopes));
+  let closest: string[] | undefined;
+  for (const group of scopeGroups) {
+    const missing = group.filter((scope) => !coveredAllowedScopes.has(scope));
+    if (missing.length === 0) {
+      return [];
+    }
+    if (!closest || missing.length < closest.length) {
+      closest = missing;
+    }
+  }
+  return closest ?? [];
 }
 
 function collapseRedundantScopes(scopes: string[]): string[] {
@@ -167,7 +237,7 @@ function buildScopesFromEndpoints(
       return;
     }
 
-    getEndpointRequiredScopes(endpoint, includeWorkAccountScopes).forEach((scope) =>
+    getEndpointLoginScopes(endpoint, includeWorkAccountScopes).forEach((scope) =>
       scopesSet.add(scope)
     );
   });
@@ -270,6 +340,9 @@ function buildAllowedScopeDiagnostics(options: AllowedScopeOptions = {}): ScopeD
 
   const normalToolScopes = new Set<string>();
   const effectiveToolScopes = new Set<string>();
+  // Union of every group's scopes for passing tools, used only to judge whether an
+  // allowed scope is used by some tool (an OR-group's non-primary scopes still count).
+  const effectiveToolScopesAllGroups = new Set<string>();
   const disabledTools: DisabledToolScope[] = [];
 
   for (const endpoint of endpoints.default) {
@@ -284,20 +357,23 @@ function buildAllowedScopeDiagnostics(options: AllowedScopeOptions = {}): ScopeD
       continue;
     }
 
-    const requiredScopes = getEndpointRequiredScopes(endpoint, Boolean(options.orgMode));
-    requiredScopes.forEach((scope) => normalToolScopes.add(scope));
+    const scopeGroups = getEndpointScopeGroups(endpoint, Boolean(options.orgMode));
+    const loginScopes = getEndpointLoginScopes(endpoint, Boolean(options.orgMode));
+    const allScopes = getEndpointRequiredScopes(endpoint, Boolean(options.orgMode));
+    loginScopes.forEach((scope) => normalToolScopes.add(scope));
 
-    const missingScopes = getMissingAllowedScopes(requiredScopes, allowedScopes);
+    const missingScopes = getMissingAllowedScopesForGroups(scopeGroups, allowedScopes);
     if (missingScopes.length > 0) {
       disabledTools.push({
         toolName: endpoint.toolName,
-        requiredScopes: requiredScopes.sort((a, b) => a.localeCompare(b)),
+        requiredScopes: allScopes.sort((a, b) => a.localeCompare(b)),
         missingScopes: missingScopes.sort((a, b) => a.localeCompare(b)),
       });
       continue;
     }
 
-    requiredScopes.forEach((scope) => effectiveToolScopes.add(scope));
+    loginScopes.forEach((scope) => effectiveToolScopes.add(scope));
+    allScopes.forEach((scope) => effectiveToolScopesAllGroups.add(scope));
   }
 
   const toolPermissions = collapseRedundantScopes(Array.from(normalToolScopes)).sort((a, b) =>
@@ -312,8 +388,10 @@ function buildAllowedScopeDiagnostics(options: AllowedScopeOptions = {}): ScopeD
   const missingAllowedScopesForTools = Array.from(
     new Set(disabledTools.flatMap((tool) => tool.missingScopes))
   ).sort((a, b) => a.localeCompare(b));
+  const allEffectiveToolScopes = Array.from(effectiveToolScopesAllGroups);
   const extraAllowedScopesNotUsedByTools =
-    sortedAllowedScopes?.filter((scope) => !isScopeUsedByTools(scope, effectivePermissions)) ?? [];
+    sortedAllowedScopes?.filter((scope) => !isScopeUsedByTools(scope, allEffectiveToolScopes)) ??
+    [];
 
   return {
     permissions: effectivePermissions,
@@ -1125,7 +1203,9 @@ export {
   buildScopeDiagnostics,
   collapseScopeHierarchy,
   getEndpointRequiredScopes,
+  getEndpointScopeGroups,
   getMissingAllowedScopes,
+  getMissingAllowedScopesForGroups,
   getTokenCachePath,
   getSelectedAccountPath,
   parseAllowedScopes,

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1748,7 +1748,7 @@
     "toolName": "copilot-retrieve",
     "presets": ["search", "work"],
     "readOnly": true,
-    "workScopes": ["Files.Read.All", "Sites.Read.All", "ExternalItem.Read.All"],
+    "workScopes": [["Files.Read.All", "Sites.Read.All"], ["ExternalItem.Read.All"]],
     "requestBodySchema": {
       "type": "object",
       "required": ["queryString", "dataSource"],
@@ -1782,7 +1782,7 @@
         }
       }
     },
-    "llmTip": "Semantic/hybrid search over Microsoft 365 content via the Copilot Retrieval API. Grounds a natural-language query against the same hybrid index that powers Microsoft 365 Copilot and returns permission-trimmed text extracts with their source URLs — unlike search-query/search-onedrive-files/search-sharepoint-sites, which are lexical KQL. Prefer this for paraphrase/intent queries (e.g. resolving an informal project nickname, or matching 'packaging requirements' against text that never uses that phrase). Pass the request fields nested under a 'body' object: { queryString, dataSource, filterExpression?, resourceMetadata?, maximumNumberOfResults? }. Returns { retrievalHits: [{ webUrl, extracts: [{ text, relevanceScore }], resourceType, resourceMetadata, sensitivityLabel? }] }. Work/school accounts only (personal accounts are not supported); needs delegated Files.Read.All + Sites.Read.All (SharePoint/OneDrive) or ExternalItem.Read.All (Copilot connectors)."
+    "llmTip": "Semantic/hybrid search over Microsoft 365 content via the Copilot Retrieval API. Grounds a natural-language query against the same hybrid index that powers Microsoft 365 Copilot and returns permission-trimmed text extracts with their source URLs — unlike search-query/search-onedrive-files/search-sharepoint-sites, which are lexical KQL. Prefer this for paraphrase/intent queries (e.g. resolving an informal project nickname, or matching 'packaging requirements' against text that never uses that phrase). Pass the request fields nested under a 'body' object: { queryString, dataSource, filterExpression?, resourceMetadata?, maximumNumberOfResults? }. Returns { retrievalHits: [{ webUrl, extracts: [{ text, relevanceScore }], resourceType, resourceMetadata, sensitivityLabel? }] }. Work/school accounts only (personal accounts are not supported). dataSource 'sharePoint'/'oneDriveBusiness' need delegated Files.Read.All + Sites.Read.All (requested by default); dataSource 'externalItem' (Copilot connectors) needs ExternalItem.Read.All, which is not requested by default - add it with --extra-scopes ExternalItem.Read.All."
   },
   {
     "pathPattern": "/me/onlineMeetings",

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -4,8 +4,8 @@ import logger from './logger.js';
 import { auditLog, getUserIdentityForAudit } from './audit-log.js';
 import GraphClient from './graph-client.js';
 import AuthManager, {
-  getEndpointRequiredScopes,
-  getMissingAllowedScopes,
+  getEndpointScopeGroups,
+  getMissingAllowedScopesForGroups,
   parseAllowedScopes,
 } from './auth.js';
 import { api } from './generated/client.js';
@@ -30,8 +30,8 @@ interface EndpointConfig {
   pathPattern: string;
   method: string;
   toolName: string;
-  scopes?: string[];
-  workScopes?: string[];
+  scopes?: string[] | string[][];
+  workScopes?: string[] | string[][];
   returnDownloadUrl?: boolean;
   supportsTimezone?: boolean;
   supportsExpandExtendedProperties?: boolean;
@@ -826,11 +826,13 @@ export function registerGraphTools(
       continue;
     }
 
-    const requiredScopes = getEndpointRequiredScopes(endpointConfig, orgMode);
     const missingScopes =
       allowedScopes !== undefined && !endpointConfig
         ? ['endpoint scope metadata']
-        : getMissingAllowedScopes(requiredScopes, allowedScopes);
+        : getMissingAllowedScopesForGroups(
+            getEndpointScopeGroups(endpointConfig, orgMode),
+            allowedScopes
+          );
     if (missingScopes.length > 0) {
       disabledByAllowedScopes.push({ toolName: tool.alias, missingScopes });
       skippedCount++;
@@ -1079,8 +1081,8 @@ export function buildToolsRegistry(
     const missingScopes =
       allowedScopes !== undefined && !endpointConfig
         ? ['endpoint scope metadata']
-        : getMissingAllowedScopes(
-            getEndpointRequiredScopes(endpointConfig, orgMode),
+        : getMissingAllowedScopesForGroups(
+            getEndpointScopeGroups(endpointConfig, orgMode),
             allowedScopes
           );
     if (missingScopes.length > 0) {

--- a/test/endpoints-validation.test.ts
+++ b/test/endpoints-validation.test.ts
@@ -17,8 +17,8 @@ interface Endpoint {
   toolName: string;
   pathPattern: string;
   method: string;
-  scopes?: string[];
-  workScopes?: string[];
+  scopes?: string[] | string[][];
+  workScopes?: string[] | string[][];
 }
 
 const endpoints: Endpoint[] = JSON.parse(
@@ -39,6 +39,39 @@ describe('endpoints.json validation', () => {
       expect.fail(
         `${violations.length} endpoint(s) have both scopes and workScopes. ` +
           `Use scopes for personal-account-compatible endpoints, workScopes for org-only endpoints, never both.\n${details}`
+      );
+    }
+  });
+
+  it('should have well-formed scope groups (flat string[] or nested string[][])', () => {
+    const isStringArray = (v: unknown): boolean =>
+      Array.isArray(v) && v.every((s) => typeof s === 'string');
+
+    const malformed: string[] = [];
+    for (const e of endpoints) {
+      for (const field of ['scopes', 'workScopes'] as const) {
+        const value = e[field];
+        if (value === undefined) continue;
+        if (!Array.isArray(value)) {
+          malformed.push(`${e.toolName}.${field}: must be an array`);
+          continue;
+        }
+        if (value.length === 0) continue; // empty = no scope required, valid
+        const nested = Array.isArray(value[0]);
+        // All entries must be consistent: either all strings (flat) or all non-empty string[] (groups).
+        const ok = nested
+          ? value.every((g) => isStringArray(g) && (g as string[]).length > 0)
+          : isStringArray(value);
+        if (!ok) {
+          malformed.push(`${e.toolName}.${field}: ${JSON.stringify(value)}`);
+        }
+      }
+    }
+
+    if (malformed.length > 0) {
+      expect.fail(
+        `${malformed.length} endpoint(s) have malformed scope groups. ` +
+          `Use string[] for a single required set, or string[][] for OR-groups.\n${malformed.join('\n')}`
       );
     }
   });

--- a/test/or-group-scopes.test.ts
+++ b/test/or-group-scopes.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getEndpointScopeGroups,
+  getMissingAllowedScopesForGroups,
+  buildScopesFromEndpoints,
+  buildAllowedScopeDiagnostics,
+} from '../src/auth.js';
+
+/**
+ * OR-group scopes: workScopes/scopes may be a flat string[] (single AND-group) or a nested
+ * string[][] (alternatives - satisfied if any one group is fully held). copilot-retrieve uses
+ * [["Files.Read.All","Sites.Read.All"], ["ExternalItem.Read.All"]] because its dataSources are
+ * permission alternatives per the Microsoft Graph Copilot Retrieval API.
+ */
+describe('getEndpointScopeGroups', () => {
+  it('wraps a flat array as a single group', () => {
+    expect(getEndpointScopeGroups({ scopes: ['Mail.Read'] })).toEqual([['Mail.Read']]);
+  });
+
+  it('returns nested groups as-is', () => {
+    const groups = getEndpointScopeGroups(
+      { workScopes: [['Files.Read.All', 'Sites.Read.All'], ['ExternalItem.Read.All']] },
+      true
+    );
+    expect(groups).toEqual([['Files.Read.All', 'Sites.Read.All'], ['ExternalItem.Read.All']]);
+  });
+
+  it('omits workScopes when work account scopes are not included', () => {
+    expect(getEndpointScopeGroups({ workScopes: [['ExternalItem.Read.All']] }, false)).toEqual([]);
+  });
+});
+
+describe('getMissingAllowedScopesForGroups', () => {
+  const groups = [['Files.Read.All', 'Sites.Read.All'], ['ExternalItem.Read.All']];
+
+  it('is allowed when the primary group is fully covered', () => {
+    expect(getMissingAllowedScopesForGroups(groups, ['Files.Read.All', 'Sites.Read.All'])).toEqual(
+      []
+    );
+  });
+
+  it('is allowed when an alternative group is fully covered', () => {
+    expect(getMissingAllowedScopesForGroups(groups, ['ExternalItem.Read.All'])).toEqual([]);
+  });
+
+  it('reports the closest (smallest) gap when no group is satisfied', () => {
+    // Files.Read.All present -> group 1 missing only Sites.Read.All (1), group 2 missing
+    // ExternalItem.Read.All (1). Tie resolves to the first group encountered.
+    expect(getMissingAllowedScopesForGroups(groups, ['Files.Read.All'])).toEqual([
+      'Sites.Read.All',
+    ]);
+  });
+
+  it('treats undefined allowedScopes as no restriction', () => {
+    expect(getMissingAllowedScopesForGroups(groups, undefined)).toEqual([]);
+  });
+});
+
+describe('copilot-retrieve login + gate (real endpoints.json)', () => {
+  it('requests only the primary group at login, not ExternalItem.Read.All', () => {
+    const scopes = buildScopesFromEndpoints(true);
+    expect(scopes).toContain('Files.Read.All');
+    expect(scopes).toContain('Sites.Read.All');
+    // ExternalItem.Read.All is the higher-privileged alternative - opt-in via --extra-scopes.
+    expect(scopes).not.toContain('ExternalItem.Read.All');
+  });
+
+  const isDisabled = (allowedScopes: string) =>
+    buildAllowedScopeDiagnostics({ orgMode: true, allowedScopes }).disabledTools.find(
+      (t) => t.toolName === 'copilot-retrieve'
+    );
+
+  it('stays enabled with only SharePoint/OneDrive scopes', () => {
+    expect(isDisabled('Files.Read.All Sites.Read.All')).toBeUndefined();
+  });
+
+  it('stays enabled with only the connector scope', () => {
+    expect(isDisabled('ExternalItem.Read.All')).toBeUndefined();
+  });
+
+  it('is disabled when no group is satisfied, reporting the smallest gap', () => {
+    const disabled = isDisabled('Mail.Read');
+    expect(disabled).toBeDefined();
+    expect(disabled?.missingScopes).toEqual(['ExternalItem.Read.All']);
+  });
+});


### PR DESCRIPTION
…ernatives

Some endpoints accept alternative permission sets rather than one fixed set. copilot-retrieve is the motivating case: per the Microsoft Graph Copilot Retrieval API, dataSource sharePoint/oneDriveBusiness need Files.Read.All + Sites.Read.All, while externalItem needs ExternalItem.Read.All - they are alternatives, not a union.

workScopes/scopes may now be a nested string[][] of OR-groups (a flat string[] stays a single AND-group, so all existing endpoints are unchanged). An endpoint is available if ALL scopes in ANY one group are held.

- Gate (registration + discovery + diagnostics): tool kept if any group is satisfied; a disabled tool reports the closest group's missing scopes.
- Login: request only the primary (first) group, following Microsoft's least-privileged guidance. For copilot-retrieve that is Files.Read.All + Sites.Read.All; externalItem retrieval opts in via --extra-scopes ExternalItem.Read.All.
- llmTip and the gate now agree (previously the tip described OR while the gate ANDed).
- Validation now checks scope groups are well-formed; adds unit + integration tests.