### PR TITLE
fix: stop dropping flattened body-field params in tool calls #569

### DIFF
--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -131,6 +131,21 @@ function createMockServer() {
         tools.set(name, { description, schema, handler });
       }
     ),
+    registerTool: vi.fn(
+      (
+        name: string,
+        config: { description: string; inputSchema: any },
+        handler: (...args: any[]) => any
+      ) => {
+        // Graph tools register a zod object schema; expose its shape so tests can
+        // keep asserting on individual params like before.
+        tools.set(name, {
+          description: config.description,
+          schema: config.inputSchema?.shape ?? config.inputSchema,
+          handler,
+        });
+      }
+    ),
     tools,
   };
 }

--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -137,8 +137,7 @@ function createMockServer() {
         config: { description: string; inputSchema: any },
         handler: (...args: any[]) => any
       ) => {
-        // Graph tools register a zod object schema; expose its shape so tests can
-        // keep asserting on individual params like before.
+        // Expose the zod object's shape so tests can keep asserting on params
         tools.set(name, {
           description: config.description,
           schema: config.inputSchema?.shape ?? config.inputSchema,

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -649,6 +649,65 @@ function registerUtilityToolWithMcp(
   );
 }
 
+// Unwrap optional/nullable/effects/lazy wrappers to get at the object shape of a Body
+// schema, so unmatched top-level params can be recognized as body fields (issue #569).
+// The generated client defines some Body schemas via z.lazy (e.g. chatMessage), whose
+// inner schema sits behind _def.getter rather than innerType/schema.
+function bodySchemaShape(schema: z.ZodTypeAny | undefined): Record<string, unknown> | null {
+  let current: z.ZodTypeAny | undefined = schema;
+  for (let i = 0; i < 10 && current; i++) {
+    if (current instanceof z.ZodObject) {
+      return current.shape as Record<string, unknown>;
+    }
+    const def = (
+      current as {
+        _def?: { innerType?: z.ZodTypeAny; schema?: z.ZodTypeAny; getter?: () => z.ZodTypeAny };
+      }
+    )._def;
+    current = def?.innerType ?? def?.schema ?? def?.getter?.();
+  }
+  return null;
+}
+
+// Make a Body schema tolerant of unknown keys so SDK-side validation (which replaces
+// the args with the PARSED result) doesn't strip client-sent fields the schema doesn't
+// declare. Recurses through optional/nullable/lazy wrappers, rebuilding them around the
+// passthrough object; other schema kinds are returned unchanged.
+function lenientBodySchema(schema: z.ZodTypeAny): z.ZodTypeAny {
+  if (schema instanceof z.ZodObject) {
+    return schema.passthrough();
+  }
+  if (schema instanceof z.ZodOptional) {
+    return lenientBodySchema(schema.unwrap()).optional();
+  }
+  if (schema instanceof z.ZodNullable) {
+    return lenientBodySchema(schema.unwrap()).nullable();
+  }
+  if (schema instanceof z.ZodLazy) {
+    return z.lazy(() => lenientBodySchema(schema.schema));
+  }
+  return schema;
+}
+
+// Entity fields Graph treats as read-only. Never rescue these from flattened params —
+// injecting an echoed `id` or timestamp into a POST/PATCH body can fail the request.
+const READ_ONLY_BODY_FIELDS = new Set([
+  'id',
+  'createdDateTime',
+  'lastModifiedDateTime',
+  'changeKey',
+]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+// Object.hasOwn substitute (tsconfig targets ES2020). Own-property check, not `in`:
+// the zod shape is a normal-prototype object, so `in` would match toString/constructor.
+function hasOwn(obj: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
 async function executeGraphTool(
   tool: (typeof api.endpoints)[0],
   config: EndpointConfig | undefined,
@@ -728,6 +787,14 @@ async function executeGraphTool(
     const queryParams: Record<string, string> = {};
     const headers: Record<string, string> = {};
     let body: unknown = null;
+
+    // Fields of the body schema passed as top-level params instead of nested under
+    // `body` (issue #569: create-draft-email dropped subject/toRecipients). Collected
+    // during the loop and merged into the request body afterwards.
+    const bodyShape = bodySchemaShape(
+      parameterDefinitions.find((p) => p.type === 'Body')?.schema as z.ZodTypeAny | undefined
+    );
+    const strayBodyFields: Record<string, unknown> = {};
 
     for (const [paramName, paramValue] of Object.entries(params)) {
       // Skip control parameters - not part of the Microsoft Graph API
@@ -854,6 +921,46 @@ async function executeGraphTool(
         // list — forward it as a query param rather than silently dropping it.
         queryParams[fixedParamName] = `${paramValue}`;
         logger.info(`OData param fallback: forwarded ${fixedParamName}=${paramValue}`);
+      } else if (
+        bodyShape &&
+        (hasOwn(bodyShape, paramName) || hasOwn(bodyShape, camelCaseParamName)) &&
+        !READ_ONLY_BODY_FIELDS.has(hasOwn(bodyShape, paramName) ? paramName : camelCaseParamName)
+      ) {
+        // Fallback: param matches a field of the body schema — the client flattened the
+        // body object into top-level params. Merge into the request body instead of dropping.
+        // The read-only exclusion checks the resolved field name, so kebab-cased variants
+        // like created-date-time can't sneak past it.
+        const fieldName = hasOwn(bodyShape, paramName) ? paramName : camelCaseParamName;
+        strayBodyFields[fieldName] = paramValue;
+        logger.info(
+          `Body field fallback: merging top-level param '${fieldName}' into request body`
+        );
+      } else {
+        logger.warn(`Dropping unrecognized parameter '${paramName}' for tool ${tool.alias}`);
+      }
+    }
+
+    if (Object.keys(strayBodyFields).length > 0) {
+      if (isPlainObject(body)) {
+        // If the `body` param's own keys aren't fields of the body schema but the schema
+        // has a `body` field (e.g. message.body), the client meant it as that field —
+        // nest it. Otherwise treat it as the (partial) body object; spread order lets the
+        // explicitly nested body win over stray top-level duplicates in both branches.
+        const keys = Object.keys(body);
+        const bodyIsNestedField =
+          bodyShape != null &&
+          hasOwn(bodyShape, 'body') &&
+          keys.length > 0 &&
+          keys.every((k) => !hasOwn(bodyShape, k));
+        body = bodyIsNestedField ? { ...strayBodyFields, body } : { ...strayBodyFields, ...body };
+        logger.info(`Merged flattened body fields: ${Object.keys(strayBodyFields).join(', ')}`);
+      } else if (body == null) {
+        body = strayBodyFields;
+        logger.info(`Merged flattened body fields: ${Object.keys(strayBodyFields).join(', ')}`);
+      } else {
+        logger.warn(
+          `Cannot merge flattened body fields (${Object.keys(strayBodyFields).join(', ')}) into non-object request body; dropping them`
+        );
       }
     }
 
@@ -1229,7 +1336,14 @@ export function registerGraphTools(
     const paramSchema: Record<string, z.ZodTypeAny> = {};
     if (tool.parameters && tool.parameters.length > 0) {
       for (const param of tool.parameters) {
-        paramSchema[param.name] = param.schema || z.any();
+        // Body params get lenient (passthrough) validation: SDK validation returns the
+        // PARSED value, and strip-mode objects silently discard unknown keys. A client
+        // that puts the message's body field in the `body` param (issue #569) would
+        // otherwise have it emptied to {} before the handler can repair the request.
+        paramSchema[param.name] =
+          param.type === 'Body' && param.schema
+            ? lenientBodySchema(param.schema as z.ZodTypeAny)
+            : param.schema || z.any();
       }
     }
 
@@ -1404,17 +1518,26 @@ export function registerGraphTools(
     const isReadOnlyTool = tool.method.toUpperCase() === 'GET' || endpointConfig?.readOnly === true;
 
     try {
-      server.tool(
+      // Register with an explicit .passthrough() object schema instead of a raw shape:
+      // the SDK wraps raw shapes in z.object() which STRIPS unknown keys before the
+      // handler runs. Clients that flatten body fields into top-level params (issue #569:
+      // create-draft-email called with subject/toRecipients as siblings of body) would
+      // lose those params before executeGraphTool's body-field fallback can rescue them.
+      server.registerTool(
         tool.alias,
-        toolDescription,
-        paramSchema,
         {
           title: tool.alias,
-          readOnlyHint: isReadOnlyTool,
-          destructiveHint: destructive,
-          openWorldHint: true, // All tools call Microsoft Graph API
+          description: toolDescription,
+          inputSchema: z.object(paramSchema).passthrough(),
+          annotations: {
+            title: tool.alias,
+            readOnlyHint: isReadOnlyTool,
+            destructiveHint: destructive,
+            openWorldHint: true, // All tools call Microsoft Graph API
+          },
         },
-        async (params) => executeGraphTool(tool, endpointConfig, graphClient, params, authManager)
+        async (params: Record<string, unknown>) =>
+          executeGraphTool(tool, endpointConfig, graphClient, params, authManager)
       );
       registeredCount++;
     } catch (error) {

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -649,10 +649,8 @@ function registerUtilityToolWithMcp(
   );
 }
 
-// Unwrap optional/nullable/effects/lazy wrappers to get at the object shape of a Body
-// schema, so unmatched top-level params can be recognized as body fields (issue #569).
-// The generated client defines some Body schemas via z.lazy (e.g. chatMessage), whose
-// inner schema sits behind _def.getter rather than innerType/schema.
+// Dig out the object shape of a Body schema so flattened top-level params can be
+// matched against it (#569). z.lazy (chatMessage etc.) hides it behind _def.getter
 function bodySchemaShape(schema: z.ZodTypeAny | undefined): Record<string, unknown> | null {
   let current: z.ZodTypeAny | undefined = schema;
   for (let i = 0; i < 10 && current; i++) {
@@ -669,10 +667,8 @@ function bodySchemaShape(schema: z.ZodTypeAny | undefined): Record<string, unkno
   return null;
 }
 
-// Make a Body schema tolerant of unknown keys so SDK-side validation (which replaces
-// the args with the PARSED result) doesn't strip client-sent fields the schema doesn't
-// declare. Recurses through optional/nullable/lazy wrappers, rebuilding them around the
-// passthrough object; other schema kinds are returned unchanged.
+// SDK validation hands the handler the PARSED value, and strip-mode objects silently
+// drop unknown keys - passthrough keeps whatever the client sent
 function lenientBodySchema(schema: z.ZodTypeAny): z.ZodTypeAny {
   if (schema instanceof z.ZodObject) {
     return schema.passthrough();
@@ -689,8 +685,7 @@ function lenientBodySchema(schema: z.ZodTypeAny): z.ZodTypeAny {
   return schema;
 }
 
-// Entity fields Graph treats as read-only. Never rescue these from flattened params —
-// injecting an echoed `id` or timestamp into a POST/PATCH body can fail the request.
+// Read-only in Graph - merging an echoed id/timestamp into a POST/PATCH body can 400
 const READ_ONLY_BODY_FIELDS = new Set([
   'id',
   'createdDateTime',
@@ -702,8 +697,8 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-// Object.hasOwn substitute (tsconfig targets ES2020). Own-property check, not `in`:
-// the zod shape is a normal-prototype object, so `in` would match toString/constructor.
+// Object.hasOwn, but tsconfig targets ES2020. Not `in` - that would match
+// toString/constructor through the prototype
 function hasOwn(obj: Record<string, unknown>, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(obj, key);
 }
@@ -788,9 +783,8 @@ async function executeGraphTool(
     const headers: Record<string, string> = {};
     let body: unknown = null;
 
-    // Fields of the body schema passed as top-level params instead of nested under
-    // `body` (issue #569: create-draft-email dropped subject/toRecipients). Collected
-    // during the loop and merged into the request body afterwards.
+    // Body fields the client passed as top-level params (#569) - merged into the
+    // request body after the loop
     const bodyShape = bodySchemaShape(
       parameterDefinitions.find((p) => p.type === 'Body')?.schema as z.ZodTypeAny | undefined
     );
@@ -926,10 +920,9 @@ async function executeGraphTool(
         (hasOwn(bodyShape, paramName) || hasOwn(bodyShape, camelCaseParamName)) &&
         !READ_ONLY_BODY_FIELDS.has(hasOwn(bodyShape, paramName) ? paramName : camelCaseParamName)
       ) {
-        // Fallback: param matches a field of the body schema — the client flattened the
-        // body object into top-level params. Merge into the request body instead of dropping.
-        // The read-only exclusion checks the resolved field name, so kebab-cased variants
-        // like created-date-time can't sneak past it.
+        // Client flattened the body object into top-level params - rescue instead of
+        // dropping. The read-only check uses the resolved name so kebab-case variants
+        // can't sneak past
         const fieldName = hasOwn(bodyShape, paramName) ? paramName : camelCaseParamName;
         strayBodyFields[fieldName] = paramValue;
         logger.info(
@@ -942,10 +935,9 @@ async function executeGraphTool(
 
     if (Object.keys(strayBodyFields).length > 0) {
       if (isPlainObject(body)) {
-        // If the `body` param's own keys aren't fields of the body schema but the schema
-        // has a `body` field (e.g. message.body), the client meant it as that field —
-        // nest it. Otherwise treat it as the (partial) body object; spread order lets the
-        // explicitly nested body win over stray top-level duplicates in both branches.
+        // If none of body's keys are schema fields but the schema has a `body` field
+        // (message.body), the client meant it as that field - nest it. Spread order lets
+        // an explicit body win over stray duplicates in both branches
         const keys = Object.keys(body);
         const bodyIsNestedField =
           bodyShape != null &&
@@ -1336,10 +1328,7 @@ export function registerGraphTools(
     const paramSchema: Record<string, z.ZodTypeAny> = {};
     if (tool.parameters && tool.parameters.length > 0) {
       for (const param of tool.parameters) {
-        // Body params get lenient (passthrough) validation: SDK validation returns the
-        // PARSED value, and strip-mode objects silently discard unknown keys. A client
-        // that puts the message's body field in the `body` param (issue #569) would
-        // otherwise have it emptied to {} before the handler can repair the request.
+        // Lenient Body validation, or the SDK strips a flattened body value to {} (#569)
         paramSchema[param.name] =
           param.type === 'Body' && param.schema
             ? lenientBodySchema(param.schema as z.ZodTypeAny)
@@ -1518,11 +1507,9 @@ export function registerGraphTools(
     const isReadOnlyTool = tool.method.toUpperCase() === 'GET' || endpointConfig?.readOnly === true;
 
     try {
-      // Register with an explicit .passthrough() object schema instead of a raw shape:
-      // the SDK wraps raw shapes in z.object() which STRIPS unknown keys before the
-      // handler runs. Clients that flatten body fields into top-level params (issue #569:
-      // create-draft-email called with subject/toRecipients as siblings of body) would
-      // lose those params before executeGraphTool's body-field fallback can rescue them.
+      // .passthrough() object, not a raw shape - the SDK wraps raw shapes in z.object()
+      // and strips unknown keys before the handler runs, which is exactly how #569's
+      // flattened subject/toRecipients got lost
       server.registerTool(
         tool.alias,
         {

--- a/test/beta-routing.test.ts
+++ b/test/beta-routing.test.ts
@@ -31,12 +31,12 @@ vi.mock('../src/generated/client-beta.js', () => ({
 }));
 
 describe('beta endpoint routing (dual-generator)', () => {
-  let mockServer: { tool: ReturnType<typeof vi.fn> };
+  let mockServer: { tool: ReturnType<typeof vi.fn>; registerTool: ReturnType<typeof vi.fn> };
   let mockGraphClient: GraphClient;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockServer = { tool: vi.fn() };
+    mockServer = { tool: vi.fn(), registerTool: vi.fn() };
     mockGraphClient = {
       graphRequest: vi.fn().mockResolvedValue({
         content: [{ type: 'text', text: JSON.stringify({ value: [] }) }],
@@ -46,7 +46,7 @@ describe('beta endpoint routing (dual-generator)', () => {
 
   function getToolHandler(toolName: string) {
     registerGraphTools(mockServer, mockGraphClient, true);
-    const call = mockServer.tool.mock.calls.find((c: unknown[]) => c[0] === toolName);
+    const call = mockServer.registerTool.mock.calls.find((c: unknown[]) => c[0] === toolName);
     expect(call, `tool ${toolName} should be registered`).toBeDefined();
     return call![call!.length - 1] as (params: Record<string, unknown>) => Promise<unknown>;
   }
@@ -60,7 +60,7 @@ describe('beta endpoint routing (dual-generator)', () => {
 
   it('registers tools from both the v1.0 and beta clients', () => {
     registerGraphTools(mockServer, mockGraphClient, true);
-    const registered = mockServer.tool.mock.calls.map((c: unknown[]) => c[0]);
+    const registered = mockServer.registerTool.mock.calls.map((c: unknown[]) => c[0]);
     expect(registered).toContain('get-current-user');
     expect(registered).toContain('get-my-profile');
   });
@@ -68,7 +68,11 @@ describe('beta endpoint routing (dual-generator)', () => {
   it('prefixes a beta tool description with [beta] and leaves v1.0 unmarked', () => {
     registerGraphTools(mockServer, mockGraphClient, true);
     const descOf = (name: string) =>
-      mockServer.tool.mock.calls.find((c: unknown[]) => c[0] === name)?.[1] as string;
+      (
+        mockServer.registerTool.mock.calls.find((c: unknown[]) => c[0] === name)?.[1] as {
+          description: string;
+        }
+      )?.description;
     expect(descOf('get-my-profile')).toMatch(/^\[beta\]/);
     expect(descOf('get-current-user')).not.toMatch(/\[beta\]/);
   });

--- a/test/body-field-fallback.test.ts
+++ b/test/body-field-fallback.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { registerGraphTools } from '../src/graph-tools.js';
+import type { GraphClient } from '../src/graph-client.js';
+
+vi.mock('../src/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('../src/generated/client-beta.js', () => ({ api: { endpoints: [] } }));
+vi.mock('../src/generated/client.js', async () => {
+  const { z } = await import('zod');
+  return {
+    api: {
+      endpoints: [
+        {
+          alias: 'create-draft-email',
+          method: 'post',
+          path: '/me/messages',
+          description: 'Create a draft email.',
+          parameters: [
+            {
+              name: 'body',
+              type: 'Body',
+              schema: z.object({
+                id: z.string().optional(),
+                createdDateTime: z.string().optional(),
+                subject: z.string().nullish(),
+                body: z
+                  .object({
+                    contentType: z.enum(['text', 'html']).optional(),
+                    content: z.string().nullish(),
+                  })
+                  .nullish(),
+                toRecipients: z
+                  .array(
+                    z.object({
+                      emailAddress: z.object({ address: z.string().optional() }).optional(),
+                    })
+                  )
+                  .nullish(),
+              }),
+            },
+          ],
+        },
+      ],
+    },
+  };
+});
+
+describe('Flattened body field fallback (issue #569)', () => {
+  let mockServer: { tool: ReturnType<typeof vi.fn>; registerTool: ReturnType<typeof vi.fn> };
+  let mockGraphClient: GraphClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockServer = { tool: vi.fn(), registerTool: vi.fn() };
+    mockGraphClient = {
+      graphRequest: vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: JSON.stringify({ id: 'draft-1' }) }],
+      }),
+    } as unknown as GraphClient;
+  });
+
+  function getToolHandler(toolName: string) {
+    registerGraphTools(mockServer, mockGraphClient, false);
+    const call = mockServer.registerTool.mock.calls.find((c: unknown[]) => c[0] === toolName);
+    expect(call).toBeDefined();
+    return call![call!.length - 1] as (params: Record<string, unknown>) => Promise<unknown>;
+  }
+
+  function sentBody(): Record<string, unknown> {
+    const options = (mockGraphClient.graphRequest as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      body: string;
+    };
+    return JSON.parse(options.body);
+  }
+
+  it('merges flattened message fields and nests the body field (issue #569 repro)', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({
+      subject: 'Hello',
+      body: { contentType: 'text', content: 'Hi there' },
+      toRecipients: [{ emailAddress: { address: 'user@example.com' } }],
+    });
+
+    expect(sentBody()).toEqual({
+      subject: 'Hello',
+      body: { contentType: 'text', content: 'Hi there' },
+      toRecipients: [{ emailAddress: { address: 'user@example.com' } }],
+    });
+  });
+
+  it('builds the body entirely from flattened fields when no body param is passed', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({
+      subject: 'Hello',
+      toRecipients: [{ emailAddress: { address: 'user@example.com' } }],
+    });
+
+    expect(sentBody()).toEqual({
+      subject: 'Hello',
+      toRecipients: [{ emailAddress: { address: 'user@example.com' } }],
+    });
+  });
+
+  it('leaves a correctly nested full message body unchanged', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    const message = {
+      subject: 'Hello',
+      body: { contentType: 'text', content: 'Hi there' },
+      toRecipients: [{ emailAddress: { address: 'user@example.com' } }],
+    };
+    await handler({ body: message });
+
+    expect(sentBody()).toEqual(message);
+  });
+
+  it('merges stray fields into an explicit message object, which wins on conflict', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({
+      subject: 'stale top-level duplicate',
+      toRecipients: [{ emailAddress: { address: 'user@example.com' } }],
+      body: { subject: 'explicit wins', body: { contentType: 'text', content: 'Hi' } },
+    });
+
+    expect(sentBody()).toEqual({
+      subject: 'explicit wins',
+      toRecipients: [{ emailAddress: { address: 'user@example.com' } }],
+      body: { contentType: 'text', content: 'Hi' },
+    });
+  });
+
+  it('drops stray fields with a warning when the body is not an object', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ subject: 'Hello', body: 'raw string body' });
+
+    const options = (mockGraphClient.graphRequest as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      body: string;
+    };
+    expect(options.body).toBe('raw string body');
+  });
+
+  it('never merges read-only entity fields like id into the body', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ subject: 'Hello', id: 'AAMk-echoed-id' });
+
+    expect(sentBody()).toEqual({ subject: 'Hello' });
+  });
+
+  it('excludes read-only fields sent in kebab-case too', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ subject: 'Hello', 'created-date-time': '2026-01-01T00:00:00Z' });
+
+    expect(sentBody()).toEqual({ subject: 'Hello' });
+  });
+
+  it('merges an empty body object flat instead of nesting it as an empty itemBody', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ subject: 'Hello', body: {} });
+
+    expect(sentBody()).toEqual({ subject: 'Hello' });
+  });
+});

--- a/test/calendar-view.test.ts
+++ b/test/calendar-view.test.ts
@@ -65,12 +65,12 @@ vi.mock('../src/generated/client.js', () => ({
 }));
 
 describe('Calendar View Tools', () => {
-  let mockServer: { tool: ReturnType<typeof vi.fn> };
+  let mockServer: { tool: ReturnType<typeof vi.fn>; registerTool: ReturnType<typeof vi.fn> };
   let mockGraphClient: GraphClient;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockServer = { tool: vi.fn() };
+    mockServer = { tool: vi.fn(), registerTool: vi.fn() };
     mockGraphClient = {
       graphRequest: vi.fn().mockResolvedValue({
         content: [{ type: 'text', text: JSON.stringify({ value: [] }) }],
@@ -80,7 +80,7 @@ describe('Calendar View Tools', () => {
 
   function getToolHandler(toolName: string) {
     registerGraphTools(mockServer, mockGraphClient, false);
-    const call = mockServer.tool.mock.calls.find((c: unknown[]) => c[0] === toolName);
+    const call = mockServer.registerTool.mock.calls.find((c: unknown[]) => c[0] === toolName);
     expect(call).toBeDefined();
     return call![call!.length - 1] as (params: Record<string, unknown>) => Promise<unknown>;
   }
@@ -89,7 +89,7 @@ describe('Calendar View Tools', () => {
     it('should register all three calendar view/instances tools', () => {
       registerGraphTools(mockServer, mockGraphClient, false);
 
-      const toolNames = mockServer.tool.mock.calls.map((call: unknown[]) => call[0]);
+      const toolNames = mockServer.registerTool.mock.calls.map((call: unknown[]) => call[0]);
       expect(toolNames).toContain('get-calendar-view');
       expect(toolNames).toContain('get-specific-calendar-view');
       expect(toolNames).toContain('list-calendar-event-instances');
@@ -98,9 +98,10 @@ describe('Calendar View Tools', () => {
     it('should include timezone parameter for calendar view tools', () => {
       registerGraphTools(mockServer, mockGraphClient, false);
 
-      for (const call of mockServer.tool.mock.calls) {
+      for (const call of mockServer.registerTool.mock.calls) {
         const toolName = call[0] as string;
-        const paramSchema = call[2] as Record<string, z.ZodTypeAny>;
+        const paramSchema = (call[1] as { inputSchema: z.AnyZodObject }).inputSchema
+          .shape as Record<string, z.ZodTypeAny>;
 
         if (
           [
@@ -117,9 +118,10 @@ describe('Calendar View Tools', () => {
     it('should include expandExtendedProperties parameter for calendar view tools', () => {
       registerGraphTools(mockServer, mockGraphClient, false);
 
-      for (const call of mockServer.tool.mock.calls) {
+      for (const call of mockServer.registerTool.mock.calls) {
         const toolName = call[0] as string;
-        const paramSchema = call[2] as Record<string, z.ZodTypeAny>;
+        const paramSchema = (call[1] as { inputSchema: z.AnyZodObject }).inputSchema
+          .shape as Record<string, z.ZodTypeAny>;
 
         if (
           [
@@ -136,7 +138,7 @@ describe('Calendar View Tools', () => {
     it('should include fetchAllPages parameter for GET tools', () => {
       registerGraphTools(mockServer, mockGraphClient, false);
 
-      for (const call of mockServer.tool.mock.calls) {
+      for (const call of mockServer.registerTool.mock.calls) {
         const toolName = call[0] as string;
         // Skip utilities and read-only POST query tools that are not GET Graph endpoints.
         if (
@@ -146,7 +148,8 @@ describe('Calendar View Tools', () => {
           toolName === 'get-download-url'
         )
           continue;
-        const paramSchema = call[2] as Record<string, z.ZodTypeAny>;
+        const paramSchema = (call[1] as { inputSchema: z.AnyZodObject }).inputSchema
+          .shape as Record<string, z.ZodTypeAny>;
         expect(paramSchema).toHaveProperty('fetchAllPages');
       }
     });
@@ -154,9 +157,9 @@ describe('Calendar View Tools', () => {
     it('should append llmTip to tool descriptions', () => {
       registerGraphTools(mockServer, mockGraphClient, false);
 
-      for (const call of mockServer.tool.mock.calls) {
+      for (const call of mockServer.registerTool.mock.calls) {
         const toolName = call[0] as string;
-        const description = call[1] as string;
+        const description = (call[1] as { description: string }).description;
 
         if (toolName === 'get-calendar-view') {
           expect(description).toContain('TIP:');

--- a/test/http-account-param.test.ts
+++ b/test/http-account-param.test.ts
@@ -64,7 +64,7 @@ describe('Discussion #467: account parameter in HTTP/OAuth mode', () => {
     capturedHandler = undefined;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.spyOn(server, 'tool').mockImplementation(((...args: any[]) => {
+    vi.spyOn(server, 'registerTool').mockImplementation(((...args: any[]) => {
       const name = args[0];
       const handler = args[args.length - 1];
       if (name === 'list-mail-messages' && typeof handler === 'function') {

--- a/test/http-oauth-fix.test.ts
+++ b/test/http-oauth-fix.test.ts
@@ -52,7 +52,7 @@ describe('Issue #258: HTTP/OAuth mode with empty MSAL cache', () => {
 
     // Capture the registered tool handler
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.spyOn(server, 'tool').mockImplementation(((...args: any[]) => {
+    vi.spyOn(server, 'registerTool').mockImplementation(((...args: any[]) => {
       const name = args[0];
       const handler = args[args.length - 1];
       if (name === 'list-mail-messages' && typeof handler === 'function') {

--- a/test/issue-569-e2e.test.ts
+++ b/test/issue-569-e2e.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { registerGraphTools } from '../src/graph-tools.js';
+import type { GraphClient } from '../src/graph-client.js';
+
+vi.mock('../src/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('../src/generated/client-beta.js', () => ({ api: { endpoints: [] } }));
+vi.mock('../src/generated/client.js', async () => {
+  const { z } = await import('zod');
+  return {
+    api: {
+      endpoints: [
+        {
+          alias: 'create-draft-email',
+          method: 'post',
+          path: '/me/messages',
+          description: 'Create a draft email.',
+          parameters: [
+            {
+              name: 'body',
+              type: 'Body',
+              schema: z.object({
+                subject: z.string().nullish(),
+                body: z
+                  .object({
+                    contentType: z.enum(['text', 'html']).optional(),
+                    content: z.string().nullish(),
+                  })
+                  .nullish(),
+                toRecipients: z
+                  .array(
+                    z.object({
+                      emailAddress: z.object({ address: z.string().optional() }).optional(),
+                    })
+                  )
+                  .nullish(),
+              }),
+            },
+          ],
+        },
+      ],
+    },
+  };
+});
+
+// Issue #569: MCP clients flatten message fields (subject, toRecipients) into
+// top-level tool arguments. The SDK validates registered tool input, and with a
+// raw-shape registration it strips unknown keys BEFORE the handler runs — so this
+// test must go through a real McpServer + transport, not call the handler directly.
+describe('issue #569 end-to-end (through MCP SDK validation)', () => {
+  let mockGraphClient: GraphClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGraphClient = {
+      graphRequest: vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: JSON.stringify({ id: 'draft-1' }) }],
+      }),
+    } as unknown as GraphClient;
+  });
+
+  async function connectedClient(): Promise<Client> {
+    const server = new McpServer({ name: 'test', version: '1.0.0' });
+    registerGraphTools(server, mockGraphClient, false);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    await client.connect(clientTransport);
+    return client;
+  }
+
+  it('flattened subject/toRecipients survive SDK validation and reach Graph', async () => {
+    const client = await connectedClient();
+
+    const result = await client.callTool({
+      name: 'create-draft-email',
+      arguments: {
+        subject: 'Hello',
+        body: { contentType: 'text', content: 'Hi there' },
+        toRecipients: [{ emailAddress: { address: 'user@example.com' } }],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const options = (mockGraphClient.graphRequest as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      body: string;
+    };
+    expect(JSON.parse(options.body)).toEqual({
+      subject: 'Hello',
+      body: { contentType: 'text', content: 'Hi there' },
+      toRecipients: [{ emailAddress: { address: 'user@example.com' } }],
+    });
+  });
+
+  it('a correctly nested full message still works through the SDK', async () => {
+    const client = await connectedClient();
+
+    const message = {
+      subject: 'Hello',
+      body: { contentType: 'text', content: 'Hi there' },
+      toRecipients: [{ emailAddress: { address: 'user@example.com' } }],
+    };
+    await client.callTool({ name: 'create-draft-email', arguments: { body: message } });
+
+    const options = (mockGraphClient.graphRequest as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      body: string;
+    };
+    expect(JSON.parse(options.body)).toEqual(message);
+  });
+});

--- a/test/issue-569-e2e.test.ts
+++ b/test/issue-569-e2e.test.ts
@@ -52,10 +52,9 @@ vi.mock('../src/generated/client.js', async () => {
   };
 });
 
-// Issue #569: MCP clients flatten message fields (subject, toRecipients) into
-// top-level tool arguments. The SDK validates registered tool input, and with a
-// raw-shape registration it strips unknown keys BEFORE the handler runs — so this
-// test must go through a real McpServer + transport, not call the handler directly.
+// #569: clients flatten message fields into top-level tool args, and the SDK strips
+// unknown keys during validation BEFORE the handler runs. So this test must go through
+// a real McpServer + transport, not call the handler directly
 describe('issue #569 end-to-end (through MCP SDK validation)', () => {
   let mockGraphClient: GraphClient;
 

--- a/test/multi-account.test.ts
+++ b/test/multi-account.test.ts
@@ -32,11 +32,14 @@ describe('Multi-account support', () => {
   let graphClient: GraphClient;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- McpServer.tool() has ~6 overloads; spying it requires any
   let toolSpy: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let registerToolSpy: any;
 
   beforeEach(() => {
     server = new McpServer({ name: 'test', version: '1.0.0' });
     graphClient = {} as GraphClient;
     toolSpy = vi.spyOn(server, 'tool').mockImplementation((() => {}) as any);
+    registerToolSpy = vi.spyOn(server, 'registerTool').mockImplementation((() => {}) as any);
   });
 
   describe('account parameter injection (Layer 2)', () => {
@@ -46,21 +49,20 @@ describe('Multi-account support', () => {
         'work@company.com',
       ]);
 
-      const toolCall = toolSpy.mock.calls.find(([name]) => name === 'list-mail-messages');
+      const toolCall = registerToolSpy.mock.calls.find(([name]) => name === 'list-mail-messages');
       expect(toolCall).toBeDefined();
 
-      // Schema is the 3rd argument (index 2)
-      const schema = toolCall![2] as Record<string, unknown>;
+      const schema = toolCall![1].inputSchema.shape as Record<string, unknown>;
       expect(schema).toHaveProperty('account');
     });
 
     it('should not inject account param when multiAccount=false', () => {
       registerGraphTools(server, graphClient, false);
 
-      const toolCall = toolSpy.mock.calls.find(([name]) => name === 'list-mail-messages');
+      const toolCall = registerToolSpy.mock.calls.find(([name]) => name === 'list-mail-messages');
       expect(toolCall).toBeDefined();
 
-      const schema = toolCall![2] as Record<string, unknown>;
+      const schema = toolCall![1].inputSchema.shape as Record<string, unknown>;
       expect(schema).not.toHaveProperty('account');
     });
 
@@ -69,8 +71,8 @@ describe('Multi-account support', () => {
         'user@outlook.com',
       ]);
 
-      const toolCall = toolSpy.mock.calls.find(([name]) => name === 'list-mail-messages');
-      const schema = toolCall![2] as Record<string, unknown>;
+      const toolCall = registerToolSpy.mock.calls.find(([name]) => name === 'list-mail-messages');
+      const schema = toolCall![1].inputSchema.shape as Record<string, unknown>;
       // account should be a Zod string type, not enum — verify it's present and optional
       expect(schema).toHaveProperty('account');
     });
@@ -313,8 +315,8 @@ describe('Multi-account support', () => {
           ['user@outlook.com', 'work@company.com']
         );
 
-        const toolCall = toolSpy.mock.calls.find(([name]) => name === 'list-mail-messages');
-        const schema = toolCall![2] as Record<string, unknown>;
+        const toolCall = registerToolSpy.mock.calls.find(([name]) => name === 'list-mail-messages');
+        const schema = toolCall![1].inputSchema.shape as Record<string, unknown>;
         expect(schema).not.toHaveProperty('account');
       });
     });

--- a/test/path-encoding.test.ts
+++ b/test/path-encoding.test.ts
@@ -37,12 +37,12 @@ vi.mock('../src/generated/client.js', () => ({
 }));
 
 describe('Path parameter encoding (issue #245)', () => {
-  let mockServer: { tool: ReturnType<typeof vi.fn> };
+  let mockServer: { tool: ReturnType<typeof vi.fn>; registerTool: ReturnType<typeof vi.fn> };
   let mockGraphClient: GraphClient;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockServer = { tool: vi.fn() };
+    mockServer = { tool: vi.fn(), registerTool: vi.fn() };
     mockGraphClient = {
       graphRequest: vi.fn().mockResolvedValue({
         content: [{ type: 'text', text: JSON.stringify({ value: [] }) }],
@@ -52,7 +52,7 @@ describe('Path parameter encoding (issue #245)', () => {
 
   function getToolHandler(toolName: string) {
     registerGraphTools(mockServer, mockGraphClient, false);
-    const call = mockServer.tool.mock.calls.find((c: unknown[]) => c[0] === toolName);
+    const call = mockServer.registerTool.mock.calls.find((c: unknown[]) => c[0] === toolName);
     expect(call).toBeDefined();
     return call![call!.length - 1] as (params: Record<string, unknown>) => Promise<unknown>;
   }

--- a/test/read-only.test.ts
+++ b/test/read-only.test.ts
@@ -60,7 +60,7 @@ vi.mock('../src/logger.js', () => {
 });
 
 describe('Read-Only Mode', () => {
-  let mockServer: { tool: ReturnType<typeof vi.fn> };
+  let mockServer: { tool: ReturnType<typeof vi.fn>; registerTool: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -69,6 +69,7 @@ describe('Read-Only Mode', () => {
 
     mockServer = {
       tool: vi.fn(),
+      registerTool: vi.fn(),
     };
   });
 
@@ -84,10 +85,12 @@ describe('Read-Only Mode', () => {
 
     registerGraphTools(mockServer, {} as GraphClient, options.readOnly);
 
-    // 1 GET endpoint + parse-teams-url + download-bytes + get-download-url
-    expect(mockServer.tool).toHaveBeenCalledTimes(4);
+    // 1 GET graph endpoint via registerTool; parse-teams-url + download-bytes +
+    // get-download-url utilities via tool
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(1);
+    expect(mockServer.tool).toHaveBeenCalledTimes(3);
 
-    const toolCalls = mockServer.tool.mock.calls.map((call: unknown[]) => call[0]);
+    const toolCalls = mockServer.registerTool.mock.calls.map((call: unknown[]) => call[0]);
     expect(toolCalls).toContain('list-mail-messages');
     expect(toolCalls).not.toContain('send-mail');
     expect(toolCalls).not.toContain('delete-mail-message');
@@ -102,9 +105,10 @@ describe('Read-Only Mode', () => {
     registerGraphTools(mockServer, {} as GraphClient, options.readOnly);
 
     // 4 mocked endpoints (get-schedule skipped: workScopes only, no orgMode) + utilities
-    expect(mockServer.tool).toHaveBeenCalledTimes(7);
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(4);
+    expect(mockServer.tool).toHaveBeenCalledTimes(3);
 
-    const toolCalls = mockServer.tool.mock.calls.map((call: unknown[]) => call[0]);
+    const toolCalls = mockServer.registerTool.mock.calls.map((call: unknown[]) => call[0]);
     expect(toolCalls).toContain('list-mail-messages');
     expect(toolCalls).toContain('send-mail');
     expect(toolCalls).toContain('delete-mail-message');
@@ -120,7 +124,7 @@ describe('Read-Only Mode', () => {
 
     registerGraphTools(mockServer, {} as GraphClient, readOnly, enabledToolsPattern, orgMode);
 
-    const toolCalls = mockServer.tool.mock.calls.map((call: unknown[]) => call[0]);
+    const toolCalls = mockServer.registerTool.mock.calls.map((call: unknown[]) => call[0]);
 
     // GET endpoint should be registered
     expect(toolCalls).toContain('list-mail-messages');
@@ -134,7 +138,8 @@ describe('Read-Only Mode', () => {
     expect(toolCalls).not.toContain('update-mail-folder');
 
     // 2 graph tools (list-mail-messages + get-schedule) + utilities
-    expect(mockServer.tool).toHaveBeenCalledTimes(5);
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(2);
+    expect(mockServer.tool).toHaveBeenCalledTimes(3);
   });
 
   it('reports a readOnly POST endpoint as read-only, not destructive, in its hints', () => {
@@ -143,9 +148,10 @@ describe('Read-Only Mode', () => {
     registerGraphTools(mockServer, {} as GraphClient, false, undefined, true);
 
     const annotationsFor = (alias: string) => {
-      const call = mockServer.tool.mock.calls.find((c: unknown[]) => c[0] === alias);
+      const call = mockServer.registerTool.mock.calls.find((c: unknown[]) => c[0] === alias);
       expect(call, `${alias} should be registered`).toBeDefined();
-      return call![3] as { readOnlyHint: boolean; destructiveHint: boolean };
+      return (call![1] as { annotations: { readOnlyHint: boolean; destructiveHint: boolean } })
+        .annotations;
     };
 
     const getSchedule = annotationsFor('get-schedule');
@@ -167,7 +173,7 @@ describe('Read-Only Mode', () => {
 
     registerGraphTools(mockServer, {} as GraphClient, readOnly, enabledToolsPattern, orgMode);
 
-    const toolCalls = mockServer.tool.mock.calls.map((call: unknown[]) => call[0]);
+    const toolCalls = mockServer.registerTool.mock.calls.map((call: unknown[]) => call[0]);
 
     // PATCH is always blocked in read-only mode
     expect(toolCalls).not.toContain('update-mail-folder');

--- a/test/tool-filtering.test.ts
+++ b/test/tool-filtering.test.ts
@@ -42,50 +42,45 @@ describe('Tool Filtering', () => {
   let server: McpServer;
   let graphClient: GraphClient;
   let toolSpy: ReturnType<typeof vi.spyOn>;
+  let registerToolSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     server = new McpServer({ name: 'test', version: '1.0.0' });
     graphClient = {} as GraphClient;
     toolSpy = vi.spyOn(server, 'tool').mockImplementation(() => {});
+    registerToolSpy = vi
+      .spyOn(server, 'registerTool')
+      .mockImplementation(() => ({}) as ReturnType<McpServer['registerTool']>);
   });
 
   it('should register all tools when no filter is provided', () => {
     registerGraphTools(server, graphClient, false);
 
-    // 5 mocked endpoints + parse-teams-url + download-bytes + get-download-url
-    expect(toolSpy).toHaveBeenCalledTimes(8);
-    expect(toolSpy).toHaveBeenCalledWith(
+    // 5 mocked graph endpoints via registerTool; utilities via tool
+    expect(registerToolSpy).toHaveBeenCalledTimes(5);
+    expect(toolSpy).toHaveBeenCalledTimes(3);
+    expect(registerToolSpy).toHaveBeenCalledWith(
       'list-mail-messages',
-      expect.any(String),
-      expect.any(Object),
       expect.any(Object),
       expect.any(Function)
     );
-    expect(toolSpy).toHaveBeenCalledWith(
+    expect(registerToolSpy).toHaveBeenCalledWith(
       'send-mail',
-      expect.any(String),
-      expect.any(Object),
       expect.any(Object),
       expect.any(Function)
     );
-    expect(toolSpy).toHaveBeenCalledWith(
+    expect(registerToolSpy).toHaveBeenCalledWith(
       'list-calendar-events',
-      expect.any(String),
-      expect.any(Object),
       expect.any(Object),
       expect.any(Function)
     );
-    expect(toolSpy).toHaveBeenCalledWith(
+    expect(registerToolSpy).toHaveBeenCalledWith(
       'list-excel-worksheets',
-      expect.any(String),
-      expect.any(Object),
       expect.any(Object),
       expect.any(Function)
     );
-    expect(toolSpy).toHaveBeenCalledWith(
+    expect(registerToolSpy).toHaveBeenCalledWith(
       'get-current-user',
-      expect.any(String),
-      expect.any(Object),
       expect.any(Object),
       expect.any(Function)
     );
@@ -94,18 +89,14 @@ describe('Tool Filtering', () => {
   it('should filter tools by regex pattern - mail only', () => {
     registerGraphTools(server, graphClient, false, 'mail');
 
-    expect(toolSpy).toHaveBeenCalledTimes(2);
-    expect(toolSpy).toHaveBeenCalledWith(
+    expect(registerToolSpy).toHaveBeenCalledTimes(2);
+    expect(registerToolSpy).toHaveBeenCalledWith(
       'list-mail-messages',
-      expect.any(String),
-      expect.any(Object),
       expect.any(Object),
       expect.any(Function)
     );
-    expect(toolSpy).toHaveBeenCalledWith(
+    expect(registerToolSpy).toHaveBeenCalledWith(
       'send-mail',
-      expect.any(String),
-      expect.any(Object),
       expect.any(Object),
       expect.any(Function)
     );
@@ -114,18 +105,14 @@ describe('Tool Filtering', () => {
   it('should filter tools by regex pattern - calendar or excel', () => {
     registerGraphTools(server, graphClient, false, 'calendar|excel');
 
-    expect(toolSpy).toHaveBeenCalledTimes(2);
-    expect(toolSpy).toHaveBeenCalledWith(
+    expect(registerToolSpy).toHaveBeenCalledTimes(2);
+    expect(registerToolSpy).toHaveBeenCalledWith(
       'list-calendar-events',
-      expect.any(String),
-      expect.any(Object),
       expect.any(Object),
       expect.any(Function)
     );
-    expect(toolSpy).toHaveBeenCalledWith(
+    expect(registerToolSpy).toHaveBeenCalledWith(
       'list-excel-worksheets',
-      expect.any(String),
-      expect.any(Object),
       expect.any(Object),
       expect.any(Function)
     );
@@ -135,17 +122,16 @@ describe('Tool Filtering', () => {
     registerGraphTools(server, graphClient, false, '[invalid regex');
 
     // 5 mocked endpoints + utilities (no filter applied on invalid regex)
-    expect(toolSpy).toHaveBeenCalledTimes(8);
+    expect(registerToolSpy).toHaveBeenCalledTimes(5);
+    expect(toolSpy).toHaveBeenCalledTimes(3);
   });
 
   it('should combine read-only and filtering correctly', () => {
     registerGraphTools(server, graphClient, true, 'mail');
 
-    expect(toolSpy).toHaveBeenCalledTimes(1);
-    expect(toolSpy).toHaveBeenCalledWith(
+    expect(registerToolSpy).toHaveBeenCalledTimes(1);
+    expect(registerToolSpy).toHaveBeenCalledWith(
       'list-mail-messages',
-      expect.any(String),
-      expect.any(Object),
       expect.any(Object),
       expect.any(Function)
     );
@@ -154,6 +140,7 @@ describe('Tool Filtering', () => {
   it('should register no tools when pattern matches nothing', () => {
     registerGraphTools(server, graphClient, false, 'nonexistent');
 
+    expect(registerToolSpy).toHaveBeenCalledTimes(0);
     expect(toolSpy).toHaveBeenCalledTimes(0);
   });
 });


### PR DESCRIPTION
MCP clients flatten message fields (subject, toRecipients) into top-level
tool params; these were silently dropped before the request was built,
so create-draft-email sent only the body field and Graph returned 400
UnableToDeserializePostBody.

Three layers were needed:

- Register graph tools via registerTool with a passthrough object schema,
  since the SDK validates raw shapes with strip semantics and removed the
  flattened params before the handler ever ran.
- Make Body param schemas lenient (passthrough through optional/nullable/
  lazy wrappers) so nested validation does not empty the flattened body
  value.
- Rescue unmatched params that match the Body schema shape into the
  request body in executeGraphTool, nesting the body field when the
  client meant it as message.body. Read-only entity fields are excluded,
  explicit body values win over stray duplicates, and z.lazy schemas
  (chatMessage tools) are unwrapped too.