### PR TITLE
fix(schema): tell the model which path-parameter name to use

### DIFF
--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -532,6 +532,25 @@ describe('graph-tools', () => {
       // Names at least one real navigation property so the model has something to copy.
       expect(schema['expand'].description).toContain('attachments');
     });
+
+    // graph-tools synthesizes path params only for endpoints where the generated
+    // client (via hack.ts) has not already supplied one — mostly function-style paths.
+    it('should describe path params it synthesizes itself', async () => {
+      const endpoint = makeEndpoint({ path: '/me/messages/:messageId' });
+      const config = makeConfig();
+      mockEndpoints.push(endpoint);
+      mockEndpointsJson = [config];
+
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, createMockGraphClient() as any);
+
+      const schema = server.tools.get('test-tool')!.schema;
+
+      expect(schema['messageId']).toBeDefined();
+      expect(schema['messageId'].description).not.toBe('Path parameter: messageId');
+      expect(schema['messageId'].description).toContain("not as 'id'");
+    });
   });
 
   describe('MS365_MCP_MAX_TOP', () => {

--- a/src/generated/hack.ts
+++ b/src/generated/hack.ts
@@ -1,8 +1,15 @@
 import { Endpoint, Parameter } from './endpoint-types.js';
 import { z } from 'zod';
+import { describePathParam } from '../lib/path-params.js';
 
 export function makeApi(endpoints: Endpoint[]) {
   return endpoints;
+}
+
+/** True when a path parameter carries only the generated `Path parameter: x` placeholder. */
+function isPathParamStub(param: Parameter): boolean {
+  const description = param.description ?? param.schema?.description;
+  return typeof description === 'string' && /^Path parameter: /.test(description);
 }
 
 export class Zodios {
@@ -26,18 +33,30 @@ export class Zodios {
       }
 
       for (const pathParam of pathParams) {
-        const paramExists = endpoint.parameters.some(
+        const existing = endpoint.parameters.find(
           (param) => param.name === pathParam || param.name === pathParam.replace(/[$_]+/g, '')
         );
 
-        if (!paramExists) {
+        if (!existing) {
+          const description = describePathParam(pathParam);
           const newParam: Parameter = {
             name: pathParam,
             type: 'Path',
-            schema: z.string().describe(`Path parameter: ${pathParam}`),
-            description: `Path parameter: ${pathParam}`,
+            schema: z.string().describe(description),
+            description,
           };
           endpoint.parameters.push(newParam);
+          continue;
+        }
+
+        // Some operations arrive with the path parameter already declared, but described
+        // only as `Path parameter: drive-id` — no more use to the model than nothing, and
+        // spelled in kebab-case so it does not even match the name callers must send.
+        // Upgrade those; any real upstream description is left alone.
+        if (existing.type === 'Path' && isPathParamStub(existing)) {
+          const description = describePathParam(existing.name);
+          existing.description = description;
+          existing.schema = z.string().describe(description);
         }
       }
 

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -4,6 +4,7 @@ import logger from './logger.js';
 import { auditLog, getUserIdentityForAudit } from './audit-log.js';
 import GraphClient from './graph-client.js';
 import { isDestructiveOperation } from './lib/destructive-ops.js';
+import { describePathParam } from './lib/path-params.js';
 import AuthManager, {
   getEndpointScopeGroups,
   getMissingAllowedScopesForGroups,
@@ -1505,7 +1506,7 @@ export function registerGraphTools(
     for (const match of pathParamMatches) {
       const pathParamName = match[1];
       if (!(pathParamName in paramSchema)) {
-        paramSchema[pathParamName] = z.string().describe(`Path parameter: ${pathParamName}`);
+        paramSchema[pathParamName] = z.string().describe(describePathParam(pathParamName));
       }
     }
 

--- a/src/lib/path-params.ts
+++ b/src/lib/path-params.ts
@@ -1,0 +1,44 @@
+/**
+ * Microsoft's OpenAPI metadata omits path parameters from the parameter list of most
+ * operations, so they are synthesized — in `generated/hack.ts` for endpoints the
+ * generated client already knows about, and in `graph-tools.ts` for the rest.
+ *
+ * Both used to emit `Path parameter: messageId`, which tells the model nothing about
+ * where the value comes from. Because Graph listings return the identifier under the
+ * generic key `id`, models passed `id`, the `:messageId` placeholder was never
+ * substituted, and the request went to a literal `/me/messages/:messageId`.
+ *
+ * Keep this in one place so both synthesis sites stay in sync.
+ */
+export function describePathParam(pathParamName: string): string {
+  const match = /^(.*?)Id(\d*)$/.exec(pathParamName);
+  if (match && match[1]) {
+    const base =
+      `Value for the '${pathParamName}' path segment. ` +
+      `Pass it under the name '${pathParamName}', not as 'id'. `;
+
+    // A numeric suffix means the path names the same resource type twice — in
+    // /messages/:chatMessageId/replies/:chatMessageId1 the numbered one is the reply, not
+    // the parent — so say which is which rather than naming one object for both.
+    if (match[2]) {
+      return (
+        base +
+        `It identifies a different resource from the similarly named parameter ` +
+        `without the number; check the tool's path to see which.`
+      );
+    }
+
+    const resource = match[1].replace(/([a-z0-9])([A-Z])/g, '$1 $2').toLowerCase();
+    // 'directoryObjectId' would otherwise read "the directory object object".
+    const noun = /(^|\s)object$/.test(resource) ? resource : `${resource} object`;
+    // Not every resource has a list tool — placeId, plannerPlanId and
+    // virtualEventWebinarId do not — so point at Graph rather than promising a tool.
+    return base + `Use the 'id' field of the ${noun} as returned by Microsoft Graph.`;
+  }
+
+  // Not an identifier — say nothing about where the value comes from. Function-style
+  // segments are caller-supplied values, not ids looked up beforehand: 'address' is an
+  // A1 range, 'q' is search text, 'index' selects a position. Claiming they come from a
+  // list or get response would steer the model to the wrong value.
+  return `Value for the '${pathParamName}' path segment.`;
+}

--- a/test/path-param-descriptions.test.ts
+++ b/test/path-param-descriptions.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { describePathParam } from '../src/lib/path-params.js';
+
+// Node 18 lacks the File global that the generated Zod schemas reference.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+if (!globalThis.File) (globalThis as any).File = Blob;
+
+const { api } = await import('../src/generated/client.js');
+
+/**
+ * Path parameters are injected into the generated client by generated/hack.ts, not by
+ * registerGraphTools — so a mock-endpoint test in graph-tools.test.ts does not cover
+ * them. Assert against the real client to make sure the description the model actually
+ * receives is the informative one.
+ */
+describe('describePathParam', () => {
+  it('names the parameter and steers off the generic `id` key', () => {
+    const d = describePathParam('messageId');
+    expect(d).toContain("'messageId'");
+    expect(d).toContain("not as 'id'");
+    expect(d).toContain('message');
+  });
+
+  it('splits camelCase resource names into readable words', () => {
+    expect(describePathParam('todoTaskListId')).toContain('todo task list');
+  });
+
+  // 'address' is an A1 range, 'q' is search text, 'index' selects a position — none are
+  // ids fetched beforehand, so the description must not claim a source.
+  it.each(['address', 'q', 'index', 'sideIndex'])(
+    'makes no provenance claim for non-identifier param %s',
+    (name) => {
+      const d = describePathParam(name);
+      expect(d).toContain(`'${name}'`);
+      expect(d).not.toContain('list or get tool');
+      expect(d).not.toContain("not as 'id'");
+    }
+  );
+});
+
+describe('generated client path parameters', () => {
+  const pathParams = api.endpoints.flatMap((endpoint) =>
+    (endpoint.parameters ?? [])
+      .filter((p) => p.type === 'Path')
+      .map((p) => ({
+        alias: endpoint.alias,
+        name: p.name,
+        // Pre-declared params carry their text on the zod schema rather than alongside it.
+        description: p.description ?? p.schema?.description,
+      }))
+  );
+
+  it('has path parameters to check', () => {
+    expect(pathParams.length).toBeGreaterThan(100);
+  });
+
+  // Covers both the synthesized `Path parameter: messageId` and the pre-declared
+  // kebab-case `Path parameter: drive-id`, which is spelled differently from the name
+  // callers actually have to send.
+  it('never ships a "Path parameter: …" stub', () => {
+    const stubs = pathParams.filter((p) => /^Path parameter: /.test(p.description ?? ''));
+    expect(
+      stubs.slice(0, 10).map((p) => `${p.alias}.${p.name}`),
+      `${stubs.length} path parameter(s) still carry the stub description`
+    ).toEqual([]);
+  });
+
+  // Asserted against literal text, not against describePathParam's own output — comparing
+  // the helper to itself would pass however wrong the helper became.
+  it('describes get-mail-message.messageId with the id guidance', () => {
+    const p = pathParams.find((x) => x.alias === 'get-mail-message' && x.name === 'messageId');
+    expect(p?.description).toBe(
+      "Value for the 'messageId' path segment. Pass it under the name 'messageId', not as " +
+        "'id'. Use the 'id' field of the message object as returned by Microsoft Graph."
+    );
+  });
+
+  // get-excel-range.address is an A1 range the caller composes, not an id to look up.
+  it('describes get-excel-range.address without inventing a source', () => {
+    const p = pathParams.find((x) => x.alias === 'get-excel-range' && x.name === 'address');
+    expect(p?.description).toBe("Value for the 'address' path segment.");
+  });
+
+  it('describes get-mail-message.messageId usefully', () => {
+    const p = pathParams.find((x) => x.alias === 'get-mail-message' && x.name === 'messageId');
+    expect(p).toBeDefined();
+    expect(p!.description).toContain("not as 'id'");
+  });
+});


### PR DESCRIPTION
Path parameters reach the model with no usable description. Microsoft's
metadata leaves them out of most operations' parameter lists, so
generated/hack.ts synthesizes them as

  Path parameter: messageId

and the operations that do declare them describe them as

  Path parameter: drive-id

Neither says where the value comes from, and the second is spelled
differently from the name a caller actually has to send. Graph listings
return the identifier under the generic key `id`, so models pass `id`,
the parameter is rejected as missing, and retrying does not help because
nothing in the schema hints at the real name.

Both cases now get:

  Value for the 'messageId' path segment. Pass it under the name
  'messageId', not as 'id'. Use the 'id' field of the message object as
  returned by Microsoft Graph.

Deliberately narrow about what it claims:

- Non-identifiers get only `Value for the 'address' path segment.` A
  fallback that pointed at "the corresponding list tool" would be wrong
  for get-excel-range.address (an A1 range), search-onedrive-files.q
  (search text), list-supported-time-zones.TimeZoneStandard (an enum)
  and get-sharepoint-site-by-path.path.
- It says "as returned by Microsoft Graph" rather than naming a list
  tool, because placeId, plannerPlanId and virtualEventWebinarId have
  none.
- A numeric suffix gets no resource name at all. In
  /messages/:chatMessageId/replies/:chatMessageId1 the numbered
  parameter is the reply, not the parent.

The text lives in one helper so the two sites cannot drift. Tests assert
against the real generated client and against literal expected strings,
not against the helper's own output: hack.ts supplies parameters before
registerGraphTools sees them, so a mock-only test passes while
production is unchanged.

