### PR TITLE
fix: normalize tool inputSchema $refs to #/$defs (#571)

### DIFF
--- a/src/normalize-tool-schema.ts
+++ b/src/normalize-tool-schema.ts
@@ -1,0 +1,170 @@
+// The MCP SDK converts each tool's Zod inputSchema to JSON Schema with
+// zod-to-json-schema's default `$refStrategy: 'root'`. That emits internal
+// `$ref`s as root-relative JSON pointers (e.g. `#/properties/body/properties/from`)
+// wherever a sub-schema recurses OR is reused by object identity. Strict
+// JSON-Schema backends (e.g. Kimi/Moonshot) reject any `$ref` that does not start
+// with `#/$defs/`, so they refuse the whole tools/list. The SDK hard-codes the
+// conversion options, so we normalize its output here instead: hoist every
+// referenced sub-schema into a top-level `$defs` and repoint the refs. This is
+// content-preserving (refs still resolve to the same schema) and keeps the payload
+// compact, unlike inlining. See issue #571.
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import logger from './logger.js';
+
+type JsonSchema = Record<string, unknown>;
+
+function unescapePointer(token: string): string {
+  return token.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+// We only normalize internal, root-relative refs (`#/...`). A bare `#` (a
+// whole-document self-ref) can't occur here: the SDK wraps every tool inputSchema in
+// `z.object({...})`, so recursion always resolves to a nested path, never the root.
+function isBadRef(value: unknown): value is string {
+  return typeof value === 'string' && value.startsWith('#/') && !value.startsWith('#/$defs/');
+}
+
+function collectBadRefTargets(node: unknown, targets: Set<string>): void {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const item of node) collectBadRefTargets(item, targets);
+    return;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (key === '$ref' && isBadRef(value)) {
+      targets.add(value.slice(1)); // strip leading '#', keep the JSON pointer
+    } else {
+      collectBadRefTargets(value, targets);
+    }
+  }
+}
+
+interface Slot {
+  parent: Record<string, unknown> | unknown[];
+  key: string | number;
+  obj: unknown;
+}
+
+function resolvePointer(root: unknown, pointer: string): Slot | null {
+  const tokens = pointer.split('/').slice(1).map(unescapePointer);
+  if (tokens.length === 0) return null; // root ('#') is never a hoist target
+  let parent: Record<string, unknown> | unknown[] | null = null;
+  let key: string | number = '';
+  let cur: unknown = root;
+  for (const token of tokens) {
+    if (!cur || typeof cur !== 'object') return null;
+    parent = cur as Record<string, unknown> | unknown[];
+    key = Array.isArray(cur) ? Number(token) : token;
+    cur = (cur as Record<string, unknown>)[key as never];
+    if (cur === undefined) return null;
+  }
+  return parent === null ? null : { parent, key, obj: cur };
+}
+
+function repointRefs(node: unknown, nameFor: Map<string, string>): void {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const item of node) repointRefs(item, nameFor);
+    return;
+  }
+  const record = node as Record<string, unknown>;
+  for (const [key, value] of Object.entries(record)) {
+    if (key === '$ref' && isBadRef(value)) {
+      const name = nameFor.get(value.slice(1));
+      if (name) record.$ref = `#/$defs/${name}`;
+    } else {
+      repointRefs(value, nameFor);
+    }
+  }
+}
+
+/**
+ * Rewrite a tool inputSchema so every internal `$ref` is anchored under `#/$defs/`.
+ * Returns the input untouched when it already complies (the common case), so only
+ * the handful of tools with recursive/shared Graph schemas pay any cost.
+ */
+export function normalizeToolSchemaRefs<T extends JsonSchema>(schema: T): T {
+  const targets = new Set<string>();
+  collectBadRefTargets(schema, targets);
+  if (targets.size === 0) return schema;
+
+  const clone = structuredClone(schema) as JsonSchema;
+
+  // Resolve every target from the un-mutated clone first: capturing the object
+  // references up front keeps nested targets valid even after we replace their
+  // enclosing slot with a $ref. Names are assigned only to targets that resolve, so
+  // an (unexpected) unresolvable pointer is left untouched rather than repointed to a
+  // missing $defs entry. Sorted for stable, reproducible output.
+  const slots = new Map<string, Slot>();
+  for (const pointer of [...targets].sort()) {
+    const slot = resolvePointer(clone, pointer);
+    if (slot) slots.set(pointer, slot);
+  }
+  if (slots.size === 0) return schema;
+
+  // Assign def names that can't clash with a pre-existing $defs key. The SDK's `root`
+  // strategy never emits $defs today, but we merge existing defs below, so guard the
+  // names too rather than rely on that (a clash would silently repoint a valid ref).
+  const takenNames = new Set(
+    clone.$defs && typeof clone.$defs === 'object' ? Object.keys(clone.$defs) : []
+  );
+  const nameFor = new Map<string, string>();
+  let index = 0;
+  for (const pointer of slots.keys()) {
+    let name = `def${index++}`;
+    while (takenNames.has(name)) name = `def${index++}`;
+    takenNames.add(name);
+    nameFor.set(pointer, name);
+  }
+
+  const defs: Record<string, unknown> = {};
+  for (const [pointer, slot] of slots) {
+    defs[nameFor.get(pointer)!] = slot.obj;
+  }
+  for (const [pointer, slot] of slots) {
+    (slot.parent as Record<string, unknown>)[slot.key as never] = {
+      $ref: `#/$defs/${nameFor.get(pointer)}`,
+    } as never;
+  }
+
+  repointRefs(clone, nameFor);
+  for (const name of Object.keys(defs)) repointRefs(defs[name], nameFor);
+
+  const existingDefs = (clone.$defs as Record<string, unknown> | undefined) ?? {};
+  clone.$defs = { ...existingDefs, ...defs };
+  return clone as T;
+}
+
+// Decorate the SDK's tools/list handler so every emitted inputSchema is passed
+// through normalizeToolSchemaRefs. The SDK hard-codes its Zod->JSON-Schema options,
+// so this is the only place to enforce #/$defs/-anchored refs. 'tools/list' is the
+// stable MCP protocol method the low-level Server keys its handler by; we grab the
+// existing handler and delegate to it so all of McpServer's listing behavior is
+// preserved. Falls back to a no-op (with a warning) if the SDK internals move.
+export function installToolSchemaRefNormalization(server: McpServer): void {
+  const lowLevel = server.server;
+  const handlers = (
+    lowLevel as unknown as {
+      _requestHandlers?: Map<
+        string,
+        (request: unknown, extra: unknown) => Promise<{ tools?: Array<{ inputSchema?: unknown }> }>
+      >;
+    }
+  )._requestHandlers;
+  const original = handlers?.get('tools/list');
+  if (!original) {
+    logger.warn('Skipping tool-schema $ref normalization: tools/list handler not found');
+    return;
+  }
+  lowLevel.setRequestHandler(ListToolsRequestSchema, async (request, extra) => {
+    const result = await original(request, extra);
+    for (const tool of result.tools ?? []) {
+      if (tool.inputSchema && typeof tool.inputSchema === 'object') {
+        tool.inputSchema = normalizeToolSchemaRefs(tool.inputSchema as JsonSchema);
+      }
+    }
+    return result;
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import logger, { enableConsoleLogging } from './logger.js';
 import { registerAuthTools } from './auth-tools.js';
 import { registerGraphTools, registerDiscoveryTools } from './graph-tools.js';
 import { buildMcpServerInstructions } from './mcp-instructions.js';
+import { installToolSchemaRefNormalization } from './normalize-tool-schema.js';
 import GraphClient from './graph-client.js';
 import AuthManager, {
   buildScopesFromEndpoints,
@@ -135,6 +136,12 @@ class MicrosoftGraphServer {
         this.options.allowedScopes
       );
     }
+
+    // Strict JSON-Schema backends (e.g. Kimi/Moonshot) reject a tools/list whose
+    // inputSchema $refs aren't anchored under #/$defs/. The SDK emits root-relative
+    // refs for recursive/shared Microsoft Graph schemas and hard-codes its conversion
+    // options, so normalize the emitted schemas here. See issue #571.
+    installToolSchemaRefNormalization(server);
 
     return server;
   }

--- a/test/normalize-tool-schema.test.ts
+++ b/test/normalize-tool-schema.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  normalizeToolSchemaRefs,
+  installToolSchemaRefNormalization,
+} from '../src/normalize-tool-schema.js';
+
+// Collect every $ref value in a schema.
+function collectRefs(node: unknown, out: string[] = []): string[] {
+  if (!node || typeof node !== 'object') return out;
+  if (Array.isArray(node)) {
+    for (const item of node) collectRefs(item, out);
+    return out;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (key === '$ref' && typeof value === 'string') out.push(value);
+    else collectRefs(value, out);
+  }
+  return out;
+}
+
+// Resolve a JSON pointer ('#/a/b') against a document; undefined if it dangles.
+function resolvePointer(root: unknown, ref: string): unknown {
+  if (!ref.startsWith('#')) return undefined;
+  const tokens = ref
+    .slice(1)
+    .split('/')
+    .slice(1)
+    .map((t) => t.replace(/~1/g, '/').replace(/~0/g, '~'));
+  let cur: unknown = root;
+  for (const token of tokens) {
+    if (!cur || typeof cur !== 'object') return undefined;
+    cur = (cur as Record<string, unknown>)[token];
+    if (cur === undefined) return undefined;
+  }
+  return cur;
+}
+
+describe('normalizeToolSchemaRefs', () => {
+  it('returns the same object untouched when there are no refs', () => {
+    const schema = { type: 'object', properties: { a: { type: 'string' } } };
+    expect(normalizeToolSchemaRefs(schema)).toBe(schema);
+  });
+
+  it('leaves already-#/$defs-anchored refs alone', () => {
+    const schema = {
+      type: 'object',
+      properties: { a: { $ref: '#/$defs/x' } },
+      $defs: { x: { type: 'string' } },
+    };
+    expect(normalizeToolSchemaRefs(schema)).toBe(schema);
+  });
+
+  it('rewrites a root-relative dedup ref into #/$defs and preserves resolution', () => {
+    // `to` is emitted inline once and referenced by object identity elsewhere.
+    const schema = {
+      type: 'object',
+      properties: {
+        from: { type: 'object', properties: { email: { type: 'string' } } },
+        to: { $ref: '#/properties/from' },
+      },
+    };
+    const out = normalizeToolSchemaRefs(schema);
+    const refs = collectRefs(out);
+    expect(refs.length).toBeGreaterThan(0);
+    expect(refs.every((r) => r.startsWith('#/$defs/'))).toBe(true);
+    for (const r of refs) expect(resolvePointer(out, r)).toBeDefined();
+    // The extracted def is the original `from` schema.
+    const to = (out.properties as Record<string, { $ref: string }>).to;
+    expect(resolvePointer(out, to.$ref)).toMatchObject({
+      type: 'object',
+      properties: { email: { type: 'string' } },
+    });
+  });
+
+  it('rewrites a recursion ref (target is an ancestor of the ref) into valid #/$defs recursion', () => {
+    // Mirrors mailFolder.childFolders: body refs itself.
+    const schema = {
+      type: 'object',
+      properties: {
+        body: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            childFolders: { type: 'array', items: { $ref: '#/properties/body' } },
+          },
+        },
+      },
+    };
+    const out = normalizeToolSchemaRefs(schema);
+    const refs = collectRefs(out);
+    expect(refs.every((r) => r.startsWith('#/$defs/'))).toBe(true);
+    for (const r of refs) expect(resolvePointer(out, r)).toBeDefined();
+    // The recursive def points at itself, still under #/$defs.
+    const def = resolvePointer(out, refs[0]) as Record<string, unknown>;
+    const items = (def.properties as Record<string, { items: { $ref: string } }>).childFolders
+      .items;
+    expect(items.$ref.startsWith('#/$defs/')).toBe(true);
+  });
+
+  it('handles nested targets without leaving dangling refs', () => {
+    const inner = { type: 'object', properties: { v: { type: 'string' } } };
+    const schema = {
+      type: 'object',
+      properties: {
+        a: { type: 'object', properties: { inner, other: { type: 'string' } } },
+        b: { $ref: '#/properties/a' }, // outer target
+        c: { $ref: '#/properties/a/properties/inner' }, // nested target
+      },
+    };
+    const out = normalizeToolSchemaRefs(schema);
+    const refs = collectRefs(out);
+    expect(refs.length).toBeGreaterThanOrEqual(2);
+    expect(refs.every((r) => r.startsWith('#/$defs/'))).toBe(true);
+    for (const r of refs) expect(resolvePointer(out, r)).toBeDefined();
+  });
+
+  it('does not mutate the input schema', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        from: { type: 'object' },
+        to: { $ref: '#/properties/from' },
+      },
+    };
+    const snapshot = JSON.stringify(schema);
+    normalizeToolSchemaRefs(schema);
+    expect(JSON.stringify(schema)).toBe(snapshot);
+  });
+
+  it('collapses multiple refs to the same target onto one def', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        from: { type: 'object', properties: { email: { type: 'string' } } },
+        to: { $ref: '#/properties/from' },
+        cc: { $ref: '#/properties/from' },
+      },
+    };
+    const out = normalizeToolSchemaRefs(schema);
+    expect(Object.keys(out.$defs as object)).toHaveLength(1);
+    const props = out.properties as Record<string, { $ref: string }>;
+    expect(props.to.$ref).toBe(props.cc.$ref);
+    expect(props.to.$ref.startsWith('#/$defs/')).toBe(true);
+    for (const r of collectRefs(out)) expect(resolvePointer(out, r)).toBeDefined();
+  });
+
+  it('resolves JSON-pointer ~0/~1 escapes (keys containing ~ and /)', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        'a/b~c': { type: 'object', properties: { v: { type: 'string' } } },
+        ref: { $ref: '#/properties/a~1b~0c' }, // ~1 => '/', ~0 => '~'
+      },
+    };
+    const out = normalizeToolSchemaRefs(schema);
+    const refs = collectRefs(out);
+    expect(refs.every((r) => r.startsWith('#/$defs/'))).toBe(true);
+    for (const r of refs) expect(resolvePointer(out, r)).toBeDefined();
+    expect(
+      resolvePointer(out, (out.properties as Record<string, { $ref: string }>).ref.$ref)
+    ).toMatchObject({ properties: { v: { type: 'string' } } });
+  });
+
+  it('resolves array-index pointer targets (anyOf/0)', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        pick: {
+          anyOf: [{ type: 'object', properties: { x: { type: 'string' } } }, { type: 'null' }],
+        },
+        alias: { $ref: '#/properties/pick/anyOf/0' },
+      },
+    };
+    const out = normalizeToolSchemaRefs(schema);
+    const refs = collectRefs(out);
+    expect(refs.every((r) => r.startsWith('#/$defs/'))).toBe(true);
+    for (const r of refs) expect(resolvePointer(out, r)).toBeDefined();
+  });
+
+  it('leaves an unresolvable ref untouched rather than dangling it', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        from: { type: 'object' },
+        good: { $ref: '#/properties/from' }, // resolvable -> hoisted
+        bad: { $ref: '#/properties/does/not/exist' }, // unresolvable -> left as-is
+      },
+    };
+    const out = normalizeToolSchemaRefs(schema);
+    // Every $defs ref we introduce must resolve: we never manufacture a dangling
+    // def ref. A pre-existing unresolvable ref is left exactly as-is (not "fixed"
+    // into a missing $defs target).
+    for (const r of collectRefs(out).filter((x) => x.startsWith('#/$defs/'))) {
+      expect(resolvePointer(out, r)).toBeDefined();
+    }
+    const props = out.properties as Record<string, { $ref: string }>;
+    expect(props.good.$ref.startsWith('#/$defs/')).toBe(true);
+    expect(props.bad.$ref).toBe('#/properties/does/not/exist');
+  });
+
+  it('preserves a pre-existing $defs and never overwrites its keys', () => {
+    const schema = {
+      type: 'object',
+      $defs: { def0: { const: 'sentinel' } },
+      properties: {
+        from: { type: 'object', properties: { email: { type: 'string' } } },
+        existing: { $ref: '#/$defs/def0' },
+        to: { $ref: '#/properties/from' },
+      },
+    };
+    const out = normalizeToolSchemaRefs(schema);
+    const defs = out.$defs as Record<string, unknown>;
+    // The pre-existing def0 must survive intact...
+    expect(defs.def0).toEqual({ const: 'sentinel' });
+    // ...and the newly hoisted schema must land under a different key.
+    const toRef = (out.properties as Record<string, { $ref: string }>).to.$ref;
+    expect(toRef).not.toBe('#/$defs/def0');
+    for (const r of collectRefs(out)) expect(resolvePointer(out, r)).toBeDefined();
+  });
+});
+
+describe('installToolSchemaRefNormalization (end-to-end against the real SDK)', () => {
+  it('normalizes recursive tool schemas in the tools/list response', async () => {
+    const server = new McpServer({ name: 'test', version: '0.0.0' });
+
+    // A self-referential schema, exactly the shape that makes the SDK emit a
+    // root-relative $ref under its default conversion strategy.
+    type Folder = { name?: string; childFolders?: Folder[] };
+    const folder: z.ZodType<Folder> = z.lazy(() =>
+      z.object({ name: z.string().optional(), childFolders: z.array(folder).optional() })
+    );
+
+    server.registerTool(
+      'create-folder',
+      { description: 'create', inputSchema: z.object({ body: folder }).passthrough() },
+      async () => ({ content: [] })
+    );
+
+    installToolSchemaRefNormalization(server);
+
+    const handler = (
+      server.server as unknown as {
+        _requestHandlers: Map<string, (req: unknown, extra: unknown) => Promise<unknown>>;
+      }
+    )._requestHandlers.get('tools/list')!;
+
+    const result = (await handler(
+      { method: 'tools/list' },
+      { signal: new AbortController().signal }
+    )) as { tools: Array<{ name: string; inputSchema: unknown }> };
+
+    const tool = result.tools.find((t) => t.name === 'create-folder')!;
+    const refs = collectRefs(tool.inputSchema);
+    expect(refs.length).toBeGreaterThan(0); // the recursion did produce a ref
+    expect(refs.every((r) => r.startsWith('#/$defs/'))).toBe(true);
+    for (const r of refs) expect(resolvePointer(tool.inputSchema, r)).toBeDefined();
+  });
+
+  it('no-ops without throwing when no tools/list handler exists', () => {
+    // A fresh server with no tools registered has no tools/list handler yet, so the
+    // installer must fall back gracefully rather than crash startup.
+    const server = new McpServer({ name: 'test', version: '0.0.0' });
+    expect(() => installToolSchemaRefNormalization(server)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Strict JSON-Schema MCP clients (e.g. Kimi/Moonshot) reject the entire tools/list when a tool inputSchema contains a $ref that isn't anchored under #/$defs/. The MCP SDK converts Zod schemas with zod-to-json-schema's default root strategy, which emits root-relative refs for recursive and shared Microsoft Graph schemas, and hard-codes the conversion options.

Normalize the emitted schemas at the tools/list boundary: hoist every referenced sub-schema into a top-level $defs and repoint the refs. This is content-preserving and keeps the payload compact, unlike inlining.