### PR TITLE
fix(auth): avoid keychain token cache by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,9 +609,9 @@ Environment variables:
 
 ## Token Storage
 
-Authentication tokens are stored using the OS credential store (via keytar) when available. If keytar is not installed or fails (common on headless Linux), the server falls back to file-based storage.
+Authentication tokens are stored in file-based storage by default. The server does not use the OS credential store, `keytar`, macOS Keychain, Windows Credential Manager, or Linux Secret Service, so a local auth flow must not trigger an operating-system password prompt just to read or write the MSAL cache.
 
-**Default fallback paths** are relative to the installed package directory. This means tokens can be lost when the package is reinstalled or updated via npm.
+**Default paths** are relative to the installed package directory. This means tokens can be lost when the package is reinstalled or updated via npm.
 
 To persist tokens across updates, set custom paths outside the package directory:
 
@@ -622,20 +622,20 @@ export MS365_MCP_SELECTED_ACCOUNT_PATH="$HOME/.config/ms365-mcp/.selected-accoun
 
 Parent directories are created automatically. Files are written with `0600` permissions.
 
-> **Security note**: File-based token storage writes sensitive credentials to disk. Ensure the chosen directory has appropriate access controls. The OS credential store (keytar) is preferred when available.
+> **Security note**: File-based token storage writes sensitive credentials to disk. Ensure the chosen directory has appropriate access controls, ideally a private `0700` directory on an encrypted volume. For stricter custody, use `MS365_MCP_AUTH_CACHE_COMMAND` to wrap a provider-neutral external store.
 
 > **Hosted/sandboxed environments** (e.g. Anthropic Cowork): Set `MS365_MCP_TOKEN_CACHE_PATH` and `MS365_MCP_SELECTED_ACCOUNT_PATH` to a persistent mount so tokens survive between sessions.
 
 ### External auth-cache command
 
-Headless local-MSAL deployments can replace the built-in keytar/file storage with a provider-neutral external command:
+Headless local-MSAL deployments can replace the built-in file storage with a provider-neutral external command:
 
 ```bash
 export MS365_MCP_AUTH_CACHE_COMMAND="/path/to/ms365-auth-cache-store"
 export MS365_MCP_AUTH_CACHE_COMMAND_TIMEOUT_MS=10000
 ```
 
-When `MS365_MCP_AUTH_CACHE_COMMAND` is set for a local auth flow, the server uses only that command for the MSAL token cache and selected-account metadata. It does not fall back to keytar or local files. If the command path is missing, not executable on POSIX, exits non-zero, times out, or returns malformed data, auth-cache operations fail closed with a sanitized error message.
+When `MS365_MCP_AUTH_CACHE_COMMAND` is set for a local auth flow, the server uses only that command for the MSAL token cache and selected-account metadata. It does not fall back to local files. If the command path is missing, not executable on POSIX, exits non-zero, times out, or returns malformed data, auth-cache operations fail closed with a sanitized error message.
 
 The value must be a real executable wrapper path. It is not a shell command string, and there is no companion args environment variable. Put any interpreter, region, profile, or provider-specific settings inside the wrapper. Windows users should point the variable at a wrapper executable or script that can be launched directly by Node without shell parsing.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,8 +51,7 @@
       },
       "optionalDependencies": {
         "@azure/identity": "^4.5.0",
-        "@azure/keyvault-secrets": "^4.9.0",
-        "keytar": "^7.9.0"
+        "@azure/keyvault-secrets": "^4.9.0"
       }
     },
     "node_modules/@actions/core": {
@@ -4114,27 +4113,6 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
@@ -4160,33 +4138,6 @@
       },
       "peerDependencies": {
         "ajv": "4.11.8 - 8"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/body-parser": {
@@ -4244,31 +4195,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -4435,13 +4361,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/classnames": {
       "version": "2.5.1",
@@ -4974,27 +4893,11 @@
       "integrity": "sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ==",
       "dev": true
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
@@ -5060,7 +4963,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5180,16 +5083,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/env-ci": {
@@ -5804,16 +5697,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -6191,13 +6074,6 @@
         "readable-stream": "^2.0.0"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/fs-extra": {
       "version": "11.3.4",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
@@ -6354,13 +6230,6 @@
         "through2": "~2.0.0",
         "traverse": "0.6.8"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/glob": {
       "version": "13.0.6",
@@ -6626,27 +6495,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -6742,7 +6590,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/into-stream": {
@@ -7228,18 +7076,6 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/keytar": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
-      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-addon-api": "^4.3.0",
-        "prebuild-install": "^7.0.1"
       }
     },
     "node_modules/keyv": {
@@ -8012,19 +7848,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -8045,7 +7868,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8060,13 +7883,6 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/mlly": {
       "version": "1.8.2",
@@ -8181,13 +7997,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -8217,26 +8026,6 @@
       "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/node-emoji": {
       "version": "2.2.0",
@@ -10985,34 +10774,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11129,17 +10890,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -11224,7 +10974,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "devOptional": true,
+      "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
         "deep-extend": "^0.6.0",
@@ -11240,7 +10990,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12437,53 +12187,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/simple-websocket": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-9.1.0.tgz",
@@ -12940,51 +12643,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/temp-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
@@ -13376,19 +13034,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
   },
   "optionalDependencies": {
     "@azure/identity": "^4.5.0",
-    "@azure/keyvault-secrets": "^4.9.0",
-    "keytar": "^7.9.0"
+    "@azure/keyvault-secrets": "^4.9.0"
   },
   "devDependencies": {
     "@redocly/cli": "^2.11.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import { dumpError, getActiveResources } from './crash-logging.js';
 import { version } from './version.js';
 
 // Global crash handlers. Without these, an unhandled rejection from a dependency
-// (MSAL HTTP, keytar native, fetch in node) kills the stdio process silently
+// (MSAL HTTP, fetch in node, external auth-cache wrappers) kills the stdio process silently
 // before winston can flush. Log to stderr synchronously so the dump survives.
 process.on('unhandledRejection', (reason) => {
   const dump = {

--- a/src/token-cache-storage.ts
+++ b/src/token-cache-storage.ts
@@ -25,9 +25,6 @@ type SpawnCommand = (
   options: { stdio: 'pipe'; shell: false }
 ) => ChildProcessWithoutNullStreams;
 
-const SERVICE_NAME = 'ms-365-mcp-server';
-const TOKEN_CACHE_ACCOUNT = 'msal-token-cache';
-const SELECTED_ACCOUNT_KEY = 'selected-account';
 const AUTH_CACHE_COMMAND_ENV = 'MS365_MCP_AUTH_CACHE_COMMAND';
 const AUTH_CACHE_COMMAND_TIMEOUT_ENV = 'MS365_MCP_AUTH_CACHE_COMMAND_TIMEOUT_MS';
 const DEFAULT_AUTH_CACHE_COMMAND_TIMEOUT_MS = 10_000;
@@ -39,32 +36,6 @@ const __dirname = path.dirname(__filename);
 const FALLBACK_DIR = __dirname;
 const DEFAULT_TOKEN_CACHE_PATH = path.join(FALLBACK_DIR, '..', '.token-cache.json');
 const DEFAULT_SELECTED_ACCOUNT_PATH = path.join(FALLBACK_DIR, '..', '.selected-account.json');
-
-let keytar: typeof import('keytar') | null | undefined = null;
-
-async function getKeytar() {
-  if (keytar === undefined) {
-    return null;
-  }
-  if (keytar === null) {
-    try {
-      // Normalize ESM/CJS interop: under Node 24+ `await import('keytar')` returns a
-      // namespace object whose top-level `setPassword` is undefined (functions live on
-      // `.default`). On older Node and pure CJS, methods live on the namespace itself.
-      // Falling back to the namespace keeps backward compatibility. See issue #418.
-      const mod = (await import('keytar')) as typeof import('keytar') & {
-        default?: typeof import('keytar');
-      };
-      keytar = mod.default ?? mod;
-      return keytar;
-    } catch {
-      logger.info('keytar not available, using file-based credential storage');
-      keytar = undefined;
-      return null;
-    }
-  }
-  return keytar;
-}
 
 export function wrapCache(data: string): string {
   return JSON.stringify({ _cacheEnvelope: true, data, savedAt: Date.now() });
@@ -83,28 +54,28 @@ export function unwrapCache(raw: string): { data: string; savedAt?: number } {
 }
 
 export function pickNewest(
-  keytarRaw: string | undefined,
+  primaryRaw: string | undefined,
   fileRaw: string | undefined
 ): string | undefined {
-  const newest = pickNewestRaw(keytarRaw, fileRaw);
+  const newest = pickNewestRaw(primaryRaw, fileRaw);
   return newest ? unwrapCache(newest).data : undefined;
 }
 
 function pickNewestRaw(
-  keytarRaw: string | undefined,
+  primaryRaw: string | undefined,
   fileRaw: string | undefined
 ): string | undefined {
-  if (!keytarRaw && !fileRaw) return undefined;
-  if (keytarRaw && !fileRaw) return keytarRaw;
-  if (!keytarRaw && fileRaw) return fileRaw;
+  if (!primaryRaw && !fileRaw) return undefined;
+  if (primaryRaw && !fileRaw) return primaryRaw;
+  if (!primaryRaw && fileRaw) return fileRaw;
 
-  const kt = unwrapCache(keytarRaw!);
+  const primary = unwrapCache(primaryRaw!);
   const file = unwrapCache(fileRaw!);
 
-  if (kt.savedAt === undefined && file.savedAt === undefined) return keytarRaw;
-  if (kt.savedAt !== undefined && file.savedAt === undefined) return keytarRaw;
-  if (kt.savedAt === undefined && file.savedAt !== undefined) return fileRaw;
-  return kt.savedAt! >= file.savedAt! ? keytarRaw : fileRaw;
+  if (primary.savedAt === undefined && file.savedAt === undefined) return primaryRaw;
+  if (primary.savedAt !== undefined && file.savedAt === undefined) return primaryRaw;
+  if (primary.savedAt === undefined && file.savedAt !== undefined) return fileRaw;
+  return primary.savedAt! >= file.savedAt! ? primaryRaw : fileRaw;
 }
 
 export function getTokenCachePath(): string {
@@ -115,11 +86,6 @@ export function getTokenCachePath(): string {
 export function getSelectedAccountPath(): string {
   const envPath = process.env.MS365_MCP_SELECTED_ACCOUNT_PATH?.trim();
   return envPath || DEFAULT_SELECTED_ACCOUNT_PATH;
-}
-
-function storageAccountForKey(key: TokenCacheStorageKey): string {
-  assertValidKey(key);
-  return key === 'token-cache' ? TOKEN_CACHE_ACCOUNT : SELECTED_ACCOUNT_KEY;
 }
 
 function filePathForKey(key: TokenCacheStorageKey): string {
@@ -149,58 +115,26 @@ function writeFileAtomically(filePath: string, value: string): void {
 }
 
 export class DefaultTokenCacheStorage implements TokenCacheStorage {
-  readonly description = 'default (keytar+file)';
+  readonly description = 'default (file)';
   readonly failClosed = false;
 
   async load(key: TokenCacheStorageKey): Promise<string | undefined> {
     assertValidKey(key);
-    let keytarRaw: string | undefined;
-    try {
-      const kt = await getKeytar();
-      if (kt) {
-        keytarRaw = (await kt.getPassword(SERVICE_NAME, storageAccountForKey(key))) ?? undefined;
-      }
-    } catch (error) {
-      logger.warn(`Keychain access failed for ${key}: ${(error as Error).message}`);
-    }
-
-    let fileRaw: string | undefined;
     const cachePath = filePathForKey(key);
     if (existsSync(cachePath)) {
-      fileRaw = readFileSync(cachePath, 'utf8');
+      return readFileSync(cachePath, 'utf8');
     }
 
-    return pickNewestRaw(keytarRaw, fileRaw);
+    return undefined;
   }
 
   async save(key: TokenCacheStorageKey, value: string): Promise<void> {
     assertValidKey(key);
-    try {
-      const kt = await getKeytar();
-      if (kt) {
-        await kt.setPassword(SERVICE_NAME, storageAccountForKey(key), value);
-        return;
-      }
-    } catch (error) {
-      logger.warn(
-        `Keychain save failed for ${key}, falling back to file storage: ${(error as Error).message}`
-      );
-    }
-
     writeFileAtomically(filePathForKey(key), value);
   }
 
   async delete(key: TokenCacheStorageKey): Promise<void> {
     assertValidKey(key);
-    try {
-      const kt = await getKeytar();
-      if (kt) {
-        await kt.deletePassword(SERVICE_NAME, storageAccountForKey(key));
-      }
-    } catch (error) {
-      logger.warn(`Keychain deletion failed for ${key}: ${(error as Error).message}`);
-    }
-
     const cachePath = filePathForKey(key);
     try {
       if (fs.existsSync(cachePath)) {

--- a/test/auth-storage.test.ts
+++ b/test/auth-storage.test.ts
@@ -147,7 +147,7 @@ describe('AuthManager token cache storage', () => {
     const auth = await AuthManager.create(['User.Read']);
 
     const storage = (auth as unknown as { storage: TokenCacheStorage }).storage;
-    expect(storage.description).toBe('default (keytar+file)');
+    expect(storage.description).toBe('default (file)');
   });
 });
 

--- a/test/cache-stamp.test.ts
+++ b/test/cache-stamp.test.ts
@@ -28,7 +28,7 @@ describe('cache stamp', () => {
       expect(pickNewest(undefined, undefined)).toBeUndefined();
     });
 
-    it('should return keytar when only keytar has data', () => {
+    it('should return primary when only primary has data', () => {
       expect(pickNewest('data', undefined)).toBe('data');
     });
 
@@ -36,13 +36,13 @@ describe('cache stamp', () => {
       expect(pickNewest(undefined, 'data')).toBe('data');
     });
 
-    it('should prefer keytar when neither is stamped', () => {
-      expect(pickNewest('keytar-data', 'file-data')).toBe('keytar-data');
+    it('should prefer primary when neither is stamped', () => {
+      expect(pickNewest('primary-data', 'file-data')).toBe('primary-data');
     });
 
     it('should prefer stamped over unstamped', () => {
       const stamped = wrapCache('new-data');
-      expect(pickNewest('old-keytar', stamped)).toBe('new-data');
+      expect(pickNewest('old-primary', stamped)).toBe('new-data');
       expect(pickNewest(stamped, 'old-file')).toBe('new-data');
     });
 
@@ -53,10 +53,10 @@ describe('cache stamp', () => {
       expect(pickNewest(newer, older)).toBe('new');
     });
 
-    it('should prefer keytar when timestamps are equal', () => {
-      const a = JSON.stringify({ _cacheEnvelope: true, data: 'keytar', savedAt: 1000 });
+    it('should prefer primary when timestamps are equal', () => {
+      const a = JSON.stringify({ _cacheEnvelope: true, data: 'primary', savedAt: 1000 });
       const b = JSON.stringify({ _cacheEnvelope: true, data: 'file', savedAt: 1000 });
-      expect(pickNewest(a, b)).toBe('keytar');
+      expect(pickNewest(a, b)).toBe('primary');
     });
 
     it('should unwrap stamped data when only one source exists', () => {

--- a/test/token-cache-storage.test.ts
+++ b/test/token-cache-storage.test.ts
@@ -85,7 +85,7 @@ describe('token cache storage', () => {
       const storage = await createTokenCacheStorage();
 
       expect(storage).toBeInstanceOf(DefaultTokenCacheStorage);
-      expect(storage.description).toBe('default (keytar+file)');
+      expect(storage.description).toBe('default (file)');
     });
 
     it('rejects a whitespace-only command for local auth flows', async () => {


### PR DESCRIPTION
## Summary
- remove the default keytar/OS credential-store token-cache path
- use file-based token storage by default for local MSAL cache and selected-account metadata
- update token-storage docs and tests to reflect that local auth must not trigger Keychain/Credential Manager/Secret Service prompts

## Verification
- npm run generate
- npm run build
- npm test -- token-cache-storage auth-storage cache-stamp auth-paths
- npm test
- npm run lint
- npm run format:check
- rg scan for runtime keytar/Keychain/Credential Manager/Secret Service usage