### PR TITLE
feat: add GCF output format (--gcf flag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,52 @@ Via environment variable:
 MS365_MCP_OUTPUT_FORMAT=toon npx @softeria/ms-365-mcp-server
 ```
 
+### GCF Format
+
+[GCF (Graph Compact Format)](https://gcformat.com) for token-optimized LLM output:
+
+```
+GCF profile=generic
+## value [1]{id,displayName,mail,jobTitle}
+1|Alice Johnson|alice@example.com|Software Engineer
+```
+
+**Benefits:**
+
+- 18-32% fewer tokens vs JSON on MS365 data shapes (benchmarked on all 6 data types)
+- 24% fewer tokens vs TOON on the same data
+- 100% comprehension on every frontier model (Claude, GPT-5.5, Gemini, Grok)
+- Nested objects (calendar organizers, email senders) flatten into path columns for additional savings
+
+**Usage:**
+
+Via CLI flag:
+
+```bash
+npx @softeria/ms-365-mcp-server --gcf
+```
+
+Via Claude Desktop configuration:
+
+```json
+{
+  "mcpServers": {
+    "ms365": {
+      "command": "npx",
+      "args": ["-y", "@softeria/ms-365-mcp-server", "--gcf"]
+    }
+  }
+}
+```
+
+Via environment variable:
+
+```bash
+MS365_MCP_OUTPUT_FORMAT=gcf npx @softeria/ms-365-mcp-server
+```
+
+GCF is an optional dependency. Install it with `npm install @blackwell-systems/gcf` if it wasn't included automatically.
+
 ## Supported Services & Tools
 
 The server provides 200+ tools covering most of the Microsoft Graph API surface. Each tool maps 1-to-1 to a Graph API endpoint and is defined declaratively in [`src/endpoints.json`](src/endpoints.json).
@@ -574,6 +620,7 @@ When running as an MCP server, the following options can be used:
 --preset <names>  Use preset tool categories (comma-separated). See "Tool Presets" section above
 --list-presets    List all available presets and exit
 --toon            (experimental) Enable TOON output format for 30-60% token reduction
+--gcf             Enable GCF output format for 18-32% token reduction vs JSON
 --discovery       Dynamic tool discovery: loads tools on demand to reduce initial token usage (see "Dynamic Tool Discovery" above)
 --public-url <url> Public base URL for OAuth when behind a reverse proxy (see Open WebUI section and docs/deployment.md)
 ```

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "optionalDependencies": {
     "@azure/identity": "^4.5.0",
     "@azure/keyvault-secrets": "^4.9.0",
+    "@blackwell-systems/gcf": "^2.2.1",
     "keytar": "^7.9.0"
   },
   "devDependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,6 +64,7 @@ program
   .option('--work-mode', 'Alias for --org-mode')
   .option('--force-work-scopes', 'Backwards compatibility alias for --org-mode (deprecated)')
   .option('--toon', '(experimental) Enable TOON output format for 30-60% token reduction')
+  .option('--gcf', 'Enable GCF output format for 18-32% token reduction vs JSON (24% vs TOON)')
   .option('--discovery', 'Enable runtime tool discovery and loading (experimental feature)')
   .option('--cloud <type>', 'Microsoft cloud environment: global (default) or china (21Vianet)')
   .option(
@@ -124,6 +125,7 @@ export interface CommandOptions {
   workMode?: boolean;
   forceWorkScopes?: boolean;
   toon?: boolean;
+  gcf?: boolean;
   discovery?: boolean;
   cloud?: string;
   enableDynamicRegistration?: boolean;
@@ -267,6 +269,9 @@ export function parseArgs(): CommandOptions {
 
   if (process.env.MS365_MCP_OUTPUT_FORMAT === 'toon') {
     options.toon = true;
+  }
+  if (process.env.MS365_MCP_OUTPUT_FORMAT === 'gcf') {
+    options.gcf = true;
   }
 
   // Dynamic registration defaults to true in HTTP mode

--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -1,6 +1,14 @@
 import logger from './logger.js';
 import AuthManager from './auth.js';
 import { encode as toonEncode } from '@toon-format/toon';
+
+let encodeGeneric: ((data: unknown) => string) | null = null;
+try {
+  const gcf = await import('@blackwell-systems/gcf');
+  encodeGeneric = gcf.encodeGeneric;
+} catch {
+  // GCF is an optional dependency
+}
 import type { AppSecrets } from './secrets.js';
 import { getCloudEndpoints } from './cloud-config.js';
 import { getRequestTokens } from './request-context.js';
@@ -79,12 +87,12 @@ interface McpResponse {
 class GraphClient {
   private authManager: AuthManager;
   private secrets: AppSecrets;
-  private readonly outputFormat: 'json' | 'toon' = 'json';
+  private readonly outputFormat: 'json' | 'toon' | 'gcf' = 'json';
 
   constructor(
     authManager: AuthManager,
     secrets: AppSecrets,
-    outputFormat: 'json' | 'toon' = 'json'
+    outputFormat: 'json' | 'toon' | 'gcf' = 'json'
   ) {
     this.authManager = authManager;
     this.secrets = secrets;
@@ -209,7 +217,15 @@ class GraphClient {
     );
   }
 
-  private serializeData(data: unknown, outputFormat: 'json' | 'toon', pretty = false): string {
+  private serializeData(data: unknown, outputFormat: 'json' | 'toon' | 'gcf', pretty = false): string {
+    if (outputFormat === 'gcf' && encodeGeneric) {
+      try {
+        return encodeGeneric(data);
+      } catch (error) {
+        logger.warn(`Failed to encode as GCF, falling back to JSON: ${error}`);
+        return JSON.stringify(data, null, pretty ? 2 : undefined);
+      }
+    }
     if (outputFormat === 'toon') {
       try {
         return toonEncode(data);

--- a/src/server.ts
+++ b/src/server.ts
@@ -188,7 +188,7 @@ class MicrosoftGraphServer {
       logger.info('On-Behalf-Of (OBO) flow enabled');
     }
 
-    const outputFormat = this.options.toon ? 'toon' : 'json';
+    const outputFormat = this.options.gcf ? 'gcf' : this.options.toon ? 'toon' : 'json';
     this.graphClient = new GraphClient(this.authManager, this.secrets, outputFormat);
 
     if (!this.options.http) {


### PR DESCRIPTION
## Summary

Adds [GCF (Graph Compact Format)](https://gcformat.com) as an alternative output format alongside TOON and JSON. Opt-in via `--gcf` flag or `MS365_MCP_OUTPUT_FORMAT=gcf`. Optional dependency, zero changes to existing behavior.

## Why

We benchmarked all 6 MS365 data shapes (emails, calendar events, OneDrive files, contacts, planner tasks, chat messages) at 10/50/200 items using the o200k_base tokenizer:

| Data Type (200 items) | JSON | TOON | GCF | TOON vs JSON | GCF vs JSON | GCF vs TOON |
|----------------------|------|------|-----|-------------|-------------|-------------|
| Email messages | 26,761 | 29,546 | 22,019 | **+10.4%** | **-17.7%** | **-25.5%** |
| Calendar events | 47,421 | 51,730 | 35,016 | **+9.1%** | **-26.2%** | **-32.3%** |
| OneDrive files | 28,203 | 30,955 | 22,593 | **+9.8%** | **-19.9%** | **-27.0%** |
| Contacts | 23,951 | 25,426 | 20,834 | **+6.2%** | **-13.0%** | **-18.1%** |
| Planner tasks | 40,906 | 44,131 | 33,703 | **+7.9%** | **-17.6%** | **-23.6%** |
| Chat messages | 23,471 | 25,628 | 19,277 | **+9.2%** | **-17.9%** | **-24.8%** |

**TOON increases token counts by 8.8% vs JSON on MS365 data.** The YAML-based indentation encoding adds whitespace tokens that exceed the savings from removing JSON syntax. GCF saves 17.8% vs JSON and 24.4% vs TOON. GCF wins 18/18 comparisons.

Calendar events show the largest improvement (32% vs TOON) because GCF flattens nested organizer/attendee objects into path columns (`"organizer>name"`, `"organizer>email"`) instead of repeating the full nested structure on every row.

Benchmark script: [ms365-token-benchmark.mjs](https://github.com/blackwell-systems/gcf/blob/main/eval/ms365-token-benchmark.mjs)

## Why GCF over TOON

**TOON is not lossless.** We ran [10 million random structured values](https://github.com/blackwell-systems/gcf/blob/main/eval/results/toon-fuzz-10M-2026-06-16.log) through TOON's official encoder/decoder (`@toon-format/toon`). 7.54% of round-trips fail. 176,487 are silent data corruption: the encode and decode both "succeed" but the output doesn't match the input. Strings containing `[`, `]`, `{`, `}`, `:` are encoded unquoted and misparsed as format syntax. GCF has 43 billion+ lossless round-trips across 5 formats with zero failures.

**TOON's tab delimiter is worse than JSON's quote at the tokenization level.** We [tested all major tokenizers](https://gcformat.com/guide/tokenizer-analysis) (GPT-4o, Claude, LLaMA, Qwen, DeepSeek, Gemma, Mistral). TOON's tab character merges with adjacent field content on 59.8% of checks (1,344 tested). JSON's quote merges on 39.3%. GCF's pipe delimiter merges on 0.0%. The format designed to save tokens has worse tokenizer behavior than JSON on half the LLM market.

**LLM comprehension:**

| Eval | GCF | TOON | JSON |
|------|-----|------|------|
| General comprehension (500 orders) | **100%** every frontier model | 92.3% (fails GPT-5.5) | 76.9-100% |
| Adversarial code graphs (500 symbols) | **90.7%** | 68.5% | 53.6% |
| Generation validity (9 models) | **5/5** on every frontier model | TOON decoder rejects on 7/9 | 5/5 |

**Token efficiency across 16 real-world datasets:** GCF wins 15/16. TOON's one win is 77 tokens on a single dataset. GCF saves 218,480 tokens across the other 15. [Full comparison.](https://gcformat.com/guide/vs-toon)

## What changed

- `package.json`: added `@blackwell-systems/gcf` as optional dependency
- `src/cli.ts`: added `--gcf` flag and `MS365_MCP_OUTPUT_FORMAT=gcf` env var
- `src/server.ts`: GCF takes priority over TOON when both specified
- `src/graph-client.ts`: dynamic import of GCF (graceful fallback if not installed), `'gcf'` output format in `serializeData`
- `README.md`: GCF section parallel to existing TOON section, `--gcf` in flags table

## Implementation notes

- GCF is an optional dependency: the server works without it installed
- Dynamic `import()` with try/catch: if `@blackwell-systems/gcf` is not available, the import silently fails and `--gcf` falls back to JSON
- Same pattern as the existing TOON integration (try/catch in `serializeData`)
- Zero changes to existing JSON or TOON behavior

## Spec

- [GCF Specification v3.2 Stable](https://github.com/blackwell-systems/gcf/blob/main/SPEC.md)
- 174 conformance fixtures, 6 implementations (Go, TypeScript, Python, Rust, Swift, Kotlin)
- Zero runtime dependencies in every implementation
- [Documentation](https://gcformat.com)