### PR TITLE
fix: add download-bytes-to-file to universal tool presets

### DIFF
--- a/src/tool-categories.ts
+++ b/src/tool-categories.ts
@@ -73,10 +73,11 @@ const PRESET_META: Record<string, { description: string; requiresOrgMode?: boole
 // get-drive-item but no downloader, though its llmTip tells the model to call one. Declare their
 // preset membership here and fold it into each preset pattern.
 //
-// download-bytes fetches ANY relative Graph binary path (drive files, attachments, photos, Teams
-// content, recordings, OneNote resources), so it belongs in EVERY preset. It is universal rather
-// than an enumerated list because a list would silently miss apps and every future preset.
-const UNIVERSAL_UTILITY_TOOLS = ['download-bytes'];
+// download-bytes and download-bytes-to-file both read ANY relative Graph binary path (drive files,
+// attachments, photos, Teams content, recordings, OneNote resources) - one returns base64, the other
+// streams the bytes to a local file - so they belong in EVERY preset. Universal rather than an
+// enumerated list because a list would silently miss apps and every future preset.
+const UNIVERSAL_UTILITY_TOOLS = ['download-bytes', 'download-bytes-to-file'];
 
 // Scoped utilities are only meaningful where the resources they act on appear. get-download-url
 // resolves a pre-authenticated URL for drive/SharePoint file content ONLY (not mail/event

--- a/test/presets.test.ts
+++ b/test/presets.test.ts
@@ -134,15 +134,17 @@ describe('utility tools in presets', () => {
     }
   });
 
-  // download-bytes is a universal Graph binary reader, so no preset - current or future - should
-  // be able to find a resource without being able to read its bytes.
-  it('download-bytes is available in every preset (universal binary reader)', () => {
-    for (const preset of namedPresets) {
-      expect(inPreset(preset, 'download-bytes'), `download-bytes missing from ${preset}`).toBe(
-        true
-      );
+  // download-bytes and download-bytes-to-file are universal Graph binary readers (base64 vs stream
+  // to disk), so no preset - current or future - should be able to find a resource without being
+  // able to read its bytes.
+  it.each(['download-bytes', 'download-bytes-to-file'])(
+    '%s is available in every preset (universal binary reader)',
+    (tool) => {
+      for (const preset of namedPresets) {
+        expect(inPreset(preset, tool), `${tool} missing from ${preset}`).toBe(true);
+      }
     }
-  });
+  );
 
   // Pin the full get-download-url membership so a regression dropping any drive-backed preset
   // is caught. download-bytes membership is covered by the every-preset test above.


### PR DESCRIPTION
download-bytes-to-file (#589) is a utility tool but was in no preset, so any --preset filter stripped it - the same gap #590 closed for the other downloaders. It reads any Graph binary path like download-bytes, so it joins UNIVERSAL_UTILITY_TOOLS (every preset). The universal-reader test now covers both downloaders, so a future one can't regress unnoticed.