### PR TITLE
Add llmTips to update-todo-task and create-todo-task for tool discovery

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1100,14 +1100,16 @@
     "method": "post",
     "toolName": "create-todo-task",
     "presets": ["personal", "tasks"],
-    "scopes": ["Tasks.ReadWrite"]
+    "scopes": ["Tasks.ReadWrite"],
+    "llmTip": "Creates a new task in a Microsoft To Do list. Body: { title: \"...\" }; optional dueDateTime, reminderDateTime, importance, body (notes), recurrence, categories. Requires todoTaskListId from list-todo-task-lists."
   },
   {
     "pathPattern": "/me/todo/lists/{todoTaskList-id}/tasks/{todoTask-id}",
     "method": "patch",
     "toolName": "update-todo-task",
     "presets": ["personal", "tasks"],
-    "scopes": ["Tasks.ReadWrite"]
+    "scopes": ["Tasks.ReadWrite"],
+    "llmTip": "Updates a Microsoft To Do task. Use this to mark a to-do item complete or done (body: { status: \"completed\" }), reopen it (status: \"notStarted\"), rename it (title), or change its due date (dueDateTime), reminder (reminderDateTime), importance, or notes (body). Requires todoTaskListId from list-todo-task-lists and todoTaskId from list-todo-tasks."
   },
   {
     "pathPattern": "/me/todo/lists/{todoTaskList-id}/tasks/{todoTask-id}",


### PR DESCRIPTION
These two endpoints ship with only the bare Graph docstring ('Update the properties of a todoTask object.'), while every sibling To Do endpoint carries an llmTip. Since tool search ranks BM25 over name, description, and llmTip, natural queries like 'mark to do item complete' fail to surface update-todo-task at all, and MCP clients conclude the server has no task-update tool. 

This PR give both endpoints keyword-rich tips matching the style of their siblings. Tested and verified on my fork.