### PR TITLE
Add direct mail attachment downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,7 @@ Environment variables:
 - `MS365_MCP_FORCE_WORK_SCOPES=true|1`: Backwards compatibility for MS365_MCP_ORG_MODE
 - `MS365_MCP_OUTPUT_FORMAT=toon`: Enable TOON output format (alternative to --toon flag)
 - `MS365_MCP_MAX_TOP=<n>`: Hard cap for Graph `$top` / `top` on list requests (positive integer). When the model passes a larger value, the server clamps it to `n` so responses stay smaller. Example: `MS365_MCP_MAX_TOP=15`
+- `MS365_MCP_DOWNLOAD_DIR=<path>`: Restrict `download-mail-attachment` output to this directory. Attachments are streamed directly from Microsoft Graph to new owner-readable files and are never returned as base64 or allowed to overwrite an existing file. In HTTP mode, this path is on the MCP server host.
 - `MS365_MCP_MAX_PAGES=<n>`: Maximum number of pages followed when a tool is called with `fetchAllPages: true` (positive integer, default `100`). Bounds memory and latency for large result sets.
 - `MS365_MCP_MAX_ITEMS=<n>`: Maximum number of items accumulated when `fetchAllPages: true` (positive integer, default `10000`). Pagination stops and the response is truncated once this many items are collected.
 - `MS365_MCP_ALLOW_PAGINATION=0|false|no`: Disable multi-page following entirely. When set, the `fetchAllPages` parameter is not advertised on tools, and any request that still passes it returns only the first page (default: pagination enabled).

--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { z } from 'zod';
+import path from 'path';
 
 /**
  * We test executeGraphTool logic by importing it indirectly through registerGraphTools.
@@ -960,6 +961,113 @@ describe('graph-tools', () => {
       expect(result.isError).toBe(true);
       const payload = JSON.parse(result.content[0].text);
       expect(payload.error).toMatch(/relative Microsoft Graph path/);
+    });
+  });
+
+  describe('download-mail-attachment', () => {
+    it('downloads to the configured directory without returning attachment bytes', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+      const previousDownloadDir = process.env.MS365_MCP_DOWNLOAD_DIR;
+      const downloadDir = path.join(process.cwd(), 'attachment-downloads');
+      process.env.MS365_MCP_DOWNLOAD_DIR = downloadDir;
+
+      try {
+        const graphClient = {
+          downloadToFile: vi.fn().mockResolvedValue({
+            contentType: 'application/pdf',
+            contentLength: 32149,
+          }),
+        };
+        const server = createMockServer();
+        const { registerGraphTools } = await loadModule();
+        registerGraphTools(server as any, graphClient as any);
+
+        const result = await server.tools.get('download-mail-attachment')!.handler({
+          messageId: 'message/1',
+          attachmentId: 'attachment=1',
+          fileName: 'invoice.pdf',
+        });
+
+        expect(graphClient.downloadToFile).toHaveBeenCalledWith(
+          '/me/messages/message%2F1/attachments/attachment%3D1/$value',
+          path.join(downloadDir, 'invoice.pdf'),
+          { accessToken: undefined }
+        );
+        const payload = JSON.parse(result.content[0].text);
+        expect(payload).toEqual({
+          path: path.join(downloadDir, 'invoice.pdf'),
+          fileName: 'invoice.pdf',
+          contentType: 'application/pdf',
+          contentLength: 32149,
+        });
+        expect(payload).not.toHaveProperty('contentBytes');
+      } finally {
+        if (previousDownloadDir === undefined) delete process.env.MS365_MCP_DOWNLOAD_DIR;
+        else process.env.MS365_MCP_DOWNLOAD_DIR = previousDownloadDir;
+      }
+    });
+
+    it('sanitizes the output filename before resolving it under the configured directory', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+      const previousDownloadDir = process.env.MS365_MCP_DOWNLOAD_DIR;
+      const downloadDir = path.join(process.cwd(), 'attachment-downloads');
+      process.env.MS365_MCP_DOWNLOAD_DIR = downloadDir;
+
+      try {
+        const graphClient = {
+          downloadToFile: vi.fn().mockResolvedValue({
+            contentType: 'text/plain',
+            contentLength: 2,
+          }),
+        };
+        const server = createMockServer();
+        const { registerGraphTools } = await loadModule();
+        registerGraphTools(server as any, graphClient as any);
+
+        await server.tools.get('download-mail-attachment')!.handler({
+          messageId: 'm1',
+          attachmentId: 'a1',
+          fileName: '../../report:final?.txt',
+        });
+
+        expect(graphClient.downloadToFile).toHaveBeenCalledWith(
+          '/me/messages/m1/attachments/a1/$value',
+          path.join(downloadDir, '.._.._report_final_.txt'),
+          { accessToken: undefined }
+        );
+      } finally {
+        if (previousDownloadDir === undefined) delete process.env.MS365_MCP_DOWNLOAD_DIR;
+        else process.env.MS365_MCP_DOWNLOAD_DIR = previousDownloadDir;
+      }
+    });
+
+    it('fails before Graph access when no download directory is configured', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+      const previousDownloadDir = process.env.MS365_MCP_DOWNLOAD_DIR;
+      delete process.env.MS365_MCP_DOWNLOAD_DIR;
+
+      try {
+        const graphClient = { downloadToFile: vi.fn() };
+        const server = createMockServer();
+        const { registerGraphTools } = await loadModule();
+        registerGraphTools(server as any, graphClient as any);
+
+        const result = await server.tools.get('download-mail-attachment')!.handler({
+          messageId: 'm1',
+          attachmentId: 'a1',
+          fileName: 'invoice.pdf',
+        });
+
+        expect(result.isError).toBe(true);
+        expect(JSON.parse(result.content[0].text).error).toContain('MS365_MCP_DOWNLOAD_DIR');
+        expect(graphClient.downloadToFile).not.toHaveBeenCalled();
+      } finally {
+        if (previousDownloadDir === undefined) delete process.env.MS365_MCP_DOWNLOAD_DIR;
+        else process.env.MS365_MCP_DOWNLOAD_DIR = previousDownloadDir;
+      }
     });
   });
 

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -205,7 +205,7 @@
     "toolName": "list-mail-attachments",
     "presets": ["mail", "outlook", "personal"],
     "scopes": ["Mail.Read"],
-    "llmTip": "Lists attachments on a message: id, name, contentType, size, isInline. To download the bytes, call download-bytes with target=/me/messages/{message-id}/attachments/{attachment-id}/$value (the /$value suffix returns raw bytes; the bare attachment URL embeds contentBytes in JSON which can truncate large files)."
+    "llmTip": "Lists attachments on a message: id, name, contentType, size, isInline. To save an attachment directly to the server filesystem without passing base64 through the agent context, configure MS365_MCP_DOWNLOAD_DIR and call download-mail-attachment with the message ID, attachment ID, and name. Use download-bytes with target=/me/messages/{message-id}/attachments/{attachment-id}/$value only when a base64 response is acceptable."
   },
   {
     "pathPattern": "/me/messages/{message-id}/attachments/{attachment-id}",

--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -4,6 +4,8 @@ import { encode as toonEncode } from '@toon-format/toon';
 import type { AppSecrets } from './secrets.js';
 import { getCloudEndpoints } from './cloud-config.js';
 import { getRequestTokens } from './request-context.js';
+import { open, stat, unlink } from 'fs/promises';
+import { pipeline } from 'stream/promises';
 import {
   fetchWithResilience,
   getSharedBreaker,
@@ -77,6 +79,11 @@ interface McpResponse {
   isError?: boolean;
 
   [key: string]: unknown;
+}
+
+export interface GraphDownloadResult {
+  contentType: string;
+  contentLength: number;
 }
 
 class GraphClient {
@@ -179,6 +186,63 @@ class GraphClient {
     } catch (error) {
       logger.error('Microsoft Graph API request failed:', error);
       throw error;
+    }
+  }
+
+  async downloadToFile(
+    endpoint: string,
+    destinationPath: string,
+    options: { accessToken?: string; apiVersion?: string } = {}
+  ): Promise<GraphDownloadResult> {
+    const fileHandle = await open(destinationPath, 'wx', 0o600);
+    let completed = false;
+
+    try {
+      const contextTokens = getRequestTokens();
+      const accessToken =
+        options.accessToken ?? contextTokens?.accessToken ?? (await this.authManager.getToken());
+
+      if (!accessToken) {
+        throw new Error('No access token available');
+      }
+
+      const response = await this.performRequest(endpoint, accessToken, options);
+      if (response.status === 403) {
+        const errorText = await response.text();
+        if (errorText.includes('scope') || errorText.includes('permission')) {
+          throw new Error(
+            `Microsoft Graph API scope error: ${response.status} ${response.statusText} - ${errorText}. This tool requires organization mode. Please restart with --org-mode flag.`
+          );
+        }
+        throw new Error(
+          `Microsoft Graph API error: ${response.status} ${response.statusText} - ${errorText}`
+        );
+      }
+      if (!response.ok) {
+        throw new Error(
+          `Microsoft Graph API error: ${response.status} ${response.statusText} - ${await response.text()}`
+        );
+      }
+      if (!response.body) {
+        throw new Error('Microsoft Graph returned an empty response body');
+      }
+
+      await pipeline(response.body, fileHandle.createWriteStream());
+      const fileStats = await stat(destinationPath);
+      completed = true;
+
+      return {
+        contentType: response.headers.get('content-type') || 'application/octet-stream',
+        contentLength: fileStats.size,
+      };
+    } catch (error) {
+      logger.error('Microsoft Graph file download failed:', error);
+      throw error;
+    } finally {
+      await fileHandle.close().catch(() => undefined);
+      if (!completed) {
+        await unlink(destinationPath).catch(() => undefined);
+      }
     }
   }
 

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -123,6 +123,33 @@ function positiveIntFromEnv(name: string, defaultValue: number): number {
   return n;
 }
 
+function resolveAttachmentDownloadPath(fileName: string): string {
+  const configuredDirectory = process.env.MS365_MCP_DOWNLOAD_DIR?.trim();
+  if (!configuredDirectory) {
+    throw new Error(
+      'MS365_MCP_DOWNLOAD_DIR must be configured before downloading attachments to disk.'
+    );
+  }
+
+  const reservedCharacters = '<>:"/\\|?*';
+  const sanitizedFileName = [...fileName.trim()]
+    .map((character) =>
+      character.charCodeAt(0) <= 0x1f || reservedCharacters.includes(character) ? '_' : character
+    )
+    .join('')
+    .replace(/[. ]+$/g, '');
+  if (!sanitizedFileName) {
+    throw new Error('fileName must contain at least one filesystem-safe character.');
+  }
+
+  const downloadDirectory = path.resolve(configuredDirectory);
+  const destination = path.resolve(downloadDirectory, sanitizedFileName);
+  if (!destination.startsWith(`${downloadDirectory}${path.sep}`)) {
+    throw new Error('fileName must resolve inside MS365_MCP_DOWNLOAD_DIR.');
+  }
+  return destination;
+}
+
 /**
  * Whether `fetchAllPages` is permitted. Defaults to true; set MS365_MCP_ALLOW_PAGINATION
  * to 0/false/no to disable multi-page following entirely (returns the first page only).
@@ -378,6 +405,107 @@ export const UTILITY_TOOLS: readonly UtilityTool[] = [
           accessToken: accountAccessToken,
           rawResponse: true,
         });
+      } catch (error) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: (error as Error).message }) }],
+          isError: true,
+        };
+      }
+    },
+  },
+  {
+    name: 'download-mail-attachment',
+    method: 'GET',
+    path: 'tool:download-mail-attachment',
+    searchKeywords:
+      'download save mail email outlook attachment file disk local filesystem without base64',
+    description:
+      'Download an Outlook mail attachment directly to the MCP server filesystem without returning its bytes through the agent context. Requires MS365_MCP_DOWNLOAD_DIR. The filename is sanitized, existing files are never overwritten, and the result contains only { path, fileName, contentType, contentLength }. In local stdio mode the server filesystem is the local machine; in HTTP mode it is the remote server.',
+    readOnlyHint: false,
+    openWorldHint: true,
+    buildSchema: (ctx) => {
+      const schema: Record<string, z.ZodTypeAny> = {
+        messageId: z.string().min(1).describe('Message ID returned by a mail message tool.'),
+        attachmentId: z
+          .string()
+          .min(1)
+          .describe('Attachment ID returned by list-mail-attachments.'),
+        fileName: z
+          .string()
+          .min(1)
+          .describe(
+            'Output filename within MS365_MCP_DOWNLOAD_DIR, usually the name returned by list-mail-attachments. Path separators and platform-reserved characters are replaced with underscores.'
+          ),
+      };
+      if (ctx.multiAccount) {
+        schema['account'] = z
+          .string()
+          .optional()
+          .describe(
+            'Account to use when multiple Microsoft accounts are configured. Required when multiple accounts exist (see list-accounts).'
+          );
+      }
+      return schema;
+    },
+    execute: async (params, { graphClient, authManager }) => {
+      const messageId = params.messageId;
+      const attachmentId = params.attachmentId;
+      const fileName = params.fileName;
+      const accountParam = params.account as string | undefined;
+      if (
+        typeof messageId !== 'string' ||
+        messageId.length === 0 ||
+        typeof attachmentId !== 'string' ||
+        attachmentId.length === 0 ||
+        typeof fileName !== 'string' ||
+        fileName.length === 0
+      ) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                error: 'messageId, attachmentId, and fileName are required non-empty strings.',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      try {
+        const accountModeError = await checkAccountParamInBearerMode(accountParam, authManager);
+        if (accountModeError) {
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: accountModeError }) }],
+            isError: true,
+          };
+        }
+        let accountAccessToken: string | undefined;
+        if (authManager && !authManager.isOAuthModeEnabled() && !getRequestTokens()) {
+          accountAccessToken = await authManager.getTokenForAccount(accountParam);
+        }
+
+        const destination = resolveAttachmentDownloadPath(fileName);
+        const target =
+          `/me/messages/${encodeURIComponent(messageId)}` +
+          `/attachments/${encodeURIComponent(attachmentId)}/$value`;
+        const result = await graphClient.downloadToFile(target, destination, {
+          accessToken: accountAccessToken,
+        });
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                path: destination,
+                fileName: path.basename(destination),
+                contentType: result.contentType,
+                contentLength: result.contentLength,
+              }),
+            },
+          ],
+        };
       } catch (error) {
         return {
           content: [{ type: 'text', text: JSON.stringify({ error: (error as Error).message }) }],

--- a/test/binary-response.test.ts
+++ b/test/binary-response.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import os from 'os';
+import path from 'path';
 import { isBinaryContentType } from '../src/graph-client.js';
 
 describe('isBinaryContentType', () => {
@@ -216,6 +219,79 @@ describe('GraphClient binary response handling', () => {
       expect(result.rawResponse).toBeUndefined();
     } finally {
       global.fetch = originalFetch;
+    }
+  });
+});
+
+describe('GraphClient file downloads', () => {
+  it('streams Graph response bytes directly to a new file', async () => {
+    const { default: GraphClient } = await import('../src/graph-client.js');
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ms365-download-test-'));
+    const destination = path.join(tempDir, 'attachment.pdf');
+    const fileBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0xff, 0x00, 0x7f]);
+    const originalFetch = global.fetch;
+    global.fetch = (async () =>
+      new Response(fileBytes, {
+        status: 200,
+        headers: { 'content-type': 'application/pdf' },
+      })) as typeof fetch;
+
+    try {
+      const client = new GraphClient(
+        { getToken: async () => 'fake-token' } as Parameters<typeof GraphClient>[0],
+        {
+          clientId: 'x',
+          tenantId: 'common',
+          cloudType: 'global',
+        } as Parameters<typeof GraphClient>[1]
+      );
+
+      const result = await client.downloadToFile(
+        '/me/messages/m1/attachments/a1/$value',
+        destination
+      );
+
+      expect(result).toEqual({
+        contentType: 'application/pdf',
+        contentLength: fileBytes.byteLength,
+      });
+      expect(await readFile(destination)).toEqual(Buffer.from(fileBytes));
+    } finally {
+      global.fetch = originalFetch;
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('never overwrites an existing file', async () => {
+    const { default: GraphClient } = await import('../src/graph-client.js');
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ms365-download-test-'));
+    const destination = path.join(tempDir, 'existing.txt');
+    await writeFile(destination, 'keep me');
+    const originalFetch = global.fetch;
+    let fetchCalled = false;
+    global.fetch = (async () => {
+      fetchCalled = true;
+      return new Response('replacement', { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const client = new GraphClient(
+        { getToken: async () => 'fake-token' } as Parameters<typeof GraphClient>[0],
+        {
+          clientId: 'x',
+          tenantId: 'common',
+          cloudType: 'global',
+        } as Parameters<typeof GraphClient>[1]
+      );
+
+      await expect(
+        client.downloadToFile('/me/messages/m1/attachments/a1/$value', destination)
+      ).rejects.toMatchObject({ code: 'EEXIST' });
+      expect(fetchCalled).toBe(false);
+      expect(await readFile(destination, 'utf8')).toBe('keep me');
+    } finally {
+      global.fetch = originalFetch;
+      await rm(tempDir, { recursive: true, force: true });
     }
   });
 });

--- a/test/calendar-view.test.ts
+++ b/test/calendar-view.test.ts
@@ -144,6 +144,7 @@ describe('Calendar View Tools', () => {
         if (
           toolName === 'parse-teams-url' ||
           toolName === 'download-bytes' ||
+          toolName === 'download-mail-attachment' ||
           toolName === 'copilot-retrieve' ||
           toolName === 'get-download-url'
         )

--- a/test/read-only.test.ts
+++ b/test/read-only.test.ts
@@ -106,7 +106,7 @@ describe('Read-Only Mode', () => {
 
     // 4 mocked endpoints (get-schedule skipped: workScopes only, no orgMode) + utilities
     expect(mockServer.registerTool).toHaveBeenCalledTimes(4);
-    expect(mockServer.tool).toHaveBeenCalledTimes(3);
+    expect(mockServer.tool).toHaveBeenCalledTimes(4);
 
     const toolCalls = mockServer.registerTool.mock.calls.map((call: unknown[]) => call[0]);
     expect(toolCalls).toContain('list-mail-messages');

--- a/test/tool-filtering.test.ts
+++ b/test/tool-filtering.test.ts
@@ -58,7 +58,7 @@ describe('Tool Filtering', () => {
 
     // 5 mocked graph endpoints via registerTool; utilities via tool
     expect(registerToolSpy).toHaveBeenCalledTimes(5);
-    expect(toolSpy).toHaveBeenCalledTimes(3);
+    expect(toolSpy).toHaveBeenCalledTimes(4);
     expect(registerToolSpy).toHaveBeenCalledWith(
       'list-mail-messages',
       expect.any(Object),
@@ -123,7 +123,7 @@ describe('Tool Filtering', () => {
 
     // 5 mocked endpoints + utilities (no filter applied on invalid regex)
     expect(registerToolSpy).toHaveBeenCalledTimes(5);
-    expect(toolSpy).toHaveBeenCalledTimes(3);
+    expect(toolSpy).toHaveBeenCalledTimes(4);
   });
 
   it('should combine read-only and filtering correctly', () => {


### PR DESCRIPTION
## Summary

- add a `download-mail-attachment` utility tool that streams Outlook attachment bytes directly to the MCP server filesystem
- confine writes to `MS365_MCP_DOWNLOAD_DIR`, sanitize filenames, use exclusive mode-0600 files, and remove partial downloads
- return path, content type, and size metadata without sending base64 attachment data through the MCP response
- document the new configuration and update attachment guidance

## Why

Microsoft Graph mail attachments do not expose pre-authenticated download URLs. The existing `download-bytes` tool returns base64 through the MCP context; this tool lets local and hosted MCP servers persist authenticated attachment bytes directly instead.

## Validation

- `npm run build`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run format:check`
- `npm test` (606 tests)
- real Outlook attachment smoke test: downloaded a 36,203-byte, two-page PDF with a valid `%PDF-` signature; the MCP response contained no attachment bytes
