### PR TITLE
feat(mail): support using a local file as the email body

### DIFF
--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { z } from 'zod';
+import os from 'os';
+import path from 'path';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
 
 /**
  * We test executeGraphTool logic by importing it indirectly through registerGraphTools.
@@ -1148,6 +1151,263 @@ describe('graph-tools', () => {
       // readOnlyHint: true so they should be present.
       expect(server.tools.has('download-bytes')).toBe(true);
       expect(server.tools.has('parse-teams-url')).toBe(true);
+    });
+  });
+
+  // ---- email body from a local file (bodyFilePath) ----
+  describe('email body from file', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(path.join(os.tmpdir(), 'ms365-body-file-'));
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function sendMailSetup() {
+      const endpoint = makeEndpoint({
+        alias: 'send-mail',
+        method: 'post',
+        path: '/me/sendMail',
+        parameters: [{ name: 'body', type: 'Body', schema: z.any() }],
+      });
+      const config = makeConfig({
+        toolName: 'send-mail',
+        method: 'post',
+        pathPattern: '/me/sendMail',
+        scopes: ['Mail.Send'],
+        // Graph's sendMail action wraps the message in capital `Message`.
+        bodyFile: {
+          contentTarget: 'Message.body.content',
+          contentTypeTarget: 'Message.body.contentType',
+        },
+      });
+      mockEndpoints.push(endpoint);
+      mockEndpointsJson = [config];
+    }
+
+    function draftSetup() {
+      const endpoint = makeEndpoint({
+        alias: 'create-draft-email',
+        method: 'post',
+        path: '/me/messages',
+        parameters: [{ name: 'body', type: 'Body', schema: z.any() }],
+      });
+      const config = makeConfig({
+        toolName: 'create-draft-email',
+        method: 'post',
+        pathPattern: '/me/messages',
+        scopes: ['Mail.ReadWrite'],
+        bodyFile: { contentTarget: 'body.content', contentTypeTarget: 'body.contentType' },
+      });
+      mockEndpoints.push(endpoint);
+      mockEndpointsJson = [config];
+    }
+
+    // allowFileBody is the 10th positional arg to registerGraphTools.
+    async function register(graphClient: any, allowFileBody = true) {
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(
+        server as any,
+        graphClient as any,
+        false,
+        undefined,
+        false,
+        undefined,
+        false,
+        [],
+        undefined,
+        allowFileBody
+      );
+      return server;
+    }
+
+    it('reads an .html file into Message.body.content and infers contentType=html', async () => {
+      sendMailSetup();
+      const htmlPath = path.join(tmpDir, 'newsletter.html');
+      writeFileSync(htmlPath, '<h1>Hello</h1><p>From a file</p>');
+
+      const graphClient = createMockGraphClient([{ content: [{ type: 'text', text: '{}' }] }]);
+      const server = await register(graphClient);
+
+      await server.tools.get('send-mail')!.handler({
+        body: {
+          Message: { subject: 'Hi', toRecipients: [{ emailAddress: { address: 'a@b.com' } }] },
+        },
+        bodyFilePath: htmlPath,
+      });
+
+      expect(graphClient.graphRequest).toHaveBeenCalledTimes(1);
+      const [, options] = graphClient.graphRequest.mock.calls[0];
+      const sent = JSON.parse(options.body);
+      expect(sent.Message.body.content).toBe('<h1>Hello</h1><p>From a file</p>');
+      expect(sent.Message.body.contentType).toBe('html');
+      // Caller-provided fields are preserved.
+      expect(sent.Message.subject).toBe('Hi');
+      expect(sent.Message.toRecipients).toEqual([{ emailAddress: { address: 'a@b.com' } }]);
+    });
+
+    it('writes into the caller Message wrapper without creating a duplicate key (issue: duplicate Message property)', async () => {
+      // Reproduces the Graph 500 "Property with the same name already exists":
+      // the caller (correctly) wraps recipients under `Message`; the merge must
+      // land inside it, not add a lowercase `message`.
+      sendMailSetup();
+      const htmlPath = path.join(tmpDir, 'briefing.html');
+      writeFileSync(htmlPath, '<h1>Briefing</h1>');
+
+      const graphClient = createMockGraphClient([{ content: [{ type: 'text', text: '{}' }] }]);
+      const server = await register(graphClient);
+
+      await server.tools.get('send-mail')!.handler({
+        body: {
+          Message: { subject: 'Test', toRecipients: [{ emailAddress: { address: 'romeo@x.io' } }] },
+          SaveToSentItems: true,
+        },
+        bodyFilePath: htmlPath,
+        bodyContentType: 'html',
+      });
+
+      const [, options] = graphClient.graphRequest.mock.calls[0];
+      const sent = JSON.parse(options.body);
+      // Exactly one message wrapper — no lowercase `message` duplicate.
+      expect(Object.keys(sent).sort()).toEqual(['Message', 'SaveToSentItems']);
+      expect(sent.message).toBeUndefined();
+      expect(sent.Message.body).toEqual({ content: '<h1>Briefing</h1>', contentType: 'html' });
+      expect(sent.Message.toRecipients).toEqual([{ emailAddress: { address: 'romeo@x.io' } }]);
+      expect(sent.Message.subject).toBe('Test');
+      expect(sent.SaveToSentItems).toBe(true);
+    });
+
+    it('reuses a lowercase `message` wrapper case-insensitively', async () => {
+      // Even if a caller uses lowercase `message`, the configured `Message.*`
+      // target must reuse it rather than add a second key.
+      sendMailSetup();
+      const htmlPath = path.join(tmpDir, 'lower.html');
+      writeFileSync(htmlPath, 'hi');
+
+      const graphClient = createMockGraphClient([{ content: [{ type: 'text', text: '{}' }] }]);
+      const server = await register(graphClient);
+
+      await server.tools.get('send-mail')!.handler({
+        body: { message: { toRecipients: [{ emailAddress: { address: 'a@b.com' } }] } },
+        bodyFilePath: htmlPath,
+      });
+
+      const [, options] = graphClient.graphRequest.mock.calls[0];
+      const sent = JSON.parse(options.body);
+      expect(Object.keys(sent)).toEqual(['message']);
+      expect(sent.Message).toBeUndefined();
+      expect(sent.message.body.content).toBe('hi');
+      expect(sent.message.toRecipients).toEqual([{ emailAddress: { address: 'a@b.com' } }]);
+    });
+
+    it('reads a .txt file into a draft body and infers contentType=text', async () => {
+      draftSetup();
+      const txtPath = path.join(tmpDir, 'body.txt');
+      writeFileSync(txtPath, 'plain text body');
+
+      const graphClient = createMockGraphClient([{ content: [{ type: 'text', text: '{}' }] }]);
+      const server = await register(graphClient);
+
+      await server.tools.get('create-draft-email')!.handler({
+        body: { subject: 'Draft', toRecipients: [{ emailAddress: { address: 'a@b.com' } }] },
+        bodyFilePath: txtPath,
+      });
+
+      const [, options] = graphClient.graphRequest.mock.calls[0];
+      const sent = JSON.parse(options.body);
+      expect(sent.body.content).toBe('plain text body');
+      expect(sent.body.contentType).toBe('text');
+      expect(sent.subject).toBe('Draft');
+    });
+
+    it('lets an explicit bodyContentType override extension inference', async () => {
+      sendMailSetup();
+      const txtPath = path.join(tmpDir, 'body.txt');
+      writeFileSync(txtPath, '<b>actually html</b>');
+
+      const graphClient = createMockGraphClient([{ content: [{ type: 'text', text: '{}' }] }]);
+      const server = await register(graphClient);
+
+      await server.tools.get('send-mail')!.handler({
+        body: { Message: { subject: 'Hi' } },
+        bodyFilePath: txtPath,
+        bodyContentType: 'html',
+      });
+
+      const [, options] = graphClient.graphRequest.mock.calls[0];
+      const sent = JSON.parse(options.body);
+      expect(sent.Message.body.contentType).toBe('html');
+      expect(sent.Message.body.content).toBe('<b>actually html</b>');
+    });
+
+    it('returns an error and skips the Graph call when the file is missing', async () => {
+      sendMailSetup();
+      const graphClient = createMockGraphClient([{ content: [{ type: 'text', text: '{}' }] }]);
+      const server = await register(graphClient);
+
+      const result = await server.tools.get('send-mail')!.handler({
+        body: { message: { subject: 'Hi' } },
+        bodyFilePath: path.join(tmpDir, 'does-not-exist.html'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Failed to read body file');
+      expect(graphClient.graphRequest).not.toHaveBeenCalled();
+    });
+
+    it('overrides inline content already present in the body', async () => {
+      sendMailSetup();
+      const htmlPath = path.join(tmpDir, 'override.html');
+      writeFileSync(htmlPath, 'FROM FILE');
+
+      const graphClient = createMockGraphClient([{ content: [{ type: 'text', text: '{}' }] }]);
+      const server = await register(graphClient);
+
+      await server.tools.get('send-mail')!.handler({
+        body: { Message: { body: { content: 'INLINE', contentType: 'text' } } },
+        bodyFilePath: htmlPath,
+      });
+
+      const [, options] = graphClient.graphRequest.mock.calls[0];
+      const sent = JSON.parse(options.body);
+      expect(sent.Message.body.content).toBe('FROM FILE');
+      expect(sent.Message.body.contentType).toBe('html');
+    });
+
+    it('leaves the request unchanged when no bodyFilePath is given (regression)', async () => {
+      sendMailSetup();
+      const inline = {
+        Message: {
+          subject: 'Inline',
+          body: { contentType: 'html', content: '<p>inline</p>' },
+          toRecipients: [{ emailAddress: { address: 'a@b.com' } }],
+        },
+      };
+      const graphClient = createMockGraphClient([{ content: [{ type: 'text', text: '{}' }] }]);
+      const server = await register(graphClient);
+
+      await server.tools.get('send-mail')!.handler({ body: inline });
+
+      const [, options] = graphClient.graphRequest.mock.calls[0];
+      expect(JSON.parse(options.body)).toEqual(inline);
+    });
+
+    it('does not expose bodyFilePath in the schema when file body is disallowed (HTTP mode)', async () => {
+      sendMailSetup();
+      const serverOff = await register({}, false);
+      expect(serverOff.tools.get('send-mail')!.schema.bodyFilePath).toBeUndefined();
+      expect(serverOff.tools.get('send-mail')!.schema.bodyContentType).toBeUndefined();
+
+      // Sanity: the param IS offered when allowed.
+      mockEndpoints.length = 0;
+      sendMailSetup();
+      const serverOn = await register({}, true);
+      expect(serverOn.tools.get('send-mail')!.schema.bodyFilePath).toBeDefined();
+      expect(serverOn.tools.get('send-mail')!.schema.bodyContentType).toBeDefined();
     });
   });
 });

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -81,7 +81,11 @@
     "toolName": "send-mail",
     "presets": ["mail", "outlook", "personal"],
     "scopes": ["Mail.Send"],
-    "llmTip": "CRITICAL: Do not try to guess the email address of the recipients. Use the list-users tool to find the email address of the recipients."
+    "llmTip": "CRITICAL: Do not try to guess the email address of the recipients. Use the list-users tool to find the email address of the recipients. To use a local .html/.txt file as the message body, set 'bodyFilePath' to its path (stdio mode only); the server writes the file contents into the message's body. Keep passing recipients/subject under the normal Message wrapper, e.g. body = { \"Message\": { \"subject\": \"...\", \"toRecipients\": [...] } }. Do NOT also set Message.body.content yourself — the file overrides it.",
+    "bodyFile": {
+      "contentTarget": "Message.body.content",
+      "contentTypeTarget": "Message.body.contentType"
+    }
   },
   {
     "pathPattern": "/users/{user-id}/messages",
@@ -112,14 +116,20 @@
     "toolName": "send-shared-mailbox-mail",
     "presets": ["work"],
     "workScopes": ["Mail.Send.Shared"],
-    "llmTip": "CRITICAL: Do not try to guess the email address of the recipients. Use the list-users tool to find the email address of the recipients."
+    "llmTip": "CRITICAL: Do not try to guess the email address of the recipients. Use the list-users tool to find the email address of the recipients. To use a local .html/.txt file as the message body, set 'bodyFilePath' to its path (stdio mode only); the server writes the file contents into the message's body. Keep passing recipients/subject under the normal Message wrapper, e.g. body = { \"Message\": { \"subject\": \"...\", \"toRecipients\": [...] } }. Do NOT also set Message.body.content yourself — the file overrides it.",
+    "bodyFile": {
+      "contentTarget": "Message.body.content",
+      "contentTypeTarget": "Message.body.contentType"
+    }
   },
   {
     "pathPattern": "/users/{user-id}/messages",
     "method": "post",
     "toolName": "create-shared-mailbox-draft",
     "presets": ["work"],
-    "workScopes": ["Mail.ReadWrite.Shared"]
+    "workScopes": ["Mail.ReadWrite.Shared"],
+    "llmTip": "To use a local .html/.txt file as the draft body, set 'bodyFilePath' to its path (stdio mode only) and still pass recipients/subject in 'body'; the file contents override any inline body content.",
+    "bodyFile": { "contentTarget": "body.content", "contentTypeTarget": "body.contentType" }
   },
   {
     "pathPattern": "/users/{user-id}/messages/{message-id}/reply",
@@ -158,7 +168,9 @@
     "method": "post",
     "toolName": "create-draft-email",
     "presets": ["mail", "outlook", "personal"],
-    "scopes": ["Mail.ReadWrite"]
+    "scopes": ["Mail.ReadWrite"],
+    "llmTip": "To use a local .html/.txt file as the draft body, set 'bodyFilePath' to its path (stdio mode only) and still pass recipients/subject in 'body'; the file contents override any inline body content.",
+    "bodyFile": { "contentTarget": "body.content", "contentTypeTarget": "body.contentType" }
   },
   {
     "pathPattern": "/me/messages/{message-id}",

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -22,6 +22,12 @@ import { fileURLToPath } from 'url';
 import { TOOL_CATEGORIES } from './tool-categories.js';
 import { getRequestTokens } from './request-context.js';
 import { parseTeamsUrl } from './lib/teams-url-parser.js';
+import {
+  applyBodyFile,
+  inferContentType,
+  type BodyFileConfig,
+  type BodyFileContentType,
+} from './lib/body-file.js';
 import { buildBM25Index, scoreQuery, tokenize, type BM25Index } from './lib/bm25.js';
 export interface DiscoverySearchIndex {
   bm25: BM25Index;
@@ -53,6 +59,10 @@ interface EndpointConfig {
   // to synthesize a typed requestBody (instead of a generic object), so the generated client
   // exposes a validated `body` param. Ignored for endpoints already present in the spec.
   requestBodySchema?: Record<string, unknown>;
+  // When set, a `bodyFilePath` parameter is offered (stdio mode only) that reads a
+  // local file and writes its contents into the request body at `contentTarget`
+  // (and the inferred/explicit content type at `contentTypeTarget`).
+  bodyFile?: BodyFileConfig;
 }
 
 const endpointsData = JSON.parse(
@@ -382,7 +392,8 @@ async function executeGraphTool(
   config: EndpointConfig | undefined,
   graphClient: GraphClient,
   params: Record<string, unknown>,
-  authManager?: AuthManager
+  authManager?: AuthManager,
+  allowFileBody: boolean = false
 ): Promise<CallToolResult> {
   logger.info(`Tool ${tool.alias} called with params: ${JSON.stringify(params)}`);
 
@@ -426,6 +437,33 @@ async function executeGraphTool(
 
     const parameterDefinitions = tool.parameters || [];
 
+    // When a local file is supplied as the email body, read it and merge its
+    // contents into the caller-provided `body` at the endpoint's configured path.
+    // Gated on stdio mode (allowFileBody) so it is never reachable in HTTP/OBO.
+    if (allowFileBody && config?.bodyFile && typeof params.bodyFilePath === 'string') {
+      const bodyFilePath = params.bodyFilePath;
+      let fileContent: string;
+      try {
+        fileContent = readFileSync(bodyFilePath, 'utf8');
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                error: `Failed to read body file '${bodyFilePath}': ${(err as Error).message}`,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+      const contentType: BodyFileContentType =
+        (params.bodyContentType as BodyFileContentType | undefined) ??
+        inferContentType(bodyFilePath);
+      params.body = applyBodyFile(params.body, config.bodyFile, fileContent, contentType);
+    }
+
     let path = tool.path;
     const queryParams: Record<string, string> = {};
     const headers: Record<string, string> = {};
@@ -441,6 +479,8 @@ async function executeGraphTool(
           'excludeResponse',
           'timezone',
           'expandExtendedProperties',
+          'bodyFilePath',
+          'bodyContentType',
         ].includes(paramName)
       ) {
         continue;
@@ -842,7 +882,8 @@ export function registerGraphTools(
   authManager?: AuthManager,
   multiAccount: boolean = false,
   accountNames: string[] = [],
-  allowedScopesValue?: string
+  allowedScopesValue?: string,
+  allowFileBody: boolean = false
 ): number {
   let enabledToolsRegex: RegExp | undefined;
   if (enabledToolsPattern) {
@@ -1044,6 +1085,28 @@ export function registerGraphTools(
         .optional();
     }
 
+    // Add bodyFilePath parameter for mail endpoints that support reading the body
+    // from a local file. Only offered in stdio mode (allowFileBody) — in HTTP/OBO
+    // mode the filesystem belongs to the server host, not the caller, so exposing a
+    // path parameter would be a local-file-read vector.
+    if (allowFileBody && endpointConfig?.bodyFile) {
+      paramSchema['bodyFilePath'] = z
+        .string()
+        .describe(
+          'Path to a local .html/.txt file (absolute, or relative to the server working directory) whose contents become the email body. ' +
+            'Still pass recipients/subject in "body"; the file contents override any inline body content.'
+        )
+        .optional();
+      if (endpointConfig.bodyFile.contentTypeTarget) {
+        paramSchema['bodyContentType'] = z
+          .enum(['html', 'text'])
+          .describe(
+            'Content type for the file body. Inferred from the file extension (.html/.htm → html, else text) when omitted.'
+          )
+          .optional();
+      }
+    }
+
     // Build the tool description, optionally appending LLM tips
     let toolDescription = withApiVersionPrefix(
       tool.description || `Execute ${tool.method.toUpperCase()} request to ${tool.path}`,
@@ -1071,7 +1134,8 @@ export function registerGraphTools(
             !isReadOnlyTool && ['POST', 'PATCH', 'DELETE'].includes(tool.method.toUpperCase()),
           openWorldHint: true, // All tools call Microsoft Graph API
         },
-        async (params) => executeGraphTool(tool, endpointConfig, graphClient, params, authManager)
+        async (params) =>
+          executeGraphTool(tool, endpointConfig, graphClient, params, authManager, allowFileBody)
       );
       registeredCount++;
     } catch (error) {

--- a/src/lib/body-file.ts
+++ b/src/lib/body-file.ts
@@ -1,0 +1,91 @@
+/**
+ * Helpers for using a local file's contents as an email message body.
+ *
+ * The mail tools (send-mail, create-draft-email and their shared-mailbox
+ * variants) take a single `body` parameter holding the full Microsoft Graph
+ * payload. The message text lives at a different place per endpoint
+ * (`message.body.content` for /sendMail, `body.content` for a draft message),
+ * so the target location is declared per-endpoint in endpoints.json via a
+ * `bodyFile` config and applied here.
+ *
+ * These functions are pure (no I/O) so the file read and its error handling
+ * stay in the tool handler, where they can be turned into an MCP error result.
+ */
+
+export type BodyFileContentType = 'html' | 'text';
+
+export interface BodyFileConfig {
+  /** Dot-path within the request body where the file contents are written. */
+  contentTarget: string;
+  /** Dot-path where the content type ('html'|'text') is written. Omit for plain-text-only targets (e.g. a reply `comment`). */
+  contentTypeTarget?: string;
+}
+
+/**
+ * Infer the Graph body content type from a file extension.
+ * `.html`/`.htm` → 'html', everything else → 'text'.
+ */
+export function inferContentType(filePath: string): BodyFileContentType {
+  return /\.html?$/i.test(filePath) ? 'html' : 'text';
+}
+
+/**
+ * Find an existing own key on `node` that matches `key` case-insensitively,
+ * returning the actual key if present. This lets the merge reuse whatever
+ * casing the caller used (e.g. the Graph sendMail action wrapper is `Message`,
+ * not `message`) instead of creating a second, conflicting key.
+ */
+function resolveKey(node: Record<string, unknown>, key: string): string {
+  if (Object.prototype.hasOwnProperty.call(node, key)) return key;
+  const lower = key.toLowerCase();
+  for (const existing of Object.keys(node)) {
+    if (existing.toLowerCase() === lower) return existing;
+  }
+  return key;
+}
+
+/**
+ * Set a value at a dot-path within `target`, creating intermediate plain
+ * objects as needed. Sibling keys are preserved, so caller-provided fields
+ * (recipients, subject, ...) are never clobbered. Path segments match existing
+ * keys case-insensitively, so writing `Message.body.content` lands inside a
+ * caller-supplied `message`/`Message` object rather than adding a duplicate.
+ */
+export function setByPath(target: Record<string, unknown>, dotPath: string, value: unknown): void {
+  const keys = dotPath.split('.');
+  let node: Record<string, unknown> = target;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = resolveKey(node, keys[i]);
+    const next = node[key];
+    if (typeof next !== 'object' || next === null || Array.isArray(next)) {
+      node[key] = {};
+    }
+    node = node[key] as Record<string, unknown>;
+  }
+  const leaf = resolveKey(node, keys[keys.length - 1]);
+  node[leaf] = value;
+}
+
+/**
+ * Merge file contents into a copy of the caller-supplied request body at the
+ * locations declared by `config`. The file content overrides any inline
+ * content already present at `contentTarget`. Returns a new object; the input
+ * is not mutated.
+ */
+export function applyBodyFile(
+  requestBody: unknown,
+  config: BodyFileConfig,
+  fileContent: string,
+  contentType: BodyFileContentType
+): Record<string, unknown> {
+  const base: Record<string, unknown> =
+    typeof requestBody === 'object' && requestBody !== null && !Array.isArray(requestBody)
+      ? structuredClone(requestBody as Record<string, unknown>)
+      : {};
+
+  setByPath(base, config.contentTarget, fileContent);
+  if (config.contentTypeTarget) {
+    setByPath(base, config.contentTypeTarget, contentType);
+  }
+  return base;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -132,7 +132,11 @@ class MicrosoftGraphServer {
         this.authManager,
         this.multiAccount,
         this.accountNames,
-        this.options.allowedScopes
+        this.options.allowedScopes,
+        // Reading the email body from a local file is only safe in stdio mode, where the
+        // server runs on the caller's own machine. HTTP, OBO and trust-proxy-auth all set
+        // options.http, so the bodyFilePath parameter is not exposed in those deployments.
+        !this.options.http
       );
     }
 

--- a/test/allowed-scopes.test.ts
+++ b/test/allowed-scopes.test.ts
@@ -211,7 +211,9 @@ describe('allowed scope HTTP behavior', () => {
       expect.anything(),
       false,
       [],
-      'Mail.Read'
+      'Mail.Read',
+      // allowFileBody — false here because http: true (stdio-only feature)
+      false
     );
   });
 });

--- a/test/body-file.test.ts
+++ b/test/body-file.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { inferContentType, setByPath, applyBodyFile } from '../src/lib/body-file.js';
+
+describe('body-file helper', () => {
+  describe('inferContentType', () => {
+    it('maps .html and .htm to html (case-insensitive)', () => {
+      expect(inferContentType('/tmp/newsletter.html')).toBe('html');
+      expect(inferContentType('/tmp/page.HTM')).toBe('html');
+      expect(inferContentType('C:\\mail\\Body.Html')).toBe('html');
+    });
+
+    it('maps everything else to text', () => {
+      expect(inferContentType('/tmp/body.txt')).toBe('text');
+      expect(inferContentType('/tmp/body')).toBe('text');
+      expect(inferContentType('/tmp/body.md')).toBe('text');
+    });
+  });
+
+  describe('setByPath', () => {
+    it('sets a nested leaf, creating intermediate objects', () => {
+      const target: Record<string, unknown> = {};
+      setByPath(target, 'message.body.content', 'hello');
+      expect(target).toEqual({ message: { body: { content: 'hello' } } });
+    });
+
+    it('preserves sibling keys at every level', () => {
+      const target: Record<string, unknown> = {
+        message: { subject: 'Hi', body: { contentType: 'text' }, toRecipients: [{ x: 1 }] },
+      };
+      setByPath(target, 'message.body.content', 'world');
+      expect(target).toEqual({
+        message: {
+          subject: 'Hi',
+          body: { contentType: 'text', content: 'world' },
+          toRecipients: [{ x: 1 }],
+        },
+      });
+    });
+
+    it('replaces a non-object node in the path with an object', () => {
+      const target: Record<string, unknown> = { message: { body: 'oops' } };
+      setByPath(target, 'message.body.content', 'fixed');
+      expect(target).toEqual({ message: { body: { content: 'fixed' } } });
+    });
+
+    it('handles a single-segment path', () => {
+      const target: Record<string, unknown> = { keep: 1 };
+      setByPath(target, 'comment', 'reply text');
+      expect(target).toEqual({ keep: 1, comment: 'reply text' });
+    });
+
+    it('reuses an existing key that differs only in case (no duplicate)', () => {
+      // The Graph sendMail action wrapper is `Message`; writing `Message.body.content`
+      // must land inside it, not create a second key.
+      const target: Record<string, unknown> = {
+        Message: { toRecipients: [{ emailAddress: { address: 'a@b.com' } }] },
+      };
+      setByPath(target, 'Message.body.content', 'hi');
+      expect(Object.keys(target)).toEqual(['Message']);
+      expect(target).toEqual({
+        Message: {
+          toRecipients: [{ emailAddress: { address: 'a@b.com' } }],
+          body: { content: 'hi' },
+        },
+      });
+    });
+
+    it('matches case-insensitively when target casing differs from caller casing', () => {
+      // Config says `Message.*` but caller used lowercase `message`: reuse it.
+      const target: Record<string, unknown> = { message: { subject: 'Hi' } };
+      setByPath(target, 'Message.body.content', 'hi');
+      expect(Object.keys(target)).toEqual(['message']);
+      expect(target).toEqual({ message: { subject: 'Hi', body: { content: 'hi' } } });
+    });
+  });
+
+  describe('applyBodyFile', () => {
+    const config = {
+      contentTarget: 'message.body.content',
+      contentTypeTarget: 'message.body.contentType',
+    };
+
+    it('writes content and content type without clobbering caller fields', () => {
+      const result = applyBodyFile(
+        {
+          message: { subject: 'Report', toRecipients: [{ emailAddress: { address: 'a@b.com' } }] },
+        },
+        config,
+        '<h1>Hi</h1>',
+        'html'
+      );
+      expect(result).toEqual({
+        message: {
+          subject: 'Report',
+          toRecipients: [{ emailAddress: { address: 'a@b.com' } }],
+          body: { content: '<h1>Hi</h1>', contentType: 'html' },
+        },
+      });
+    });
+
+    it('overrides any inline content already present', () => {
+      const result = applyBodyFile(
+        { message: { body: { content: 'OLD', contentType: 'text' } } },
+        config,
+        'NEW',
+        'html'
+      );
+      expect((result.message as any).body).toEqual({ content: 'NEW', contentType: 'html' });
+    });
+
+    it('does not mutate the input object', () => {
+      const input = { message: { subject: 'x' } };
+      const result = applyBodyFile(input, config, 'body', 'text');
+      expect(input).toEqual({ message: { subject: 'x' } });
+      expect(result).not.toBe(input);
+    });
+
+    it('treats null/non-object body as an empty object', () => {
+      expect(applyBodyFile(null, config, 'c', 'text')).toEqual({
+        message: { body: { content: 'c', contentType: 'text' } },
+      });
+      expect(applyBodyFile(undefined, { contentTarget: 'body.content' }, 'c', 'text')).toEqual({
+        body: { content: 'c' },
+      });
+    });
+
+    it('omits the content type when no contentTypeTarget is configured', () => {
+      const result = applyBodyFile({}, { contentTarget: 'comment' }, 'reply', 'html');
+      expect(result).toEqual({ comment: 'reply' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an optional `bodyFilePath` parameter to the mail tools so a caller can use a local `.html`/`.txt` file as the email body instead of inlining the whole body into the tool-call arguments. This is handy for templated/large HTML emails, where inlining the body wastes context.

Closes #549.

Applies to: `send-mail`, `create-draft-email`, `send-shared-mailbox-mail`, `create-shared-mailbox-draft`.

## How it works

- **Declarative, per-endpoint** — each supported entry in `endpoints.json` gets a `bodyFile` config (`contentTarget` / `contentTypeTarget`) describing *where* in the request body the file contents go. The message text lives at different paths per endpoint (`Message.body.content` for the `sendMail` action vs `body.content` for a draft message), so the target is data-driven rather than hard-coded.
- **Param injection** reuses the existing mechanism (the same path as `account` / `timezone`): when an endpoint declares `bodyFile`, an optional `bodyFilePath` and `bodyContentType` (`html`/`text`, inferred from the extension when omitted) are added to that tool's schema.
- **Pure helper** `src/lib/body-file.ts` (`inferContentType`, `setByPath`, `applyBodyFile`) does the merge; the file read + error handling stay in the tool handler so a read failure becomes a clean MCP error result.
- **Case-insensitive merge** — Graph's `sendMail` action wraps the message under the capital `Message` parameter, while a draft message uses lowercase `body`. `setByPath` matches existing keys case-insensitively, so the file content is merged *into* whatever wrapper the caller supplied (`Message` or `message`) rather than ever creating a duplicate key (which Graph rejects with a 500 "property with the same name already exists").

## Security / gating

Reading a path off disk only makes sense in **stdio** mode, where the server runs on the caller's own machine. The parameter is gated behind a new `allowFileBody` flag derived from `!options.http`, so it is **not registered at all in HTTP / OBO / trust-proxy deployments** (where the filesystem belongs to the server host, not the caller).

## Backward compatibility

`bodyFilePath` / `bodyContentType` are optional and additive — existing inline-body usage is unchanged (covered by a regression test asserting a byte-identical request when no file path is given).

## Tests

- `test/body-file.test.ts` — unit tests for the helper (content-type inference, no-clobber deep set, case-insensitive key reuse, inline override).
- `src/__tests__/graph-tools.test.ts` — integration tests: HTML/text inference, explicit content-type override, file-not-found → `isError` (no Graph call), inline override, the duplicate-`Message` collision regression, case-insensitive wrapper reuse, the no-`bodyFilePath` regression, and the HTTP-mode gating check.

Full suite green (`npm run verify`): generate → lint → format → build → 502 tests pass.

## Out of scope (possible follow-ups)

- reply/forward tools (their body is a plain `comment` string, no content type).
- attachments from a file path.
- discovery-mode registration (`registerDiscoveryTools`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)