### PR TITLE
fix: include download utilities in tool presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ npx @softeria/ms-365-mcp-server --list-presets  # See all available presets
 
 Available presets: `mail`, `calendar`, `files`, `personal`, `work`, `excel`, `contacts`, `tasks`, `onenote`, `search`, `users`, `outlook`, `onedrive`, `teams`, `all`
 
-Each endpoint in `endpoints.json` declares which presets it belongs to via a `presets` array, so every preset is an exact tool-name allow-list that never over-matches across apps (e.g. `mail` does not include shared-mailbox tools; those are in `work`).
+Each endpoint in `endpoints.json` declares which presets it belongs to via a `presets` array, so every preset is an exact tool-name allow-list that never over-matches across apps (e.g. `mail` does not include shared-mailbox tools; those are in `work`). The universal binary reader `download-bytes` is included in every preset, so whatever an app returns (a file, an attachment, a photo, a recording) can always be fetched; `get-download-url` (a pre-authenticated URL for drive/SharePoint files) rides with the drive-backed presets. So a preset that can find a file can always read its bytes.
 
 The `outlook`, `onedrive` and `teams` presets are app-scoped: they expose exactly one Microsoft app. Use these for "expose exactly one app" deployments:
 

--- a/src/tool-categories.ts
+++ b/src/tool-categories.ts
@@ -68,13 +68,53 @@ const PRESET_META: Record<string, { description: string; requiresOrgMode?: boole
   },
 };
 
+// Utility tools (graph-tools.ts UTILITY_TOOLS) are code-defined, not in endpoints.json, so they
+// carry no `presets` there and every --preset filter dropped them - e.g. `--preset files` had
+// get-drive-item but no downloader, though its llmTip tells the model to call one. Declare their
+// preset membership here and fold it into each preset pattern.
+//
+// download-bytes fetches ANY relative Graph binary path (drive files, attachments, photos, Teams
+// content, recordings, OneNote resources), so it belongs in EVERY preset. It is universal rather
+// than an enumerated list because a list would silently miss apps and every future preset.
+const UNIVERSAL_UTILITY_TOOLS = ['download-bytes'];
+
+// Scoped utilities are only meaningful where the resources they act on appear. get-download-url
+// resolves a pre-authenticated URL for drive/SharePoint file content ONLY (not mail/event
+// attachments or recordings), so it rides with the drive-backed presets; where it is absent the
+// universal download-bytes still reads the bytes. parse-teams-url only parses Teams meeting URLs.
+const SCOPED_UTILITY_TOOLS: Record<string, string[]> = {
+  'get-download-url': ['files', 'onedrive', 'personal', 'work', 'search'],
+  'parse-teams-url': ['teams', 'work'],
+};
+
+// Fail fast if a scoped utility references a preset that does not exist (e.g. a typo like
+// 'serach'): otherwise the tool would silently never join the intended preset, with no error.
+for (const [tool, presets] of Object.entries(SCOPED_UTILITY_TOOLS)) {
+  for (const preset of presets) {
+    if (!Object.prototype.hasOwnProperty.call(PRESET_META, preset)) {
+      throw new Error(
+        `SCOPED_UTILITY_TOOLS["${tool}"] references unknown preset "${preset}" (not in PRESET_META)`
+      );
+    }
+  }
+}
+
 function presetPattern(preset: string): RegExp {
-  const names = [
+  const endpointNames = [
     ...new Set(endpointEntries.filter((e) => e.presets?.includes(preset)).map((e) => e.toolName)),
   ];
-  if (names.length === 0) {
+  // Guard on endpoint membership, not the final `names` list: the universal utility spread below
+  // would otherwise mask a preset that no endpoint declares (a typo'd or unwired preset name).
+  if (endpointNames.length === 0) {
     throw new Error(`Preset "${preset}" matches no endpoints in endpoints.json`);
   }
+  const names = [
+    ...endpointNames,
+    ...UNIVERSAL_UTILITY_TOOLS,
+    ...Object.entries(SCOPED_UTILITY_TOOLS)
+      .filter(([, presets]) => presets.includes(preset))
+      .map(([name]) => name),
+  ];
   return new RegExp(`^(?:${names.join('|')})$`);
 }
 

--- a/test/presets.test.ts
+++ b/test/presets.test.ts
@@ -7,6 +7,7 @@ import {
   presetRequiresOrgMode,
   TOOL_CATEGORIES,
 } from '../src/tool-categories.js';
+import { UTILITY_TOOLS } from '../src/graph-tools.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -115,5 +116,66 @@ describe('presets from endpoints.json', () => {
 
   it('all matches everything', () => {
     expect(matchedTools('all')).toEqual(allToolNames);
+  });
+});
+
+describe('utility tools in presets', () => {
+  const namedPresets = Object.keys(TOOL_CATEGORIES).filter((name) => name !== 'all');
+  const inPreset = (preset: string, name: string) =>
+    new RegExp(TOOL_CATEGORIES[preset].pattern.source, 'i').test(name);
+
+  // Regression guard: utility tools (download-bytes, get-download-url, parse-teams-url) live in
+  // code, not endpoints.json, and used to belong to no preset - so any --preset filter stripped
+  // them. A newly added utility tool without preset membership fails this test.
+  it('every utility tool is reachable from at least one named preset', () => {
+    for (const util of UTILITY_TOOLS) {
+      const reachable = namedPresets.some((preset) => inPreset(preset, util.name));
+      expect(reachable, `utility tool ${util.name} is in no preset`).toBe(true);
+    }
+  });
+
+  // download-bytes is a universal Graph binary reader, so no preset - current or future - should
+  // be able to find a resource without being able to read its bytes.
+  it('download-bytes is available in every preset (universal binary reader)', () => {
+    for (const preset of namedPresets) {
+      expect(inPreset(preset, 'download-bytes'), `download-bytes missing from ${preset}`).toBe(
+        true
+      );
+    }
+  });
+
+  // Pin the full get-download-url membership so a regression dropping any drive-backed preset
+  // is caught. download-bytes membership is covered by the every-preset test above.
+  it('get-download-url is in every drive-backed preset it declares', () => {
+    for (const preset of ['files', 'onedrive', 'personal', 'work', 'search']) {
+      expect(inPreset(preset, 'get-download-url'), `get-download-url missing from ${preset}`).toBe(
+        true
+      );
+    }
+  });
+
+  it('mail preset has download-bytes but not the drive-only download-url helper', () => {
+    expect(inPreset('mail', 'download-bytes')).toBe(true);
+    expect(inPreset('mail', 'get-download-url')).toBe(false);
+  });
+
+  it('parse-teams-url stays scoped to teams/work', () => {
+    expect(inPreset('teams', 'parse-teams-url')).toBe(true);
+    expect(inPreset('mail', 'parse-teams-url')).toBe(false);
+    expect(inPreset('files', 'parse-teams-url')).toBe(false);
+  });
+
+  it('scoped utilities do not leak into unrelated presets', () => {
+    // download-bytes is universal, so only the scoped helpers should be absent here.
+    expect(inPreset('calendar', 'get-download-url')).toBe(false);
+    expect(inPreset('contacts', 'get-download-url')).toBe(false);
+    expect(inPreset('onenote', 'parse-teams-url')).toBe(false);
+  });
+
+  it('combined presets surface the union of their utility tools', () => {
+    const re = new RegExp(getCombinedPresetPattern(['files', 'teams']), 'i');
+    expect(re.test('download-bytes')).toBe(true);
+    expect(re.test('get-download-url')).toBe(true);
+    expect(re.test('parse-teams-url')).toBe(true);
   });
 });


### PR DESCRIPTION
Code-defined utility tools (download-bytes, get-download-url, parse-teams-url) carry no presets in endpoints.json, so every --preset filter stripped them: --preset files exposed get-drive-item but no downloader, leaving a found file unreadable.

download-bytes is now universal (any app can return fetchable content), get-download-url rides the drive-backed presets, and parse-teams-url stays on teams/work. The empty-preset guard now checks endpoint count, and scoped preset names are validated at load.