### PR TITLE
feat(auth): Support path suffix on --public-url

### DIFF
--- a/src/lib/microsoft-auth.ts
+++ b/src/lib/microsoft-auth.ts
@@ -2,10 +2,41 @@ import { Request, Response, NextFunction } from 'express';
 import logger from '../logger.js';
 import { getCloudEndpoints, type CloudType } from '../cloud-config.js';
 
-function buildWwwAuthenticate(req: Request, error: string, description: string): string {
+/**
+ * Build the resource_metadata URL per RFC 9728 §3.1.
+ * (https://www.rfc-editor.org/rfc/rfc9728.html#name-protected-resource-metadata-)
+ *
+ * When the resource identifier has a path component that should be seen as the resource path.
+ * And thus be inserted in the end of the well-known URI.
+ *
+ *   https://example.com                   → https://example.com/.well-known/oauth-protected-resource
+ *   https://example.com/tenant/ms-365-mcp → https://example.com/.well-known/oauth-protected-resource/tenant/ms-365-mcp
+ *
+ * When publicUrl is absent the request Host
+ * header is used as the origin and no additional path component is appended.
+ */
+function buildResourceMetadataUrl(req: Request, publicUrl?: string | null): string {
+  if (publicUrl) {
+    const parsed = new URL(publicUrl);
+    // If the resource identifier value contains a path or query component,
+    // any terminating slash (/) following the host component MUST be removed
+    // before inserting /.well-known/ and the well-known URI path suffix
+    // between the host component and the path and/or query components
+    const path = parsed.pathname.replace(/\/$/, '');
+    return `${parsed.origin}/.well-known/oauth-protected-resource${path}`;
+  }
   const protocol = req.secure ? 'https' : 'http';
   const origin = `${protocol}://${req.get('host')}`;
-  const resourceMetadata = `${origin}/.well-known/oauth-protected-resource`;
+  return `${origin}/.well-known/oauth-protected-resource`;
+}
+
+function buildWwwAuthenticate(
+  req: Request,
+  error: string,
+  description: string,
+  publicUrl?: string | null
+): string {
+  const resourceMetadata = buildResourceMetadataUrl(req, publicUrl);
   return `Bearer resource_metadata="${resourceMetadata}", error="${error}", error_description="${description}"`;
 }
 
@@ -58,7 +89,13 @@ function isDiscoveryRequest(req: Request): boolean {
  * default; non-discovery requests (e.g. tools/call) always still require a token.
  */
 export const microsoftBearerTokenAuthMiddleware =
-  (opts: { trustProxyAuth?: boolean; allowUnauthenticatedDiscovery?: boolean } = {}) =>
+  (
+    opts: {
+      trustProxyAuth?: boolean;
+      allowUnauthenticatedDiscovery?: boolean;
+      publicUrl?: string | null;
+    } = {}
+  ) =>
   (
     req: Request & { microsoftAuth?: { accessToken: string } },
     res: Response,
@@ -80,7 +117,12 @@ export const microsoftBearerTokenAuthMiddleware =
         .status(401)
         .set(
           'WWW-Authenticate',
-          buildWwwAuthenticate(req, 'invalid_token', 'Missing or malformed Authorization header')
+          buildWwwAuthenticate(
+            req,
+            'invalid_token',
+            'Missing or malformed Authorization header',
+            opts.publicUrl
+          )
         )
         .json({
           error: 'invalid_token',
@@ -96,7 +138,7 @@ export const microsoftBearerTokenAuthMiddleware =
         .status(401)
         .set(
           'WWW-Authenticate',
-          buildWwwAuthenticate(req, 'invalid_token', 'The access token has expired')
+          buildWwwAuthenticate(req, 'invalid_token', 'The access token has expired', opts.publicUrl)
         )
         .json({ error: 'invalid_token', error_description: 'The access token has expired' });
       return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -687,6 +687,7 @@ class MicrosoftGraphServer {
       const mcpAuth = microsoftBearerTokenAuthMiddleware({
         trustProxyAuth: this.options.trustProxyAuth,
         allowUnauthenticatedDiscovery: this.options.allowUnauthenticatedDiscovery,
+        publicUrl: publicBase,
       });
       app.get(
         '/mcp',

--- a/src/server.ts
+++ b/src/server.ts
@@ -374,7 +374,7 @@ class MicrosoftGraphServer {
           : resolveAuthScopes(this.options);
 
         res.json({
-          resource: `${requestOrigin}/mcp`,
+          resource: `${browserBase}/mcp`,
           authorization_servers: [browserBase],
           scopes_supported: scopes,
           bearer_methods_supported: ['header'],

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js';
-import express, { Request, Response } from 'express';
+import express, { Handler, Request, Response } from 'express';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import logger, { enableConsoleLogging } from './logger.js';
@@ -360,7 +360,7 @@ class MicrosoftGraphServer {
       });
 
       // OAuth Protected Resource Discovery
-      app.get('/.well-known/oauth-protected-resource', async (req, res) => {
+      const protectedResourcesHandler: Handler = async (req, res) => {
         const protocol = req.secure ? 'https' : 'http';
         const requestOrigin = `${protocol}://${req.get('host')}`;
         const browserBase = publicBase ?? requestOrigin;
@@ -380,7 +380,10 @@ class MicrosoftGraphServer {
           bearer_methods_supported: ['header'],
           resource_documentation: browserBase,
         });
-      });
+      };
+
+      app.get('/.well-known/oauth-protected-resource', protectedResourcesHandler);
+      app.get('/.well-known/oauth-protected-resource/*path', protectedResourcesHandler);
 
       if (this.options.enableDynamicRegistration) {
         app.post('/register', async (req, res) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -343,7 +343,7 @@ class MicrosoftGraphServer {
         const metadata: Record<string, unknown> = {
           issuer: browserBase,
           authorization_endpoint: `${browserBase}/authorize`,
-          token_endpoint: `${requestOrigin}/token`,
+          token_endpoint: `${browserBase}/token`,
           response_types_supported: ['code'],
           response_modes_supported: ['query'],
           grant_types_supported: ['authorization_code', 'refresh_token'],
@@ -353,7 +353,7 @@ class MicrosoftGraphServer {
         };
 
         if (this.options.enableDynamicRegistration) {
-          metadata.registration_endpoint = `${requestOrigin}/register`;
+          metadata.registration_endpoint = `${browserBase}/register`;
         }
 
         res.json(metadata);

--- a/test/discovery-auth.test.ts
+++ b/test/discovery-auth.test.ts
@@ -90,3 +90,72 @@ describe('trustProxyAuth', () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 });
+
+describe('WWW-Authenticate resource_metadata uses publicUrl when configured', () => {
+  // Helper to extract the resource_metadata value from a WWW-Authenticate header
+  function resourceMetadata(res: ReturnType<typeof makeRes>): string {
+    const wwwAuth: string = res.set.mock.calls[0][1];
+    const match = wwwAuth.match(/resource_metadata="([^"]+)"/);
+    if (!match) throw new Error(`No resource_metadata in: ${wwwAuth}`);
+    return match[1];
+  }
+
+  it('uses publicUrl origin in resource_metadata on missing token (no path)', () => {
+    const mw = microsoftBearerTokenAuthMiddleware({ publicUrl: 'https://mcp.example.com' });
+    const res = makeRes();
+    mw(makeReq('tools/call'), res, vi.fn());
+    expect(res.statusCode).toBe(401);
+    expect(resourceMetadata(res)).toBe(
+      'https://mcp.example.com/.well-known/oauth-protected-resource'
+    );
+  });
+
+  it('inserts /.well-known/ between host and path per RFC 9728 §3.1 (path component)', () => {
+    const mw = microsoftBearerTokenAuthMiddleware({
+      publicUrl: 'https://mcp.example.com/tenant/mcp',
+    });
+    const res = makeRes();
+    mw(makeReq('tools/call'), res, vi.fn());
+    expect(res.statusCode).toBe(401);
+    // Spec: insert /.well-known/oauth-protected-resource between host and path
+    expect(resourceMetadata(res)).toBe(
+      'https://mcp.example.com/.well-known/oauth-protected-resource/tenant/mcp'
+    );
+  });
+
+  it('strips a trailing slash from publicUrl path before constructing the metadata URL', () => {
+    const mw = microsoftBearerTokenAuthMiddleware({ publicUrl: 'https://mcp.example.com/tenant/' });
+    const res = makeRes();
+    mw(makeReq('tools/call'), res, vi.fn());
+    expect(res.statusCode).toBe(401);
+    expect(resourceMetadata(res)).toBe(
+      'https://mcp.example.com/.well-known/oauth-protected-resource/tenant'
+    );
+  });
+
+  it('uses publicUrl in resource_metadata on expired JWT token', () => {
+    const mw = microsoftBearerTokenAuthMiddleware({ publicUrl: 'https://mcp.example.com' });
+    // Build a JWT whose exp is in the past
+    const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+    const payload = Buffer.from(
+      JSON.stringify({ exp: Math.floor(Date.now() / 1000) - 60 })
+    ).toString('base64url');
+    const expiredJwt = `${header}.${payload}.signature`;
+    const res = makeRes();
+    mw(makeReq('tools/call', { authorization: `Bearer ${expiredJwt}` }), res, vi.fn());
+    expect(res.statusCode).toBe(401);
+    expect(resourceMetadata(res)).toBe(
+      'https://mcp.example.com/.well-known/oauth-protected-resource'
+    );
+  });
+
+  it('falls back to request host when publicUrl is not set', () => {
+    const mw = microsoftBearerTokenAuthMiddleware();
+    const res = makeRes();
+    mw(makeReq('tools/call'), res, vi.fn());
+    expect(res.statusCode).toBe(401);
+    expect(resourceMetadata(res)).toBe(
+      'http://localhost:3000/.well-known/oauth-protected-resource'
+    );
+  });
+});


### PR DESCRIPTION
Summary
---------
When hosting this service under a sub-path we need to expose the .well-known urls with specific URLs for this service/resource.

To my understanding this fix would be the common solution given this entry in the RFC: [3.1 Protected Resource Metadata Request](https://www.rfc-editor.org/rfc/rfc9728.html#name-protected-resource-metadata-). I hope you agree, otherwise please feel free to provide another approach we can look into to support this case.

Key changes:
-------------
This change makes the resource_metadata field of the WWW-Authorization response header include any path included in the --public-url parameter as a suffix to the well-known url.