### PR TITLE
fix: don't silently drop OData params absent from generated client

### DIFF
--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -444,6 +444,11 @@ async function executeGraphTool(
           .replace(`{${camelCaseParamName}}`, encodedValue)
           .replace(`:${camelCaseParamName}`, encodedValue);
         logger.info(`Path param fallback: replaced :${camelCaseParamName} with encoded value`);
+      } else if (isOdataParam) {
+        // Fallback: OData param recognised by name but absent from generated client's parameter
+        // list — forward it as a query param rather than silently dropping it.
+        queryParams[fixedParamName] = `${paramValue}`;
+        logger.info(`OData param fallback: forwarded ${fixedParamName}=${paramValue}`);
       }
     }
 


### PR DESCRIPTION
## Summary

When a recognised OData param (`$filter`, `$skip`, `$top`, etc.) was passed at runtime but had no matching `paramDef` entry — because the generated client omitted it for that endpoint — the value was silently dropped after the path-param fallback chain without reaching `queryParams`.

**Fix**: add an `else if (isOdataParam)` branch that forwards the param to `queryParams` using the already-computed `fixedParamName`.

## Test plan

- [ ] All 304 existing tests pass (`npm test`)
- [ ] Call `list-mail-folder-messages` with `$skip=10` — verify different results vs `$skip=0`
- [ ] Verify other OData params (`$filter`, `$orderby`, etc.) continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)