### PR TITLE
fix(toon): stop JSON.parse of TOON-encoded bodies breaking fetchAllges and get-download-url

### DIFF
--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -81,7 +81,7 @@ function makeConfig(overrides: Partial<any> = {}) {
 }
 
 /** Creates a mock GraphClient with a controllable graphRequest spy */
-function createMockGraphClient(responses?: any[]) {
+function createMockGraphClient(responses?: any[], outputFormat: 'json' | 'toon' = 'json') {
   const responseQueue = [...(responses || [])];
   return {
     graphRequest: vi.fn().mockImplementation(async () => {
@@ -92,6 +92,13 @@ function createMockGraphClient(responses?: any[]) {
         content: [{ type: 'text', text: JSON.stringify({ value: [] }) }],
       };
     }),
+    // Fake serialize: prefix the JSON in toon mode so a test can tell the merged
+    // body went through serialize() and not a plain JSON.stringify.
+    serialize: vi
+      .fn()
+      .mockImplementation((data: unknown) =>
+        outputFormat === 'toon' ? `TOON:${JSON.stringify(data)}` : JSON.stringify(data)
+      ),
   };
 }
 
@@ -219,6 +226,79 @@ describe('graph-tools', () => {
       expect(parsed.value.map((v: any) => v.id)).toEqual(['1', '2', '3']);
       // nextLink should be removed from final response
       expect(parsed['@odata.nextLink']).toBeUndefined();
+    });
+
+    it('merges all pages under --toon and encodes the combined result once (#560)', async () => {
+      const endpoint = makeEndpoint();
+      const config = makeConfig();
+      mockEndpoints.push(endpoint);
+      mockEndpointsJson = [config];
+
+      // Pages are JSON here to mimic the forceJsonOutput path; the mock's serialize
+      // adds the TOON prefix so we can check the merged result was re-encoded (#560).
+      const graphClient = createMockGraphClient(
+        [
+          {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  value: [{ id: '1' }, { id: '2' }],
+                  '@odata.nextLink': 'https://graph.microsoft.com/v1.0/me/messages?$skip=2',
+                }),
+              },
+            ],
+          },
+          {
+            content: [{ type: 'text', text: JSON.stringify({ value: [{ id: '3' }] }) }],
+          },
+        ],
+        'toon'
+      );
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const tool = server.tools.get('test-tool');
+      const result = await tool!.handler({ fetchAllPages: true });
+
+      // Both page requests must be forced to JSON so the merge can parse them.
+      for (const call of graphClient.graphRequest.mock.calls) {
+        expect(call[1]?.forceJsonOutput).toBe(true);
+      }
+
+      // Final body is encoded once via serialize() in the configured (toon) format,
+      // not re-parsed as JSON. It must still contain all 3 merged items.
+      expect(graphClient.serialize).toHaveBeenCalledTimes(1);
+      expect(result.content[0].text.startsWith('TOON:')).toBe(true);
+      const parsed = JSON.parse(result.content[0].text.slice('TOON:'.length));
+      expect(parsed.value.map((v: any) => v.id)).toEqual(['1', '2', '3']);
+      expect(parsed['@odata.nextLink']).toBeUndefined();
+    });
+
+    it('does not inject value:[] when fetchAllPages hits a single-object (non-collection) GET', async () => {
+      const endpoint = makeEndpoint();
+      const config = makeConfig();
+      mockEndpoints.push(endpoint);
+      mockEndpointsJson = [config];
+
+      // Single-object response (no `value`). fetchAllPages can be set on any GET,
+      // and the merge must leave the object alone, not graft on an empty value array.
+      const graphClient = createMockGraphClient([
+        { content: [{ type: 'text', text: JSON.stringify({ id: 'abc', displayName: 'Solo' }) }] },
+      ]);
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const result = await server.tools.get('test-tool')!.handler({ fetchAllPages: true });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed).toEqual({ id: 'abc', displayName: 'Solo' });
+      expect(parsed.value).toBeUndefined();
+      expect(graphClient.graphRequest).toHaveBeenCalledTimes(1);
     });
 
     it('should stop at 100 page limit', async () => {
@@ -913,6 +993,36 @@ describe('graph-tools', () => {
       expect(payload.name).toBe('report.pdf');
       expect(payload.size).toBe(12727);
       expect(payload.contentType).toBe('application/pdf');
+    });
+
+    it('forces a JSON body on the metadata request so it works under --toon (#560)', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = {
+        graphRequest: vi.fn().mockResolvedValue({
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ '@microsoft.graph.downloadUrl': 'https://dl.example/x' }),
+            },
+          ],
+        }),
+      };
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+
+      const result = await server.tools
+        .get('get-download-url')!
+        .handler({ target: '/drives/d1/items/item1/content' });
+
+      // Without forceJsonOutput the client would TOON-encode the metadata and the
+      // handler's JSON.parse would fail, masking a valid item as "no download url".
+      const [, opts] = graphClient.graphRequest.mock.calls[0];
+      expect(opts?.forceJsonOutput).toBe(true);
+      expect(JSON.parse(result.content[0].text).downloadUrl).toBe('https://dl.example/x');
     });
 
     it('rejects query-shaped targets instead of silently changing request semantics', async () => {

--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -57,6 +57,9 @@ interface GraphRequestOptions {
   // Graph API version segment for the request path. Defaults to 'v1.0'; endpoints
   // declaring "apiVersion": "beta" in endpoints.json route to the /beta surface.
   apiVersion?: string;
+  // Pin this response to JSON regardless of the configured format, so the
+  // fetchAllPages merge can JSON.parse each page before re-encoding (#560).
+  forceJsonOutput?: boolean;
 
   [key: string]: unknown;
 }
@@ -221,6 +224,15 @@ class GraphClient {
     return JSON.stringify(data, null, pretty ? 2 : undefined);
   }
 
+  /**
+   * Encode a value in the configured format (json/toon). The fetchAllPages merge
+   * uses this to encode the combined result once, after parsing pages as JSON (#560).
+   * Compact by default like JSON.stringify, so JSON-mode output is byte-identical.
+   */
+  serialize(data: unknown, pretty = false): string {
+    return this.serializeData(data, this.outputFormat, pretty);
+  }
+
   async graphRequest(endpoint: string, options: GraphRequestOptions = {}): Promise<McpResponse> {
     try {
       logger.info(`Calling ${endpoint} with options: ${JSON.stringify(options)}`);
@@ -228,7 +240,16 @@ class GraphClient {
       // Use new OAuth-aware request method
       const result = await this.makeRequest(endpoint, options);
 
-      return this.formatJsonResponse(result, options.rawResponse, options.excludeResponse);
+      // forceJsonOutput keeps this body JSON so the fetchAllPages merge can parse
+      // it; otherwise --toon would make the merge's JSON.parse throw (#560).
+      const outputFormat = options.forceJsonOutput ? 'json' : this.outputFormat;
+
+      return this.formatJsonResponse(
+        result,
+        options.rawResponse,
+        options.excludeResponse,
+        outputFormat
+      );
     } catch (error) {
       logger.error(`Error in Graph API request: ${error}`);
       return {
@@ -238,11 +259,16 @@ class GraphClient {
     }
   }
 
-  formatJsonResponse(data: unknown, rawResponse = false, excludeResponse = false): McpResponse {
+  formatJsonResponse(
+    data: unknown,
+    rawResponse = false,
+    excludeResponse = false,
+    outputFormat: 'json' | 'toon' = this.outputFormat
+  ): McpResponse {
     // If excludeResponse is true, only return success indication
     if (excludeResponse) {
       return {
-        content: [{ type: 'text', text: this.serializeData({ success: true }, this.outputFormat) }],
+        content: [{ type: 'text', text: this.serializeData({ success: true }, outputFormat) }],
       };
     }
 
@@ -264,18 +290,14 @@ class GraphClient {
 
       if (rawResponse) {
         return {
-          content: [
-            { type: 'text', text: this.serializeData(responseData.data, this.outputFormat) },
-          ],
+          content: [{ type: 'text', text: this.serializeData(responseData.data, outputFormat) }],
           _meta: meta,
         };
       }
 
       if (responseData.data === null || responseData.data === undefined) {
         return {
-          content: [
-            { type: 'text', text: this.serializeData({ success: true }, this.outputFormat) },
-          ],
+          content: [{ type: 'text', text: this.serializeData({ success: true }, outputFormat) }],
           _meta: meta,
         };
       }
@@ -301,7 +323,7 @@ class GraphClient {
 
       return {
         content: [
-          { type: 'text', text: this.serializeData(responseData.data, this.outputFormat, true) },
+          { type: 'text', text: this.serializeData(responseData.data, outputFormat, true) },
         ],
         _meta: meta,
       };
@@ -310,13 +332,13 @@ class GraphClient {
     // Original handling for backward compatibility
     if (rawResponse) {
       return {
-        content: [{ type: 'text', text: this.serializeData(data, this.outputFormat) }],
+        content: [{ type: 'text', text: this.serializeData(data, outputFormat) }],
       };
     }
 
     if (data === null || data === undefined) {
       return {
-        content: [{ type: 'text', text: this.serializeData({ success: true }, this.outputFormat) }],
+        content: [{ type: 'text', text: this.serializeData({ success: true }, outputFormat) }],
       };
     }
 
@@ -340,7 +362,7 @@ class GraphClient {
     removeODataProps(data as Record<string, unknown>);
 
     return {
-      content: [{ type: 'text', text: this.serializeData(data, this.outputFormat, true) }],
+      content: [{ type: 'text', text: this.serializeData(data, outputFormat, true) }],
     };
   }
 }

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -573,6 +573,9 @@ export const UTILITY_TOOLS: readonly UtilityTool[] = [
         }
         const response = await graphClient.graphRequest(itemPath, {
           accessToken: accountAccessToken,
+          // We JSON.parse the metadata below, so force JSON - under --toon it'd be
+          // TOON and the parse would fail, masking a real item as "no download url".
+          forceJsonOutput: true,
         });
         // graphRequest swallows Graph HTTP errors and returns { isError: true } (see
         // graph-client.ts); surface the real error (401/403/404/429/...) instead of masking
@@ -919,6 +922,7 @@ async function executeGraphTool(
       queryParams?: Record<string, string>;
       accessToken?: string;
       apiVersion?: string;
+      forceJsonOutput?: boolean;
     } = {
       method: tool.method.toUpperCase(),
       headers,
@@ -982,8 +986,6 @@ async function executeGraphTool(
       `Making graph request to ${path} with options: ${JSON.stringify(safeOptions)}${_redacted ? ' [accessToken=REDACTED]' : ''}`
     );
 
-    let response = await graphClient.graphRequest(path, options);
-
     const fetchAllPages = params.fetchAllPages === true;
     const paginationEnabled = paginationAllowed();
     if (fetchAllPages && !paginationEnabled) {
@@ -991,75 +993,104 @@ async function executeGraphTool(
         'fetchAllPages requested but MS365_MCP_ALLOW_PAGINATION is disabled; returning first page only'
       );
     }
-    if (fetchAllPages && paginationEnabled && response?.content?.[0]?.text) {
+    // Force every page to JSON so the merge loop can parse them. Under --toon they'd
+    // be TOON and JSON.parse would throw, silently returning only page one (#560).
+    // The merged result gets re-encoded once at the end.
+    const mergePages = fetchAllPages && paginationEnabled;
+    if (mergePages) {
+      options.forceJsonOutput = true;
+    }
+
+    let response = await graphClient.graphRequest(path, options);
+
+    if (mergePages && response?.content?.[0]?.text) {
+      type ODataPage = {
+        value?: unknown[];
+        '@odata.nextLink'?: string;
+        '@odata.deltaLink'?: string;
+        '@odata.count'?: number;
+        [key: string]: unknown;
+      };
+      let combinedResponse: ODataPage | undefined;
       try {
-        let combinedResponse = JSON.parse(response.content[0].text);
-        let allItems = combinedResponse.value || [];
-        let nextLink = combinedResponse['@odata.nextLink'];
-        let pageCount = 1;
-        const maxPages = positiveIntFromEnv('MS365_MCP_MAX_PAGES', DEFAULT_MAX_PAGES);
-        const maxItems = positiveIntFromEnv('MS365_MCP_MAX_ITEMS', DEFAULT_MAX_ITEMS);
-        // Graph only emits @odata.deltaLink on the final page of a /delta query.
-        // Track it across the pagination loop so we can stamp it on the combined
-        // response — otherwise fetchAllPages on a /delta endpoint silently drops
-        // the resume token and forces callers to re-list from scratch.
-        let deltaLink: string | undefined = combinedResponse['@odata.deltaLink'];
+        combinedResponse = JSON.parse(response.content[0].text) as ODataPage;
 
-        while (nextLink && pageCount < maxPages && allItems.length < maxItems) {
-          logger.info(`Fetching page ${pageCount + 1} from: ${nextLink}`);
+        // Only merge if page one is actually a collection. fetchAllPages can be set
+        // on a single-object GET too, and we'd otherwise graft a bogus value:[] on it.
+        const firstValue = combinedResponse.value;
+        if (Array.isArray(firstValue)) {
+          let allItems: unknown[] = firstValue;
+          let nextLink = combinedResponse['@odata.nextLink'];
+          let pageCount = 1;
+          const maxPages = positiveIntFromEnv('MS365_MCP_MAX_PAGES', DEFAULT_MAX_PAGES);
+          const maxItems = positiveIntFromEnv('MS365_MCP_MAX_ITEMS', DEFAULT_MAX_ITEMS);
+          // Graph only emits @odata.deltaLink on the final page of a /delta query.
+          // Track it across the pagination loop so we can stamp it on the combined
+          // response — otherwise fetchAllPages on a /delta endpoint silently drops
+          // the resume token and forces callers to re-list from scratch.
+          let deltaLink = combinedResponse['@odata.deltaLink'];
 
-          // Extract path + query string from the nextLink URL.
-          // Pass the full path (with query string) as the endpoint so that
-          // $skiptoken and other pagination params are preserved.
-          // Previously, query params were extracted into nextOptions.queryParams
-          // but graphRequest/performRequest never read that field — they were lost.
-          const url = new URL(nextLink);
-          // nextLink is absolute and version-qualified (/v1.0/... or /beta/...). Strip the
-          // version segment so performRequest can re-apply the request's own apiVersion.
-          const nextPath = url.pathname.replace(/^\/(v1\.0|beta)/, '') + url.search;
-          const nextOptions = { ...options };
+          while (nextLink && pageCount < maxPages && allItems.length < maxItems) {
+            logger.info(`Fetching page ${pageCount + 1} from: ${nextLink}`);
 
-          const nextResponse = await graphClient.graphRequest(nextPath, nextOptions);
-          if (nextResponse?.content?.[0]?.text) {
-            const nextJsonResponse = JSON.parse(nextResponse.content[0].text);
-            if (nextJsonResponse.value && Array.isArray(nextJsonResponse.value)) {
-              allItems = allItems.concat(nextJsonResponse.value);
+            // Extract path + query string from the nextLink URL.
+            // Pass the full path (with query string) as the endpoint so that
+            // $skiptoken and other pagination params are preserved.
+            // Previously, query params were extracted into nextOptions.queryParams
+            // but graphRequest/performRequest never read that field — they were lost.
+            const url = new URL(nextLink);
+            // nextLink is absolute and version-qualified (/v1.0/... or /beta/...). Strip the
+            // version segment so performRequest can re-apply the request's own apiVersion.
+            const nextPath = url.pathname.replace(/^\/(v1\.0|beta)/, '') + url.search;
+            const nextOptions = { ...options };
+
+            const nextResponse = await graphClient.graphRequest(nextPath, nextOptions);
+            if (nextResponse?.content?.[0]?.text) {
+              const nextJsonResponse = JSON.parse(nextResponse.content[0].text) as ODataPage;
+              if (Array.isArray(nextJsonResponse.value)) {
+                allItems = allItems.concat(nextJsonResponse.value);
+              }
+              nextLink = nextJsonResponse['@odata.nextLink'];
+              if (nextJsonResponse['@odata.deltaLink']) {
+                deltaLink = nextJsonResponse['@odata.deltaLink'];
+              }
+              pageCount++;
+            } else {
+              break;
             }
-            nextLink = nextJsonResponse['@odata.nextLink'];
-            if (nextJsonResponse['@odata.deltaLink']) {
-              deltaLink = nextJsonResponse['@odata.deltaLink'];
-            }
-            pageCount++;
-          } else {
-            break;
           }
-        }
 
-        if (pageCount >= maxPages) {
-          logger.warn(`Reached maximum page limit (${maxPages}) for pagination`);
-        }
-        if (allItems.length >= maxItems) {
-          logger.warn(
-            `Reached maximum item limit (${maxItems}) for pagination — truncated at ${allItems.length} items`
+          if (pageCount >= maxPages) {
+            logger.warn(`Reached maximum page limit (${maxPages}) for pagination`);
+          }
+          if (allItems.length >= maxItems) {
+            logger.warn(
+              `Reached maximum item limit (${maxItems}) for pagination — truncated at ${allItems.length} items`
+            );
+          }
+
+          combinedResponse.value = allItems;
+          if (combinedResponse['@odata.count']) {
+            combinedResponse['@odata.count'] = allItems.length;
+          }
+          delete combinedResponse['@odata.nextLink'];
+          if (deltaLink) {
+            combinedResponse['@odata.deltaLink'] = deltaLink;
+          }
+
+          logger.info(
+            `Pagination complete: collected ${allItems.length} items across ${pageCount} pages`
           );
         }
-
-        combinedResponse.value = allItems;
-        if (combinedResponse['@odata.count']) {
-          combinedResponse['@odata.count'] = allItems.length;
-        }
-        delete combinedResponse['@odata.nextLink'];
-        if (deltaLink) {
-          combinedResponse['@odata.deltaLink'] = deltaLink;
-        }
-
-        response.content[0].text = JSON.stringify(combinedResponse);
-
-        logger.info(
-          `Pagination complete: collected ${allItems.length} items across ${pageCount} pages`
-        );
       } catch (e) {
         logger.error(`Error during pagination: ${e}`);
+      }
+
+      // Re-encode once in the configured format. Runs whenever page one parsed
+      // (non-collection skip and mid-loop abort included), so a --toon client
+      // never gets handed the forced-JSON body.
+      if (combinedResponse !== undefined) {
+        response.content[0].text = graphClient.serialize(combinedResponse);
       }
     }
 

--- a/test/toon-pagination.test.ts
+++ b/test/toon-pagination.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../src/cloud-config.js', () => ({
+  getCloudEndpoints: () => ({
+    graphApi: 'https://graph.microsoft.com',
+    authority: 'https://login.microsoftonline.com',
+  }),
+}));
+
+vi.mock('../src/lib/microsoft-auth.js', () => ({
+  refreshAccessToken: vi.fn(),
+}));
+
+// Distinguishable TOON encoder so we can tell JSON output from TOON output.
+vi.mock('@toon-format/toon', () => ({
+  encode: (data: any) => `TOON<<${JSON.stringify(data)}>>`,
+}));
+
+const mockAuthManager = {
+  getToken: vi.fn().mockResolvedValue('mock-token'),
+};
+
+const mockSecrets = {
+  clientId: 'test-client-id',
+  tenantId: 'test-tenant-id',
+  clientSecret: 'test-client-secret',
+  cloudType: 'global' as const,
+};
+
+const { default: GraphClient } = await import('../src/graph-client.js');
+
+describe('TOON output + forceJsonOutput (issue #560)', () => {
+  let graphClient: InstanceType<typeof GraphClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    graphClient = new GraphClient(mockAuthManager as any, mockSecrets, 'toon');
+  });
+
+  it('encodes a normal response as TOON when configured', async () => {
+    const mockFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ value: [{ id: '1' }] }), { status: 200 })
+      );
+
+    const result = await graphClient.graphRequest('/me/messages');
+    expect(result.content[0].text.startsWith('TOON<<')).toBe(true);
+
+    mockFetch.mockRestore();
+  });
+
+  it('emits parseable JSON (not TOON) when forceJsonOutput is set', async () => {
+    const mockFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ value: [{ id: '1' }] }), { status: 200 })
+      );
+
+    const result = await graphClient.graphRequest('/me/messages', { forceJsonOutput: true });
+
+    // Must be plain JSON so the fetchAllPages merge can JSON.parse each page.
+    expect(result.content[0].text.startsWith('TOON<<')).toBe(false);
+    expect(JSON.parse(result.content[0].text).value).toEqual([{ id: '1' }]);
+
+    mockFetch.mockRestore();
+  });
+
+  it('serialize() encodes the merged result in the configured (toon) format', () => {
+    const text = graphClient.serialize({ value: [{ id: '1' }, { id: '2' }] });
+    expect(text.startsWith('TOON<<')).toBe(true);
+    expect(text).toContain('"id":"2"');
+  });
+});


### PR DESCRIPTION
Two tools parsed a graphRequest response body as JSON, but under --toon (MS365_MCP_OUTPUT_FORMAT=toon) graph-client had already TOON-encoded it, so the parse threw:

- fetchAllPages: the pagination merge JSON.parse()'d each page, the error was only logged, and multi-page results silently collapsed to the first page (#560).
- get-download-url: parsed drive-item metadata to read @microsoft.graph.downloadUrl; under --toon the parse failed and it wrongly reported 'no download URL available'.

Add a forceJsonOutput request option so a caller can pin an individual request to JSON regardless of the client's configured format, plus a GraphClient.serialize() that encodes in the configured format. The pagination merge forces every page to JSON, merges, then re-encodes the combined result once via serialize(); it only merges when the first page is actually a collection (Array.isArray(value)), so setting fetchAllPages on a single-object GET no longer grafts on a spurious value:[]. The re-encode always runs once the first page parsed, so a --toon client is never handed the forced-JSON body. get-download-url sets forceJsonOutput on its internal metadata request; it returns its own JSON payload, so its output is unchanged. serialize() defaults to compact, keeping JSON-mode output byte-identical.

Closes #560