### PR TITLE
fix(auth): keep file-backed MSAL token cache coherent across concurrent processes (#545)

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,4 +1,4 @@
-import type { AccountInfo, Configuration } from '@azure/msal-node';
+import type { AccountInfo, Configuration, ICachePlugin, TokenCacheContext } from '@azure/msal-node';
 import { AuthError, PublicClientApplication } from '@azure/msal-node';
 import logger from './logger.js';
 import { readFileSync } from 'fs';
@@ -51,6 +51,55 @@ function createMsalConfig(secrets: AppSecrets): Configuration {
     auth: {
       clientId: secrets.clientId || getDefaultClientId(secrets.cloudType),
       authority: `${cloudEndpoints.authority}/${secrets.tenantId || 'common'}`,
+    },
+  };
+}
+
+/**
+ * Builds an MSAL cache plugin that keeps the file-backed token cache coherent across
+ * concurrent processes. In the common stdio deployment several MCP server processes share
+ * one token cache file. Microsoft rotates refresh tokens on silent refresh, so without this
+ * plugin a process holds whatever it loaded at startup and fails once a sibling rotates the
+ * refresh token on disk (invalid_grant / no_tokens_found). See issue #545.
+ *
+ * MSAL invokes beforeCacheAccess/afterCacheAccess around every cache operation, so:
+ *  - beforeCacheAccess reloads the newest persisted cache into MSAL right before each access
+ *  - afterCacheAccess persists (atomically, via storage) only when MSAL changed the cache
+ * This preserves the existing cache envelope (wrapCache) and the storage provider's
+ * fail-closed semantics.
+ *
+ * This is best-effort, last-writer-wins reconciliation (the storage layer breaks ties via
+ * the savedAt stamp), not a cross-process lock. It closes the dominant #545 window - a
+ * long-lived sibling refreshing against a token another process already rotated on disk -
+ * but two processes refreshing the very same refresh token at the same instant can still race.
+ */
+export function buildDiskCoherencyCachePlugin(storage: TokenCacheStorage): ICachePlugin {
+  return {
+    beforeCacheAccess: async (context: TokenCacheContext) => {
+      try {
+        const cacheRaw = await storage.load('token-cache');
+        if (cacheRaw) {
+          context.tokenCache.deserialize(unwrapCache(cacheRaw).data);
+        }
+      } catch (error) {
+        logger.error(`Error reloading token cache: ${(error as Error).message}`);
+        if (storage.failClosed) {
+          throw error;
+        }
+      }
+    },
+    afterCacheAccess: async (context: TokenCacheContext) => {
+      if (!context.cacheHasChanged) {
+        return;
+      }
+      try {
+        await storage.save('token-cache', wrapCache(context.tokenCache.serialize()));
+      } catch (error) {
+        logger.error(`Error saving token cache: ${(error as Error).message}`);
+        if (storage.failClosed) {
+          throw error;
+        }
+      }
     },
   };
 }
@@ -558,8 +607,17 @@ class AuthManager {
     storage?: TokenCacheStorage
   ) {
     logger.info(`And scopes are ${scopes.join(', ')}`, scopes);
-    this.config = config;
     this.scopes = scopes;
+    this.storage = storage ?? new DefaultTokenCacheStorage();
+    // Register a cache plugin so MSAL reloads the newest persisted cache before every access
+    // and persists rotations, keeping concurrent stdio processes coherent (issue #545).
+    this.config = {
+      ...config,
+      cache: {
+        ...config.cache,
+        cachePlugin: buildDiskCoherencyCachePlugin(this.storage),
+      },
+    };
     this.msalApp = new PublicClientApplication(this.config);
     this.accessToken = null;
     this.tokenExpiry = null;
@@ -569,7 +627,6 @@ class AuthManager {
     this.expectedHomeAccountId = this.normalizeExpectedHomeAccountId(
       expectedAccount?.expectedHomeAccountId
     );
-    this.storage = storage ?? new DefaultTokenCacheStorage();
 
     const oauthTokenFromEnv = process.env.MS365_MCP_OAUTH_TOKEN;
     this.oauthToken = oauthTokenFromEnv ?? null;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -70,8 +70,12 @@ function createMsalConfig(secrets: AppSecrets): Configuration {
  *
  * This is best-effort, last-writer-wins reconciliation (the storage layer breaks ties via
  * the savedAt stamp), not a cross-process lock. It closes the dominant #545 window - a
- * long-lived sibling refreshing against a token another process already rotated on disk -
- * but two processes refreshing the very same refresh token at the same instant can still race.
+ * long-lived sibling refreshing against a token another process already rotated on disk.
+ * Two known limits remain, both accepted as out of scope in the #545 discussion:
+ *  - Two processes refreshing the very same refresh token at the same instant can still race.
+ *  - A sibling logout is not reflected in an already-running process: load() returns nothing
+ *    so the deletion is not picked up (the deserialize is guarded on a present cache), and a
+ *    later successful silent acquire here persists the in-memory cache, recreating the file.
  */
 export function buildDiskCoherencyCachePlugin(storage: TokenCacheStorage): ICachePlugin {
   return {
@@ -683,18 +687,6 @@ class AuthManager {
     }
   }
 
-  async saveTokenCache(): Promise<void> {
-    try {
-      const stamped = wrapCache(this.msalApp.getTokenCache().serialize());
-      await this.storage.save('token-cache', stamped);
-    } catch (error) {
-      logger.error(`Error saving token cache: ${(error as Error).message}`);
-      if (this.storage.failClosed) {
-        throw error;
-      }
-    }
-  }
-
   private async saveSelectedAccount(): Promise<void> {
     try {
       const stamped = wrapCache(JSON.stringify({ accountId: this.selectedAccountId }));
@@ -832,10 +824,21 @@ class AuthManager {
     this.tokenExpiry = null;
 
     if (account) {
+      // The cache plugin (afterCacheAccess) persists during the acquire call, so a mismatched
+      // account's tokens are already on disk by the time we get here. removeAccount triggers the
+      // plugin again to persist the removal - but if it fails we must NOT claim the login was not
+      // persisted, because the rejected account's tokens remain in the shared cache. Surface that
+      // loudly and actionably instead of swallowing it (issue #545 hardening).
       try {
         await this.msalApp.getTokenCache().removeAccount(account);
       } catch (error) {
-        logger.warn(`Failed to remove unexpected account from cache: ${(error as Error).message}`);
+        logger.error(`Failed to remove unexpected account from cache: ${(error as Error).message}`);
+        throw new Error(
+          `Authenticated Microsoft account '${this.describeAccount(account)}' does not match expected ` +
+            `Microsoft account '${this.expectedAccountLabel()}', and it could not be removed from the ` +
+            `token cache (${(error as Error).message}). Its tokens may remain persisted - run --logout ` +
+            `to clear the cache, then re-login.`
+        );
       }
       throw new Error(
         `Authenticated Microsoft account '${this.describeAccount(account)}' does not match expected Microsoft account '${this.expectedAccountLabel()}'. Login was not persisted.`
@@ -873,7 +876,10 @@ class AuthManager {
         const response = await this.msalApp.acquireTokenSilent(silentRequest);
         this.accessToken = response.accessToken;
         this.tokenExpiry = response.expiresOn ? new Date(response.expiresOn).getTime() : null;
-        await this.saveTokenCache();
+        // Persistence is owned by the cache plugin (afterCacheAccess): when MSAL rotates the
+        // refresh token it reloads-then-saves under the coherency protocol. A manual save here
+        // would serialize the in-memory cache without the reload-before-write step and could
+        // clobber a newer rotation a sibling process wrote in the meantime (issue #545).
         return this.accessToken;
       } catch (error) {
         const hint = consumersAuthorityHint(error, currentAccount, this.config.auth.authority);
@@ -948,7 +954,8 @@ class AuthManager {
         logger.info(`Auto-selected new account: ${response.account.username}`);
       }
 
-      await this.saveTokenCache();
+      // MSAL persisted the new tokens via the cache plugin (afterCacheAccess) during the
+      // acquire call; no manual save needed (issue #545).
       return this.accessToken;
     } catch (error) {
       logger.error(`Error in device code flow: ${(error as Error).message}`);
@@ -999,7 +1006,8 @@ class AuthManager {
         logger.info(`Auto-selected new account: ${response.account.username}`);
       }
 
-      await this.saveTokenCache();
+      // MSAL persisted the new tokens via the cache plugin (afterCacheAccess) during the
+      // acquire call; no manual save needed (issue #545).
       return this.accessToken;
     } catch (error) {
       logger.error(`Error in interactive browser flow: ${(error as Error).message}`);
@@ -1269,7 +1277,7 @@ class AuthManager {
 
     try {
       const response = await this.msalApp.acquireTokenSilent(silentRequest);
-      await this.saveTokenCache();
+      // Persistence is owned by the cache plugin (afterCacheAccess); see getToken (issue #545).
       return response.accessToken;
     } catch (error) {
       const hint = consumersAuthorityHint(error, targetAccount, this.config.auth.authority);

--- a/test/auth-pinning.test.ts
+++ b/test/auth-pinning.test.ts
@@ -51,7 +51,6 @@ function createAuth(accounts: AccountInfo[], expectedAccount?: ExpectedAccountOp
 
   Object.assign(auth as unknown as Record<string, unknown>, {
     msalApp,
-    saveTokenCache: vi.fn(),
     saveSelectedAccount: vi.fn(),
   });
 
@@ -154,11 +153,29 @@ describe('strict expected account pinning', () => {
 
     expect(tokenCache.removeAccount).toHaveBeenCalledWith(personal);
     expect(
-      (auth as unknown as { saveTokenCache: ReturnType<typeof vi.fn> }).saveTokenCache
-    ).not.toHaveBeenCalled();
-    expect(
       (auth as unknown as { saveSelectedAccount: ReturnType<typeof vi.fn> }).saveSelectedAccount
     ).not.toHaveBeenCalled();
+    expect((auth as unknown as { accessToken: string | null }).accessToken).toBeNull();
+  });
+
+  it('reports an actionable error when a mismatched account cannot be removed', async () => {
+    // The cache plugin persists the mismatched account during the acquire call; if removeAccount
+    // then fails, the rejected account remains on disk, so the error must say so (not the plain
+    // "Login was not persisted") and point the user at --logout (issue #545 hardening).
+    const { auth, msalApp, tokenCache } = createAuth([personal], {
+      expectedUsername: 'work@example.com',
+    });
+    msalApp.acquireTokenByDeviceCode.mockResolvedValue({
+      accessToken: 'bad-token',
+      expiresOn: new Date(Date.now() + 60_000),
+      account: personal,
+      scopes: ['User.Read'],
+    });
+    tokenCache.removeAccount.mockRejectedValue(new Error('keychain locked'));
+
+    await expect(auth.acquireTokenByDeviceCode()).rejects.toThrow(
+      /could not be removed from the token cache \(keychain locked\).*may remain persisted.*--logout/s
+    );
     expect((auth as unknown as { accessToken: string | null }).accessToken).toBeNull();
   });
 
@@ -176,9 +193,7 @@ describe('strict expected account pinning', () => {
     await expect(auth.acquireTokenByDeviceCode()).rejects.toThrow(/did not return an account/);
 
     expect(tokenCache.removeAccount).not.toHaveBeenCalled();
-    expect(
-      (auth as unknown as { saveTokenCache: ReturnType<typeof vi.fn> }).saveTokenCache
-    ).not.toHaveBeenCalled();
+    expect((auth as unknown as { accessToken: string | null }).accessToken).toBeNull();
   });
 
   it('collapses effective multi-account mode when a pin is configured', async () => {

--- a/test/auth-silent-error.test.ts
+++ b/test/auth-silent-error.test.ts
@@ -138,7 +138,6 @@ describe('silent failure hints at the call sites', () => {
 
     Object.assign(auth as unknown as Record<string, unknown>, {
       msalApp,
-      saveTokenCache: vi.fn(),
       saveSelectedAccount: vi.fn(),
     });
 

--- a/test/auth-storage.test.ts
+++ b/test/auth-storage.test.ts
@@ -1,6 +1,6 @@
 import type { AccountInfo, Configuration } from '@azure/msal-node';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import AuthManager from '../src/auth.js';
+import AuthManager, { buildDiskCoherencyCachePlugin } from '../src/auth.js';
 import { clearSecretsCache } from '../src/secrets.js';
 import { shouldUseLocalAuthStorage } from '../src/startup-pinning.js';
 import type { TokenCacheStorage } from '../src/token-cache-storage.js';
@@ -148,6 +148,98 @@ describe('AuthManager token cache storage', () => {
 
     const storage = (auth as unknown as { storage: TokenCacheStorage }).storage;
     expect(storage.description).toBe('default (keytar+file)');
+  });
+});
+
+interface FakeTokenCacheContext {
+  cacheHasChanged: boolean;
+  tokenCache: {
+    serialize: () => string;
+    deserialize: (data: string) => void;
+  };
+}
+
+function fakeContext(
+  serialized: string,
+  cacheHasChanged: boolean
+): { context: FakeTokenCacheContext; deserialized: string[] } {
+  const deserialized: string[] = [];
+  return {
+    deserialized,
+    context: {
+      cacheHasChanged,
+      tokenCache: {
+        serialize: () => serialized,
+        deserialize: (data: string) => {
+          deserialized.push(data);
+        },
+      },
+    },
+  };
+}
+
+describe('disk coherency cache plugin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps sibling processes coherent: A persists a rotation, B reloads it', async () => {
+    // One shared cache "file" backing two independent processes.
+    let diskRaw: string | undefined;
+    const storage = createStorage({
+      load: vi.fn(async () => diskRaw),
+      save: vi.fn(async (_key: string, value: string) => {
+        diskRaw = value;
+      }),
+    });
+
+    // Process A refreshes and rotates the refresh token, MSAL marks the cache changed.
+    const pluginA = buildDiskCoherencyCachePlugin(storage);
+    const a = fakeContext('rotated-cache', true);
+    await pluginA.afterCacheAccess!(a.context as never);
+    expect(storage.save).toHaveBeenCalledWith('token-cache', expect.any(String));
+    expect(unwrapCache(diskRaw!).data).toBe('rotated-cache');
+
+    // Process B accesses its cache later and must pick up A's rotation from disk.
+    const pluginB = buildDiskCoherencyCachePlugin(storage);
+    const b = fakeContext('stale-cache', false);
+    await pluginB.beforeCacheAccess!(b.context as never);
+    expect(b.deserialized).toEqual(['rotated-cache']);
+  });
+
+  it('does not persist when MSAL reports the cache is unchanged', async () => {
+    const storage = createStorage();
+    const plugin = buildDiskCoherencyCachePlugin(storage);
+    const { context } = fakeContext('unchanged-cache', false);
+
+    await plugin.afterCacheAccess!(context as never);
+
+    expect(storage.save).not.toHaveBeenCalled();
+  });
+
+  it('rethrows fail-closed reload errors', async () => {
+    const storage = createStorage({
+      failClosed: true,
+      load: vi.fn().mockRejectedValue(new Error('storage unavailable')),
+    });
+    const plugin = buildDiskCoherencyCachePlugin(storage);
+    const { context } = fakeContext('cache', false);
+
+    await expect(plugin.beforeCacheAccess!(context as never)).rejects.toThrow(
+      /storage unavailable/
+    );
+  });
+
+  it('swallows best-effort reload errors for non-strict storage', async () => {
+    const storage = createStorage({
+      failClosed: false,
+      load: vi.fn().mockRejectedValue(new Error('best-effort miss')),
+    });
+    const plugin = buildDiskCoherencyCachePlugin(storage);
+    const { context, deserialized } = fakeContext('cache', false);
+
+    await expect(plugin.beforeCacheAccess!(context as never)).resolves.toBeUndefined();
+    expect(deserialized).toEqual([]);
   });
 });
 

--- a/test/auth-storage.test.ts
+++ b/test/auth-storage.test.ts
@@ -90,15 +90,17 @@ describe('AuthManager token cache storage', () => {
     expect(auth.getSelectedAccountId()).toBe('account.home');
   });
 
-  it('saves the MSAL cache after silent token refresh', async () => {
+  it('delegates token-cache persistence to the cache plugin, not a manual save', async () => {
+    // Persistence after a silent refresh is owned by the MSAL cache plugin (afterCacheAccess),
+    // which reloads-then-saves under the coherency protocol. getToken must NOT blind-save the
+    // token-cache key itself, or it could clobber a newer sibling rotation (issue #545).
     const storage = createStorage();
     const { auth } = createAuth(storage);
 
-    await auth.getToken();
+    const token = await auth.getToken();
 
-    expect(storage.save).toHaveBeenCalledWith('token-cache', expect.any(String));
-    const saved = vi.mocked(storage.save).mock.calls[0][1];
-    expect(unwrapCache(saved).data).toBe('serialized-cache');
+    expect(token).toBe('silent-token');
+    expect(storage.save).not.toHaveBeenCalledWith('token-cache', expect.any(String));
   });
 
   it('saves selected-account metadata on account selection', async () => {
@@ -240,6 +242,110 @@ describe('disk coherency cache plugin', () => {
 
     await expect(plugin.beforeCacheAccess!(context as never)).resolves.toBeUndefined();
     expect(deserialized).toEqual([]);
+  });
+
+  it('rethrows fail-closed persist errors', async () => {
+    const storage = createStorage({
+      failClosed: true,
+      save: vi.fn().mockRejectedValue(new Error('persist unavailable')),
+    });
+    const plugin = buildDiskCoherencyCachePlugin(storage);
+    const { context } = fakeContext('rotated-cache', true);
+
+    await expect(plugin.afterCacheAccess!(context as never)).rejects.toThrow(/persist unavailable/);
+  });
+
+  it('swallows best-effort persist errors for non-strict storage', async () => {
+    const storage = createStorage({
+      failClosed: false,
+      save: vi.fn().mockRejectedValue(new Error('best-effort persist miss')),
+    });
+    const plugin = buildDiskCoherencyCachePlugin(storage);
+    const { context } = fakeContext('rotated-cache', true);
+
+    await expect(plugin.afterCacheAccess!(context as never)).resolves.toBeUndefined();
+    expect(storage.save).toHaveBeenCalledWith('token-cache', expect.any(String));
+  });
+});
+
+describe('rejected login leaves no account persisted (integration)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const personal = {
+    username: 'personal@example.com',
+    name: 'Personal',
+    homeAccountId: 'personal.home',
+  } as AccountInfo;
+
+  // Drives the REAL cache plugin built by the AuthManager constructor through a simulated MSAL
+  // client, the way the actual @azure/msal-node client would: the plugin persists during the
+  // acquire call (afterCacheAccess), and again when removeAccount mutates the cache. This proves
+  // a mismatched pinned login does not remain on disk once it is rejected (issue #545 hardening).
+  it('persists then removes a mismatched device-code login via the cache plugin', async () => {
+    let diskRaw: string | undefined;
+    const storage: TokenCacheStorage = {
+      description: 'integration',
+      failClosed: false,
+      load: vi.fn(async () => diskRaw),
+      save: vi.fn(async (_key, value: string) => {
+        diskRaw = value;
+      }),
+      delete: vi.fn(async () => {
+        diskRaw = undefined;
+      }),
+    };
+
+    const auth = new AuthManager(
+      msalConfig,
+      ['User.Read'],
+      { expectedUsername: 'work@example.com' },
+      storage
+    );
+    const plugin = (
+      auth as unknown as {
+        config: { cache: { cachePlugin: ReturnType<typeof buildDiskCoherencyCachePlugin> } };
+      }
+    ).config.cache.cachePlugin;
+
+    // Simulated MSAL in-memory account store, mutated only through the plugin like the real client.
+    let accounts: Record<string, AccountInfo> = {};
+    const tokenCache = {
+      serialize: () => JSON.stringify({ accounts }),
+      deserialize: (data: string) => {
+        accounts = (JSON.parse(data).accounts as Record<string, AccountInfo>) ?? {};
+      },
+      getAllAccounts: vi.fn(async () => Object.values(accounts)),
+      removeAccount: vi.fn(async (account: AccountInfo) => {
+        await plugin.beforeCacheAccess!({ cacheHasChanged: false, tokenCache } as never);
+        delete accounts[account.homeAccountId];
+        await plugin.afterCacheAccess!({ cacheHasChanged: true, tokenCache } as never);
+      }),
+    };
+    const msalApp = {
+      getTokenCache: vi.fn(() => tokenCache),
+      acquireTokenByDeviceCode: vi.fn(async () => {
+        // MSAL authenticates the (mismatched) account and persists it via the plugin.
+        await plugin.beforeCacheAccess!({ cacheHasChanged: false, tokenCache } as never);
+        accounts[personal.homeAccountId] = personal;
+        await plugin.afterCacheAccess!({ cacheHasChanged: true, tokenCache } as never);
+        return {
+          accessToken: 'bad-token',
+          expiresOn: new Date(Date.now() + 60_000),
+          account: personal,
+          scopes: ['User.Read'],
+        };
+      }),
+    };
+    Object.assign(auth as unknown as Record<string, unknown>, { msalApp });
+
+    await expect(auth.acquireTokenByDeviceCode()).rejects.toThrow(/does not match expected/);
+
+    // The mismatched account was written to disk during the acquire, then removed; the net
+    // persisted state must contain no accounts.
+    expect(diskRaw).toBeDefined();
+    expect(JSON.parse(unwrapCache(diskRaw!).data).accounts).toEqual({});
   });
 });
 

--- a/test/http-account-param.test.ts
+++ b/test/http-account-param.test.ts
@@ -227,7 +227,6 @@ describe('Discussion #467: AuthManager.getTokenForAccount in OAuth mode', () => 
     const auth = new AuthManager(msalConfig, ['User.Read']);
     Object.assign(auth as unknown as Record<string, unknown>, {
       msalApp,
-      saveTokenCache: vi.fn(),
     });
     return auth;
   }


### PR DESCRIPTION
Closes #545.

In the stdio-per-window setup a bunch of MCP processes share one token cache file, and Microsoft rotates the refresh token on every silent refresh. So one process refreshes and writes the new refresh token to disk, the siblings keep the old one in memory, and later they die with `invalid_grant` / `no_tokens_found`. Restarting the session "fixes" it, which is annoying.

Fix is an MSAL `cachePlugin`: it reloads the newest cache from disk before every cache access and saves after a change, so a process picks up a sibling's rotation before its next silent acquire. Reuses the existing storage layer, the cache envelope and the fail-closed bits.

While in there I made the plugin the only thing that writes the token-cache. The old manual `saveTokenCache()` calls did a blind save without the reload-before-write step, so they could clobber a newer rotation a sibling just wrote - which would narrowly re-open the same window. Also hardened the expected-account rejection so it stops claiming "Login was not persisted" when it actually couldn't remove the account.

It's best-effort last-writer-wins, not a lock. Two known limits I'm ok with (and the reporter agreed): two processes refreshing the exact same token at the same instant can still race, and a sibling logout isn't reflected in an already-running process.
