### PR TITLE
fix(download-bytes): return JSON /content bodies verbatim instead of lossy re-serialization

### DIFF
--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -144,6 +144,12 @@ class GraphClient {
 
         if (text === '') {
           result = { message: 'OK!' };
+        } else if (options.rawResponse) {
+          // download-bytes on /content wants the body verbatim. A JSON body
+          // would otherwise round-trip through JSON.parse -> JSON.stringify,
+          // which is lossy (whitespace, trailing newline, key order, number
+          // formatting). Return the raw text instead. (issue #546)
+          result = { message: 'OK!', rawResponse: text };
         } else {
           try {
             result = JSON.parse(text);

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -353,7 +353,13 @@ export const UTILITY_TOOLS: readonly UtilityTool[] = [
         if (authManager && !authManager.isOAuthModeEnabled() && !getRequestTokens()) {
           accountAccessToken = await authManager.getTokenForAccount(accountParam);
         }
-        return await graphClient.graphRequest(target, { accessToken: accountAccessToken });
+        // rawResponse keeps the body byte-faithful: binary stays base64 and a
+        // JSON body is returned verbatim instead of being re-serialized lossily
+        // through JSON.parse -> JSON.stringify (issue #546).
+        return await graphClient.graphRequest(target, {
+          accessToken: accountAccessToken,
+          rawResponse: true,
+        });
       } catch (error) {
         return {
           content: [{ type: 'text', text: JSON.stringify({ error: (error as Error).message }) }],

--- a/test/binary-response.test.ts
+++ b/test/binary-response.test.ts
@@ -104,4 +104,118 @@ describe('GraphClient binary response handling', () => {
       global.fetch = originalFetch;
     }
   });
+
+  it('returns a JSON /content body verbatim when rawResponse is set (issue #546)', async () => {
+    const { default: GraphClient } = await import('../src/graph-client.js');
+
+    // Pretty-printed JSON that JSON.parse->JSON.stringify would not preserve
+    // (indentation and trailing newline get dropped).
+    const prettyJson = '{\n  "a": 1,\n  "b": 2\n}\n';
+
+    const originalFetch = global.fetch;
+    global.fetch = (async () =>
+      new Response(prettyJson, {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })) as typeof fetch;
+
+    try {
+      const mockAuth = {
+        getToken: async () => 'fake-token',
+      };
+      const mockSecrets = {
+        clientId: 'x',
+        tenantId: 'common',
+        cloudType: 'global',
+      };
+      const client = new GraphClient(
+        mockAuth as Parameters<typeof GraphClient>[0],
+        mockSecrets as Parameters<typeof GraphClient>[1],
+        'json'
+      );
+
+      const result = (await client.makeRequest('/me/drive/items/x/content', {
+        rawResponse: true,
+      })) as Record<string, unknown>;
+
+      expect(result.rawResponse).toBe(prettyJson);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  it('preserves a JSON /content body byte-for-byte through graphRequest (issue #546)', async () => {
+    // End-to-end through graphRequest -> formatJsonResponse, the path the
+    // download-bytes tool actually uses. The body must survive verbatim in the
+    // serialized MCP content, not just at the makeRequest layer.
+    const { default: GraphClient } = await import('../src/graph-client.js');
+
+    const prettyJson = '{\n  "a": 1,\n  "b": 2\n}\n';
+
+    const originalFetch = global.fetch;
+    global.fetch = (async () =>
+      new Response(prettyJson, {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })) as typeof fetch;
+
+    try {
+      const mockAuth = {
+        getToken: async () => 'fake-token',
+      };
+      const mockSecrets = {
+        clientId: 'x',
+        tenantId: 'common',
+        cloudType: 'global',
+      };
+      const client = new GraphClient(
+        mockAuth as Parameters<typeof GraphClient>[0],
+        mockSecrets as Parameters<typeof GraphClient>[1],
+        'json'
+      );
+
+      const response = await client.graphRequest('/me/drive/items/x/content', {
+        rawResponse: true,
+      });
+      const payload = JSON.parse(response.content[0].text as string);
+
+      expect(payload.rawResponse).toBe(prettyJson);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  it('still parses JSON bodies when rawResponse is not set', async () => {
+    const { default: GraphClient } = await import('../src/graph-client.js');
+
+    const originalFetch = global.fetch;
+    global.fetch = (async () =>
+      new Response('{"value":42}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })) as typeof fetch;
+
+    try {
+      const mockAuth = {
+        getToken: async () => 'fake-token',
+      };
+      const mockSecrets = {
+        clientId: 'x',
+        tenantId: 'common',
+        cloudType: 'global',
+      };
+      const client = new GraphClient(
+        mockAuth as Parameters<typeof GraphClient>[0],
+        mockSecrets as Parameters<typeof GraphClient>[1],
+        'json'
+      );
+
+      const result = (await client.makeRequest('/me/messages')) as Record<string, unknown>;
+
+      expect(result.value).toBe(42);
+      expect(result.rawResponse).toBeUndefined();
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
 });


### PR DESCRIPTION
download-bytes on a /content body that parses as JSON ran the bytes through JSON.parse -> JSON.stringify, dropping whitespace, trailing newlines, key order and number formatting, and changing the response shape to a bare value.

Set rawResponse on the download-bytes graphRequest call and honor it in makeRequest's non-binary branch by returning the body text verbatim in the same { message, rawResponse } envelope already used for .md/.css/.svg. Both changes are required: without rawResponse the tool never hits the new branch, and without the branch the parsed object is still re-serialized lossily.

Fixes #546