### PR TITLE
Add MCP Registry metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@softeria/ms-365-mcp-server",
+  "mcpName": "io.github.softeria/ms-365-mcp-server",
   "version": "0.0.0-development",
   "description": " A Model Context Protocol (MCP) server for interacting with Microsoft 365 and Office services through the Graph API",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.softeria/ms-365-mcp-server",
+  "title": "Microsoft 365 MCP Server",
+  "description": "Interact with Microsoft 365 services through the Microsoft Graph API.",
+  "version": "0.128.2",
+  "repository": {
+    "url": "https://github.com/Softeria/ms-365-mcp-server",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@softeria/ms-365-mcp-server",
+      "version": "0.128.2",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds MCP Registry metadata so this server can be published and considered for inclusion in the GitHub MCP Registry / MCP center.

## Changes

- Adds `server.json` using the current MCP Registry schema (`2025-12-11`).
- Adds the matching npm ownership metadata field, `mcpName`, to `package.json`.

## Maintainer follow-up

After this merges and a new npm package is released containing the `mcpName` field, a Softeria maintainer can publish from the repository with:

```sh
mcp-publisher login github
mcp-publisher publish
```

After successful publication to the MCP Registry, GitHub's published guidance says to email `partnerships@github.com` to request inclusion in the GitHub MCP Registry.

## Validation

- `node -e "for (const f of ['package.json','server.json']) JSON.parse(require('fs').readFileSync(f, 'utf8')); console.log('JSON OK')"`
- `npm exec -- prettier --check package.json server.json`
- `npm exec --yes -- ajv-cli validate -s /tmp/server.schema.json -d server.json --spec=draft7 --strict=false`
