### PR TITLE
perf: stream download-bytes-to-file to disk instead of buffering

### DIFF
--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { z } from 'zod';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 
 /**
  * We test executeGraphTool logic by importing it indirectly through registerGraphTools.
@@ -978,19 +978,16 @@ describe('graph-tools', () => {
       rmSync(tmpDir, { recursive: true, force: true });
     });
 
-    it('writes decoded binary bytes to the output path and returns metadata', async () => {
+    it('streams bytes to the output path and returns metadata', async () => {
       mockEndpoints.length = 0;
       mockEndpointsJson = [];
 
-      // makeRequest (NOT graphRequest) returns the raw structured object; binary
-      // content comes back as { encoding: 'base64', contentBytes }. "hi" -> "aGk=".
+      // downloadToFile is mocked here; binary-response.test.ts covers the real
+      // streaming + write. This just checks the tool wires the call and maps it.
       const graphClient = {
-        makeRequest: vi.fn().mockResolvedValue({
-          message: 'OK!',
+        downloadToFile: vi.fn().mockResolvedValue({
           contentType: 'image/jpeg',
-          encoding: 'base64',
           contentLength: 2,
-          contentBytes: 'aGk=',
         }),
       };
 
@@ -1004,48 +1001,22 @@ describe('graph-tools', () => {
       const outputPath = join(tmpDir, 'photo.jpg');
       const result = await tool!.handler({ target: '/me/photo/$value', outputPath });
 
-      expect(graphClient.makeRequest).toHaveBeenCalledTimes(1);
-      const [reqPath, options] = graphClient.makeRequest.mock.calls[0];
+      expect(graphClient.downloadToFile).toHaveBeenCalledTimes(1);
+      const [reqPath, dest, options] = graphClient.downloadToFile.mock.calls[0];
       expect(reqPath).toBe('/me/photo/$value');
-      expect(options.rawResponse).toBe(true);
+      expect(dest).toBe(outputPath);
+      expect(options).toStrictEqual({ accessToken: undefined });
 
       expect(result.isError).toBeUndefined();
       const payload = JSON.parse(result.content[0].text);
       expect(payload).toEqual({ path: outputPath, contentType: 'image/jpeg', bytesWritten: 2 });
-      expect(existsSync(outputPath)).toBe(true);
-      expect(readFileSync(outputPath).toString('utf8')).toBe('hi');
-    });
-
-    it('writes a text/JSON body verbatim from rawResponse', async () => {
-      mockEndpoints.length = 0;
-      mockEndpointsJson = [];
-
-      const graphClient = {
-        makeRequest: vi.fn().mockResolvedValue({
-          message: 'OK!',
-          contentType: 'text/plain',
-          rawResponse: 'line1\nline2\n',
-        }),
-      };
-
-      const server = createMockServer();
-      const { registerGraphTools } = await loadModule();
-      registerGraphTools(server as any, graphClient as any);
-
-      const outputPath = join(tmpDir, 'note.txt');
-      const result = await server.tools
-        .get('download-bytes-to-file')!
-        .handler({ target: '/me/drive/root:/note.txt:/content', outputPath });
-
-      expect(result.isError).toBeUndefined();
-      expect(readFileSync(outputPath).toString('utf8')).toBe('line1\nline2\n');
     });
 
     it('rejects a relative outputPath', async () => {
       mockEndpoints.length = 0;
       mockEndpointsJson = [];
 
-      const graphClient = { makeRequest: vi.fn() };
+      const graphClient = { downloadToFile: vi.fn() };
       const server = createMockServer();
       const { registerGraphTools } = await loadModule();
       registerGraphTools(server as any, graphClient as any);
@@ -1057,7 +1028,7 @@ describe('graph-tools', () => {
       expect(result.isError).toBe(true);
       const payload = JSON.parse(result.content[0].text);
       expect(payload.error).toMatch(/absolute path/);
-      expect(graphClient.makeRequest).not.toHaveBeenCalled();
+      expect(graphClient.downloadToFile).not.toHaveBeenCalled();
     });
 
     it('rejects absolute URLs in target (Graph paths only)', async () => {
@@ -1085,7 +1056,7 @@ describe('graph-tools', () => {
       const outputPath = join(tmpDir, 'existing.bin');
       writeFileSync(outputPath, 'original');
 
-      const graphClient = { makeRequest: vi.fn() };
+      const graphClient = { downloadToFile: vi.fn() };
       const server = createMockServer();
       const { registerGraphTools } = await loadModule();
       registerGraphTools(server as any, graphClient as any);
@@ -1097,18 +1068,19 @@ describe('graph-tools', () => {
       expect(result.isError).toBe(true);
       const payload = JSON.parse(result.content[0].text);
       expect(payload.error).toMatch(/already exists/);
-      expect(graphClient.makeRequest).not.toHaveBeenCalled();
+      expect(graphClient.downloadToFile).not.toHaveBeenCalled();
       // Original file is untouched.
       expect(readFileSync(outputPath).toString('utf8')).toBe('original');
     });
 
-    it('surfaces a Graph error and writes no file when makeRequest throws', async () => {
+    it('surfaces a Graph error when downloadToFile throws', async () => {
       mockEndpoints.length = 0;
       mockEndpointsJson = [];
 
-      // makeRequest throws on Graph HTTP errors (401/403/404/429/...).
+      // downloadToFile throws on Graph HTTP errors and cleans up any partial file
+      // itself; here we just check the tool surfaces the error.
       const graphClient = {
-        makeRequest: vi
+        downloadToFile: vi
           .fn()
           .mockRejectedValue(new Error('Microsoft Graph API error: 404 Not Found')),
       };
@@ -1124,7 +1096,49 @@ describe('graph-tools', () => {
       expect(result.isError).toBe(true);
       const payload = JSON.parse(result.content[0].text);
       expect(payload.error).toMatch(/404 Not Found/);
-      expect(existsSync(outputPath)).toBe(false);
+    });
+
+    it('forwards the resolved account token to downloadToFile in multi-account mode', async () => {
+      mockEndpoints.length = 0;
+      mockEndpointsJson = [];
+
+      const graphClient = {
+        downloadToFile: vi
+          .fn()
+          .mockResolvedValue({ contentType: 'application/pdf', contentLength: 3 }),
+      };
+      const authManager = {
+        isOAuthModeEnabled: vi.fn().mockReturnValue(false),
+        getToken: vi.fn().mockResolvedValue(null),
+        getTokenForAccount: vi.fn().mockResolvedValue('account-2-token'),
+      };
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(
+        server as any,
+        graphClient as any,
+        false,
+        undefined,
+        false,
+        authManager as any,
+        true,
+        ['user1@domain.com', 'user2@domain.com']
+      );
+
+      const outputPath = join(tmpDir, 'invoice.pdf');
+      const result = await server.tools.get('download-bytes-to-file')!.handler({
+        target: '/me/messages/m1/attachments/a1/$value',
+        outputPath,
+        account: 'user2@domain.com',
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(authManager.getTokenForAccount).toHaveBeenCalledWith('user2@domain.com');
+      expect(graphClient.downloadToFile).toHaveBeenCalledWith(
+        '/me/messages/m1/attachments/a1/$value',
+        outputPath,
+        { accessToken: 'account-2-token' }
+      );
     });
 
     it('is registered in stdio mode but hidden in HTTP mode', async () => {

--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -9,6 +9,8 @@ import {
   getSharedBreaker,
   loadResilienceConfig,
 } from './lib/graph-resilience.js';
+import { open, stat, unlink } from 'fs/promises';
+import { pipeline } from 'stream/promises';
 
 /**
  * Returns true if the given HTTP Content-Type header indicates a binary
@@ -77,6 +79,11 @@ interface McpResponse {
   isError?: boolean;
 
   [key: string]: unknown;
+}
+
+export interface GraphDownloadResult {
+  contentType: string;
+  contentLength: number;
 }
 
 class GraphClient {
@@ -179,6 +186,78 @@ class GraphClient {
     } catch (error) {
       logger.error('Microsoft Graph API request failed:', error);
       throw error;
+    }
+  }
+
+  /**
+   * Stream Graph byte content straight to a file, without holding the whole
+   * payload in memory. download-bytes-to-file uses this for big mail attachments
+   * and meeting recordings, where makeRequest's base64 buffering would blow up
+   * memory or hit V8's max string length. Creates the file with wx + 0o600 (never
+   * overwrites) and removes a partial file if the transfer fails.
+   */
+  async downloadToFile(
+    endpoint: string,
+    destinationPath: string,
+    options: Pick<GraphRequestOptions, 'accessToken' | 'apiVersion'> = {}
+  ): Promise<GraphDownloadResult> {
+    const fileHandle = await open(destinationPath, 'wx', 0o600);
+    let completed = false;
+
+    try {
+      const contextTokens = getRequestTokens();
+      const accessToken =
+        options.accessToken ?? contextTokens?.accessToken ?? (await this.authManager.getToken());
+      if (!accessToken) {
+        throw new Error('No access token available');
+      }
+
+      const response = await this.performRequest(endpoint, accessToken, options);
+      if (response.status === 403) {
+        const errorText = await response.text();
+        if (errorText.includes('scope') || errorText.includes('permission')) {
+          throw new Error(
+            `Microsoft Graph API scope error: ${response.status} ${response.statusText} - ${errorText}. This tool requires organization mode. Please restart with --org-mode flag.`
+          );
+        }
+        throw new Error(
+          `Microsoft Graph API error: ${response.status} ${response.statusText} - ${errorText}`
+        );
+      }
+      if (!response.ok) {
+        throw new Error(
+          `Microsoft Graph API error: ${response.status} ${response.statusText} - ${await response.text()}`
+        );
+      }
+      if (!response.body) {
+        throw new Error('Microsoft Graph returned an empty response body');
+      }
+
+      await pipeline(response.body, fileHandle.createWriteStream());
+      // Bytes are on disk now - a stat() hiccup past here must not delete them
+      // (that also blocks a retry, since we never overwrite).
+      completed = true;
+
+      let contentLength: number;
+      try {
+        contentLength = (await stat(destinationPath)).size;
+      } catch {
+        const header = Number(response.headers.get('content-length'));
+        contentLength = Number.isFinite(header) ? header : 0;
+      }
+
+      return {
+        contentType: response.headers.get('content-type') || 'application/octet-stream',
+        contentLength,
+      };
+    } catch (error) {
+      logger.error('Microsoft Graph file download failed:', error);
+      throw error;
+    } finally {
+      await fileHandle.close().catch(() => undefined);
+      if (!completed) {
+        await unlink(destinationPath).catch(() => undefined);
+      }
     }
   }
 

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -18,7 +18,7 @@ import { api as betaApi } from './generated/client-beta.js';
 const allEndpoints = [...api.endpoints, ...betaApi.endpoints];
 import { z } from 'zod';
 import { readFileSync } from 'fs';
-import { writeFile, access } from 'fs/promises';
+import { access } from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { TOOL_CATEGORIES } from './tool-categories.js';
@@ -490,9 +490,8 @@ export const UTILITY_TOOLS: readonly UtilityTool[] = [
           isError: true,
         };
       }
-      // Fail fast before spending a Graph call on a write that can't succeed. The
-      // wx flag on writeFile below is the actual guarantee against a TOCTOU race;
-      // this check just yields a friendlier error in the common case.
+      // downloadToFile's wx is the real no-overwrite guard; this just gives a
+      // friendlier "already exists" error before we bother calling Graph.
       let fileExists = false;
       try {
         await access(outputPath);
@@ -524,44 +523,11 @@ export const UTILITY_TOOLS: readonly UtilityTool[] = [
         if (authManager && !authManager.isOAuthModeEnabled() && !getRequestTokens()) {
           accountAccessToken = await authManager.getTokenForAccount(accountParam);
         }
-        // Use makeRequest, not graphRequest: graphRequest is the MCP-formatting
-        // wrapper — it serializes the payload into { content: [{ text }] } (as
-        // TOON under --toon), which we'd then have to parse back just to reach
-        // the bytes. makeRequest returns the raw structured object directly:
-        // binary -> { encoding: 'base64', contentBytes }, text/JSON body ->
-        // { rawResponse }. rawResponse keeps a text body byte-faithful (#546).
-        // It throws on Graph HTTP errors (401/403/404/429/...), surfaced by the
-        // surrounding catch.
-        const result = (await graphClient.makeRequest(target, {
+        // Stream to disk instead of buffering: makeRequest holds the whole file
+        // in memory as base64, which dies on big recordings (V8 max string length).
+        const result = await graphClient.downloadToFile(target, outputPath, {
           accessToken: accountAccessToken,
-          rawResponse: true,
-        })) as {
-          contentType?: string;
-          encoding?: string;
-          contentBytes?: string;
-          rawResponse?: string;
-        };
-        let buffer: Buffer;
-        if (result.encoding === 'base64' && typeof result.contentBytes === 'string') {
-          buffer = Buffer.from(result.contentBytes, 'base64');
-        } else if (typeof result.rawResponse === 'string') {
-          buffer = Buffer.from(result.rawResponse, 'utf8');
-        } else {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify({
-                  error: 'Graph response contained no downloadable bytes for this target.',
-                }),
-              },
-            ],
-            isError: true,
-          };
-        }
-        // wx: create-and-fail-if-exists, closing the gap between the access() check
-        // above and this write (issue: TOCTOU).
-        await writeFile(outputPath, buffer, { flag: 'wx' });
+        });
         return {
           content: [
             {
@@ -569,7 +535,7 @@ export const UTILITY_TOOLS: readonly UtilityTool[] = [
               text: JSON.stringify({
                 path: outputPath,
                 contentType: result.contentType,
-                bytesWritten: buffer.byteLength,
+                bytesWritten: result.contentLength,
               }),
             },
           ],

--- a/test/binary-response.test.ts
+++ b/test/binary-response.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import os from 'os';
+import path from 'path';
 import { isBinaryContentType } from '../src/graph-client.js';
 
 describe('isBinaryContentType', () => {
@@ -216,6 +219,154 @@ describe('GraphClient binary response handling', () => {
       expect(result.rawResponse).toBeUndefined();
     } finally {
       global.fetch = originalFetch;
+    }
+  });
+});
+
+describe('GraphClient file downloads', () => {
+  it('streams Graph response bytes straight to a new file', async () => {
+    const { default: GraphClient } = await import('../src/graph-client.js');
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ms365-download-'));
+    const destination = path.join(tempDir, 'attachment.pdf');
+    // High bytes (0xff, 0x00, 0x7f) would be mangled by a UTF-8 text decode;
+    // streaming to disk must preserve them exactly.
+    const fileBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0xff, 0x00, 0x7f]);
+
+    const originalFetch = global.fetch;
+    global.fetch = (async () =>
+      new Response(fileBytes, {
+        status: 200,
+        headers: { 'content-type': 'application/pdf' },
+      })) as typeof fetch;
+
+    try {
+      const mockAuth = {
+        getToken: async () => 'fake-token',
+      };
+      const mockSecrets = {
+        clientId: 'x',
+        tenantId: 'common',
+        cloudType: 'global',
+      };
+      const client = new GraphClient(
+        mockAuth as Parameters<typeof GraphClient>[0],
+        mockSecrets as Parameters<typeof GraphClient>[1],
+        'json'
+      );
+
+      const result = await client.downloadToFile(
+        '/me/messages/m1/attachments/a1/$value',
+        destination
+      );
+
+      expect(result).toEqual({
+        contentType: 'application/pdf',
+        contentLength: fileBytes.byteLength,
+      });
+      expect(await readFile(destination)).toEqual(Buffer.from(fileBytes));
+    } finally {
+      global.fetch = originalFetch;
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('never overwrites an existing file and does not hit the network', async () => {
+    const { default: GraphClient } = await import('../src/graph-client.js');
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ms365-download-'));
+    const destination = path.join(tempDir, 'existing.txt');
+    await writeFile(destination, 'keep me');
+
+    const originalFetch = global.fetch;
+    let fetchCalled = false;
+    global.fetch = (async () => {
+      fetchCalled = true;
+      return new Response('replacement', { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const mockAuth = {
+        getToken: async () => 'fake-token',
+      };
+      const mockSecrets = {
+        clientId: 'x',
+        tenantId: 'common',
+        cloudType: 'global',
+      };
+      const client = new GraphClient(
+        mockAuth as Parameters<typeof GraphClient>[0],
+        mockSecrets as Parameters<typeof GraphClient>[1],
+        'json'
+      );
+
+      // The wx open fails before any request, so the original file survives.
+      await expect(
+        client.downloadToFile('/me/messages/m1/attachments/a1/$value', destination)
+      ).rejects.toMatchObject({ code: 'EEXIST' });
+      expect(fetchCalled).toBe(false);
+      expect(await readFile(destination, 'utf8')).toBe('keep me');
+    } finally {
+      global.fetch = originalFetch;
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('removes the just-created file when the download fails', async () => {
+    const { default: GraphClient } = await import('../src/graph-client.js');
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ms365-download-'));
+    const destination = path.join(tempDir, 'partial.bin');
+
+    const originalFetch = global.fetch;
+    global.fetch = (async () =>
+      new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      })) as typeof fetch;
+
+    try {
+      const mockAuth = { getToken: async () => 'fake-token' };
+      const mockSecrets = { clientId: 'x', tenantId: 'common', cloudType: 'global' };
+      const client = new GraphClient(
+        mockAuth as Parameters<typeof GraphClient>[0],
+        mockSecrets as Parameters<typeof GraphClient>[1],
+        'json'
+      );
+
+      await expect(
+        client.downloadToFile('/me/messages/m1/attachments/a1/$value', destination)
+      ).rejects.toThrow(/404/);
+      // wx creates the file up front, so a failed download must clean it up.
+      await expect(readFile(destination)).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      global.fetch = originalFetch;
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('maps a 403 scope error to the org-mode hint and leaves no file', async () => {
+    const { default: GraphClient } = await import('../src/graph-client.js');
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ms365-download-'));
+    const destination = path.join(tempDir, 'forbidden.bin');
+
+    const originalFetch = global.fetch;
+    global.fetch = (async () =>
+      new Response('Missing scope Mail.Read', { status: 403 })) as typeof fetch;
+
+    try {
+      const mockAuth = { getToken: async () => 'fake-token' };
+      const mockSecrets = { clientId: 'x', tenantId: 'common', cloudType: 'global' };
+      const client = new GraphClient(
+        mockAuth as Parameters<typeof GraphClient>[0],
+        mockSecrets as Parameters<typeof GraphClient>[1],
+        'json'
+      );
+
+      await expect(
+        client.downloadToFile('/me/messages/m1/attachments/a1/$value', destination)
+      ).rejects.toThrow(/--org-mode/);
+      await expect(readFile(destination)).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      global.fetch = originalFetch;
+      await rm(tempDir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
The tool buffered the whole payload in memory via makeRequest (a base64 string plus a decoded Buffer), which exhausted memory or tripped V8's max string length on large mail attachments and meeting recordings - the files it is meant for.

Add GraphClient.downloadToFile, which pipes the authenticated response body straight to disk (constant memory), creates the file with wx so it never overwrites, and removes a partial file if the transfer fails. Output contract unchanged.