### PR TITLE
feat(schema): describe $expand as navigation-properties-only

### DIFF
--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -64,6 +64,7 @@ function makeEndpoint(overrides: Partial<any> = {}) {
       { name: 'search', type: 'Query', schema: z.string().optional() },
       { name: 'select', type: 'Query', schema: z.string().optional() },
       { name: 'orderby', type: 'Query', schema: z.string().optional() },
+      { name: 'expand', type: 'Query', schema: z.string().optional() },
       { name: 'count', type: 'Query', schema: z.boolean().optional() },
       { name: 'top', type: 'Query', schema: z.number().optional() },
       { name: 'skip', type: 'Query', schema: z.number().optional() },
@@ -511,6 +512,25 @@ describe('graph-tools', () => {
 
       expect(schema['top'].description).toContain('Start small');
       expect(schema['top'].description).toContain('$select');
+    });
+    it('should describe $expand as navigation-properties-only', async () => {
+      const endpoint = makeEndpoint();
+      const config = makeConfig();
+      mockEndpoints.push(endpoint);
+      mockEndpointsJson = [config];
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, createMockGraphClient() as any);
+
+      const schema = server.tools.get('test-tool')!.schema;
+
+      expect(schema['expand']).toBeDefined();
+      // Must not be Microsoft's uninformative "Expand related entities".
+      expect(schema['expand'].description).not.toBe('Expand related entities');
+      expect(schema['expand'].description).toContain('navigation');
+      // Names at least one real navigation property so the model has something to copy.
+      expect(schema['expand'].description).toContain('attachments');
     });
   });
 

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -1545,6 +1545,24 @@ export function registerGraphTools(
         .describe('Comma-separated fields to return, e.g. id,subject,from,receivedDateTime')
         .optional();
     }
+    // The spec describes every $expand as "Expand related entities", which says nothing about
+    // what is expandable. Models pass non-navigation properties — message body is the one I
+    // hit repeatedly — and Graph answers 400 "Parsing OData Select and Expand failed".
+    // Restated as the override rather than a new schema: $expand is already array<string>
+    // everywhere, so the type is unchanged in practice.
+    if (paramSchema['expand'] !== undefined || paramSchema['$expand'] !== undefined) {
+      const key = paramSchema['$expand'] !== undefined ? '$expand' : 'expand';
+      paramSchema[key] = z
+        .array(z.string())
+        .describe(
+          'Navigation properties to inline, e.g. attachments on a message or event. Only ' +
+            'navigation properties can be expanded: expanding a non-navigation property such ' +
+            'as a message body fails with "Parsing OData Select and Expand failed", and an ' +
+            'unsupported value may be ignored rather than reported. Request ordinary fields ' +
+            'with $select instead.'
+        )
+        .optional();
+    }
     if (paramSchema['orderby'] !== undefined || paramSchema['$orderby'] !== undefined) {
       const key = paramSchema['$orderby'] !== undefined ? '$orderby' : 'orderby';
       paramSchema[key] = z


### PR DESCRIPTION
Every $expand in the generated client carries Microsoft's
"Expand related entities", which says nothing about what is actually
expandable. Models pass non-navigation properties - message body is the
one I hit repeatedly - and Graph answers

  400 Parsing OData Select and Expand failed: Property 'body' on type
  'microsoft.graph.message' is not a navigation property or complex
  property. Only navigation properties can be expanded.

$expand is the one OData parameter the describe() overrides in
registerGraphTools do not cover; $filter, $search, $select, $orderby,
$top, $skip and $count all get useful text. This adds $expand to that
chain, states the constraint, and points at $select for ordinary fields.

Kept deliberately generic. An earlier draft listed common navigation
properties per resource, but the override applies to all 140 $expand
params, most of them on drives, workbooks, groups and chats, where
mail and calendar examples would be noise. It also named several
properties I could not confirm are expandable in v1.0.

The schema is restated rather than changed: $expand is already
array<string> on every parameter it applies to.
