### PR TITLE
Fix tool discovery for create-calendar-event and sync package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13348,6 +13348,24 @@
         "node": ">= 12"
       }
     },
+    "node_modules/tsup/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -13831,6 +13849,24 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/web-worker": {

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -359,6 +359,7 @@
     "toolName": "create-calendar-event",
     "presets": ["calendar", "outlook", "personal"],
     "scopes": ["Calendars.ReadWrite"],
+    "descriptionOverride": "Create (schedule) a new calendar event — a meeting or appointment — on the user's calendar. Set subject, start/end times, time zone, location, body, and attendees; supports online meetings and recurrence.",
     "llmTip": "CRITICAL: Do not try to guess the email address of the recipients. Use the list-users tool to find the email address of the recipients."
   },
   {

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -43,6 +43,10 @@ interface EndpointConfig {
   supportsTimezone?: boolean;
   supportsExpandExtendedProperties?: boolean;
   llmTip?: string;
+  // Replaces the Microsoft-supplied base description everywhere it is surfaced (tool
+  // registration, BM25 discovery index, search-tools, get-tool-schema). Use when the
+  // generated description leads with the wrong Graph operation. llmTip is still appended after.
+  descriptionOverride?: string;
   skipEncoding?: string[]; // Parameter names that should NOT be URL-encoded (for function-style API calls)
   contentType?: string;
   acceptType?: string; // Custom Accept header for endpoints returning non-JSON content (e.g., text/vtt)
@@ -1046,7 +1050,8 @@ export function registerGraphTools(
 
     // Build the tool description, optionally appending LLM tips
     let toolDescription = withApiVersionPrefix(
-      tool.description || `Execute ${tool.method.toUpperCase()} request to ${tool.path}`,
+      (endpointConfig?.descriptionOverride ?? tool.description) ||
+        `Execute ${tool.method.toUpperCase()} request to ${tool.path}`,
       endpointConfig
     );
     if (endpointConfig?.llmTip) {
@@ -1189,7 +1194,10 @@ export function buildDiscoverySearchIndex(
     const nt = tokenize(name);
     nameTokens.set(name, new Set(nt));
     const pathTokens = tokenize(tool.path);
-    const descTokens = tokenize(tool.description).slice(0, DESC_CAP_TOKENS);
+    const descTokens = tokenize(config?.descriptionOverride ?? tool.description).slice(
+      0,
+      DESC_CAP_TOKENS
+    );
     const tipTokens = tokenize(config?.llmTip).slice(0, TIP_EXCERPT_TOKENS);
     const tokens = [
       ...nt,
@@ -1315,7 +1323,8 @@ export function registerDiscoveryTools(
         method: tool.method.toUpperCase(),
         path: tool.path,
         description: withApiVersionPrefix(
-          tool.description || `${tool.method.toUpperCase()} ${tool.path}`,
+          (config?.descriptionOverride ?? tool.description) ||
+            `${tool.method.toUpperCase()} ${tool.path}`,
           config
         ),
         ...(config?.llmTip ? { llmTip: config.llmTip } : {}),
@@ -1402,7 +1411,11 @@ export function registerDiscoveryTools(
     async ({ tool_name }) => {
       const entry = toolsRegistry.get(tool_name);
       if (entry) {
-        const schema = describeToolSchema(entry.tool, entry.config?.llmTip);
+        const schema = describeToolSchema(
+          entry.tool,
+          entry.config?.llmTip,
+          entry.config?.descriptionOverride
+        );
         return {
           content: [{ type: 'text', text: JSON.stringify(schema, null, 2) }],
         };

--- a/src/lib/tool-schema.ts
+++ b/src/lib/tool-schema.ts
@@ -19,7 +19,8 @@ function unwrapOptional(schema: z.ZodTypeAny): { inner: z.ZodTypeAny; optional: 
  */
 export function describeToolSchema(
   tool: ToolEndpoint,
-  llmTip: string | undefined
+  llmTip: string | undefined,
+  descriptionOverride?: string
 ): {
   name: string;
   method: string;
@@ -52,7 +53,7 @@ export function describeToolSchema(
     name: tool.alias,
     method: tool.method.toUpperCase(),
     path: tool.path,
-    description: tool.description ?? '',
+    description: descriptionOverride ?? tool.description ?? '',
     ...(llmTip ? { llmTip } : {}),
     parameters: params,
   };

--- a/test/discovery-search.test.ts
+++ b/test/discovery-search.test.ts
@@ -36,6 +36,10 @@ const cases: Case[] = [
   // Calendar
   { query: 'create calendar event', expect: 'create-calendar-event', inTop: 5 },
   { query: 'create event', expect: 'create-calendar-event', inTop: 5 },
+  // Semantic queries that don't contain the tool name — these rely on the description
+  // override (the Microsoft-supplied base description leads with unrelated boilerplate).
+  { query: 'schedule a meeting', expect: 'create-calendar-event', inTop: 5 },
+  { query: 'add appointment to calendar', expect: 'create-calendar-event', inTop: 5 },
   { query: 'list calendars', expect: 'list-calendars', inTop: 3 },
   { query: 'list calendar events', expect: 'list-calendar-events', inTop: 5 },
   { query: 'accept event', expect: 'accept-calendar-event', inTop: 5 },


### PR DESCRIPTION
This pull request introduces support for overriding the default tool descriptions with a new `descriptionOverride` field, allowing more accurate and relevant descriptions to be surfaced in tool registration, discovery, and schema generation. Several functions are updated to consistently use this override, and new tests are added to ensure improved discovery for calendar-related actions.

**Enhancements for Tool Description Overrides:**

* Added the `descriptionOverride` field to the `EndpointConfig` interface in `src/graph-tools.ts`, with documentation explaining its purpose and usage.
* Updated the `create-calendar-event` entry in `src/endpoints.json` to provide a more relevant, user-focused description via `descriptionOverride`.

**Consistent Use of Description Overrides:**

* Modified tool registration, discovery, and search index functions in `src/graph-tools.ts` to prioritize `descriptionOverride` over the default description when present. This affects tool descriptions, discovery indexing, and schema generation. [[1]](diffhunk://#diff-0be11dfcc21fdb6d7ffe5fed7332a1ff4631245880bfc61ef449ee65b52b712cL1049-R1054) [[2]](diffhunk://#diff-0be11dfcc21fdb6d7ffe5fed7332a1ff4631245880bfc61ef449ee65b52b712cL1192-R1200) [[3]](diffhunk://#diff-0be11dfcc21fdb6d7ffe5fed7332a1ff4631245880bfc61ef449ee65b52b712cL1318-R1327) [[4]](diffhunk://#diff-0be11dfcc21fdb6d7ffe5fed7332a1ff4631245880bfc61ef449ee65b52b712cL1405-R1418)
* Updated the `describeToolSchema` function in `src/lib/tool-schema.ts` to accept and use `descriptionOverride` for the tool description field. [[1]](diffhunk://#diff-b77791194a159930fde3b2e0b4e3bbee982eb557bef70123eef9339abe3a4a27L22-R23) [[2]](diffhunk://#diff-b77791194a159930fde3b2e0b4e3bbee982eb557bef70123eef9339abe3a4a27L55-R56)

**Testing Improvements:**

* Added new semantic search test cases in `test/discovery-search.test.ts` to verify that queries like "schedule a meeting" and "add appointment to calendar" correctly match the `create-calendar-event` tool, demonstrating the effectiveness of the description override.

Fixes #543 