### PR TITLE
fix(teams): document @mention shape in send/reply tool tips (#558)

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1486,7 +1486,7 @@
     "toolName": "send-chat-message",
     "presets": ["teams", "work"],
     "workScopes": ["ChatMessage.Send"],
-    "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API."
+    "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API. To @mention someone, put an <at id=\"0\">Name</at> tag in the html content and add a mentions array to the request body, as a sibling of the body property (not a separate top-level tool parameter): { body: { contentType: 'html', content: 'Hi <at id=\"0\">Name</at>' }, mentions: [{ id: 0, mentionText: 'Name', mentioned: { user: { id: '<aad-user-id>', displayName: 'Name', userIdentityType: 'aadUser' } } }] }. Each mention id must match its <at id> value; include userIdentityType: 'aadUser' or Graph returns 400 'value without a type name'."
   },
   {
     "pathPattern": "/me/joinedTeams",
@@ -1572,7 +1572,7 @@
     "toolName": "send-channel-message",
     "presets": ["teams", "work"],
     "workScopes": ["ChannelMessage.Send"],
-    "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API."
+    "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API. To @mention someone, put an <at id=\"0\">Name</at> tag in the html content and add a mentions array to the request body, as a sibling of the body property (not a separate top-level tool parameter): { body: { contentType: 'html', content: 'Hi <at id=\"0\">Name</at>' }, mentions: [{ id: 0, mentionText: 'Name', mentioned: { user: { id: '<aad-user-id>', displayName: 'Name', userIdentityType: 'aadUser' } } }] }. Each mention id must match its <at id> value; include userIdentityType: 'aadUser' or Graph returns 400 'value without a type name'."
   },
   {
     "pathPattern": "/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies",
@@ -1580,7 +1580,7 @@
     "toolName": "reply-to-channel-message",
     "presets": ["teams", "work"],
     "workScopes": ["ChannelMessage.Send"],
-    "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API."
+    "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API. To @mention someone, put an <at id=\"0\">Name</at> tag in the html content and add a mentions array to the request body, as a sibling of the body property (not a separate top-level tool parameter): { body: { contentType: 'html', content: 'Hi <at id=\"0\">Name</at>' }, mentions: [{ id: 0, mentionText: 'Name', mentioned: { user: { id: '<aad-user-id>', displayName: 'Name', userIdentityType: 'aadUser' } } }] }. Each mention id must match its <at id> value; include userIdentityType: 'aadUser' or Graph returns 400 'value without a type name'."
   },
   {
     "pathPattern": "/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies",
@@ -1659,7 +1659,7 @@
     "toolName": "reply-to-chat-message",
     "presets": ["teams", "work"],
     "workScopes": ["ChatMessage.Send"],
-    "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API."
+    "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API. To @mention someone, put an <at id=\"0\">Name</at> tag in the html content and add a mentions array to the request body, as a sibling of the body property (not a separate top-level tool parameter): { body: { contentType: 'html', content: 'Hi <at id=\"0\">Name</at>' }, mentions: [{ id: 0, mentionText: 'Name', mentioned: { user: { id: '<aad-user-id>', displayName: 'Name', userIdentityType: 'aadUser' } } }] }. Each mention id must match its <at id> value; include userIdentityType: 'aadUser' or Graph returns 400 'value without a type name'."
   },
   {
     "pathPattern": "/chats/{chat-id}/messages/{chatMessage-id}/setReaction",

--- a/test/endpoints-validation.test.ts
+++ b/test/endpoints-validation.test.ts
@@ -8,7 +8,7 @@ import path from 'path';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 if (!globalThis.File) (globalThis as any).File = Blob;
 
-const { api } = await import('../src/generated/client.js');
+const { api, schemas } = await import('../src/generated/client.js');
 const { api: betaApi } = await import('../src/generated/client-beta.js');
 
 const __filename = fileURLToPath(import.meta.url);
@@ -142,5 +142,47 @@ describe('endpoints.json validation', () => {
     expect(endpoint?.llmTip).toContain('call get-download-url');
     expect(endpoint?.llmTip).toContain('out-of-band');
     expect(endpoint?.llmTip).toContain('call download-bytes');
+  });
+
+  it('should document the @mention shape on the Teams send/reply tools', () => {
+    const mentionTools = [
+      'send-chat-message',
+      'send-channel-message',
+      'reply-to-channel-message',
+      'reply-to-chat-message',
+    ];
+
+    for (const toolName of mentionTools) {
+      const endpoint = endpoints.find((e) => e.toolName === toolName);
+      expect(endpoint, `${toolName} should exist`).toBeDefined();
+      // Model omits userIdentityType without this, and Graph 400s (issue #558)
+      expect(endpoint?.llmTip, `${toolName} llmTip`).toContain('<at id');
+      expect(endpoint?.llmTip, `${toolName} llmTip`).toContain('userIdentityType');
+    }
+  });
+
+  it('should accept and preserve userIdentityType on a mentions payload (passthrough schema)', () => {
+    const chatMessage = (
+      schemas as Record<string, { safeParse: (v: unknown) => { success: boolean; data?: unknown } }>
+    ).microsoft_graph_chatMessage;
+    const payload = {
+      body: { contentType: 'html', content: 'Hi <at id="0">Jane</at>' },
+      mentions: [
+        {
+          id: 0,
+          mentionText: 'Jane',
+          mentioned: { user: { id: 'guid', displayName: 'Jane', userIdentityType: 'aadUser' } },
+        },
+      ],
+    };
+
+    const result = chatMessage.safeParse(payload);
+    expect(result.success).toBe(true);
+    // userIdentityType isn't a modeled field - it survives only because the schemas are
+    // .passthrough(). So this guards the codegen trait, not request serialization.
+    const mentioned = (
+      result.data as { mentions: Array<{ mentioned: { user: { userIdentityType?: string } } }> }
+    ).mentions[0].mentioned.user;
+    expect(mentioned.userIdentityType).toBe('aadUser');
   });
 });


### PR DESCRIPTION
Mentions already flow through to Graph (the chatMessage schema is passthrough), so the 400 'value without a type name' was really a guidance gap: nothing told the model to add the <at id> tag and mentioned.user.userIdentityType. Extend the four Teams send/reply llmTips with the exact shape, plus tests for the guidance text and the passthrough round-trip.