### PR TITLE
fix(discovery): share param-description overrides between registration paths

### DIFF
--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -30,6 +30,28 @@ export interface DiscoverySearchIndex {
   nameTokens: Map<string, Set<string>>;
 }
 import { describeToolSchema, describeUtilityToolSchema } from './lib/tool-schema.js';
+import {
+  TOP_UNSUPPORTED_DELTA_TOOLS,
+  shouldOmitTopParam,
+  paginationAllowed,
+  positiveIntFromEnv,
+  DEFAULT_MAX_PAGES,
+  getMaxPages,
+  isFetchAllPagesApplicable,
+  FILTER_PARAM_DESCRIPTION,
+  SEARCH_PARAM_DESCRIPTION,
+  SELECT_PARAM_DESCRIPTION,
+  EXPAND_PARAM_DESCRIPTION,
+  ORDERBY_PARAM_DESCRIPTION,
+  TOP_PARAM_DESCRIPTION,
+  SKIP_PARAM_DESCRIPTION,
+  COUNT_PARAM_DESCRIPTION,
+  CONFIRM_PARAM_DESCRIPTION,
+  TIMEZONE_PARAM_DESCRIPTION,
+  EXPAND_EXTENDED_PROPERTIES_PARAM_DESCRIPTION,
+  getAccountParamDescription,
+  getFetchAllPagesParamDescription,
+} from './lib/param-descriptions.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -66,18 +88,6 @@ const endpointsData = JSON.parse(
 ) as EndpointConfig[];
 
 /**
- * Delta tools where Graph does NOT support `$top`. The calendarView delta function
- * lists `$top` neither as supported nor among its rejected params; page size is
- * controlled via `Prefer: odata.maxpagesize` instead. By contrast message/driveItem/site
- * delta explicitly document `$top` support, so it must be preserved for those.
- * See https://learn.microsoft.com/en-us/graph/api/event-delta
- */
-const TOP_UNSUPPORTED_DELTA_TOOLS = new Set([
-  'list-calendar-events-delta',
-  'list-calendar-view-delta',
-]);
-
-/**
  * Prefix beta-version tools with a [beta] marker so the instability is visible in the
  * tool description itself, regardless of what (if anything) the llmTip says. Tools on
  * v1.0 (the default) are returned unchanged.
@@ -109,30 +119,13 @@ function clampTopQueryParam(queryParams: Record<string, string>): void {
   queryParams['$top'] = String(cap);
 }
 
-const DEFAULT_MAX_PAGES = 100;
 const DEFAULT_MAX_ITEMS = 10_000;
 
-/** Reads a positive-integer env var, falling back to `defaultValue` when unset or invalid. */
-function positiveIntFromEnv(name: string, defaultValue: number): number {
-  const raw = process.env[name];
-  if (raw === undefined || raw === '') return defaultValue;
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 1) {
-    logger.warn(`Ignoring invalid ${name}=${JSON.stringify(raw)} (use a positive integer)`);
-    return defaultValue;
-  }
-  return n;
-}
-
-/**
- * Whether `fetchAllPages` is permitted. Defaults to true; set MS365_MCP_ALLOW_PAGINATION
- * to 0/false/no to disable multi-page following entirely (returns the first page only).
- */
-function paginationAllowed(): boolean {
-  const raw = process.env.MS365_MCP_ALLOW_PAGINATION;
-  if (raw === undefined || raw === '') return true;
-  return !/^(0|false|no)$/i.test(raw.trim());
-}
+// Canonical definitions of TOP_UNSUPPORTED_DELTA_TOOLS, paginationAllowed, and
+// positiveIntFromEnv live in lib/param-descriptions.ts so tool-schema.ts can use
+// them without circling back through graph-tools.ts, and so the description text
+// they parameterize can't drift between the two registration paths (see that
+// file's header comment).
 
 // Canonical definition lives in lib/destructive-ops.ts so tool-schema.ts can
 // use it without circling back through graph-tools.ts; re-exported here for
@@ -1509,41 +1502,28 @@ export function registerGraphTools(
       }
     }
 
-    if (tool.method.toUpperCase() === 'GET' && tool.path.includes('/') && paginationAllowed()) {
-      const maxPages = positiveIntFromEnv('MS365_MCP_MAX_PAGES', DEFAULT_MAX_PAGES);
+    if (isFetchAllPagesApplicable(tool)) {
+      const maxPages = getMaxPages();
       paramSchema['fetchAllPages'] = z
         .boolean()
-        .describe(
-          `Follow @odata.nextLink and merge up to ${maxPages} pages into one response. ` +
-            'Can return enormous payloads—only when the user explicitly needs a full export. ' +
-            'Prefer a small $top first, then paginate or narrow with $filter/$search.'
-        )
+        .describe(getFetchAllPagesParamDescription(maxPages))
         .optional();
     }
 
-    // Override OData parameter descriptions with spec-gap guidance
+    // Override OData parameter descriptions with spec-gap guidance. Text lives in
+    // lib/param-descriptions.ts, shared with describeToolSchema (--discovery mode),
+    // so the two paths cannot describe the same parameter differently.
     if (paramSchema['filter'] !== undefined || paramSchema['$filter'] !== undefined) {
       const key = paramSchema['$filter'] !== undefined ? '$filter' : 'filter';
-      paramSchema[key] = z
-        .string()
-        .describe(
-          'OData filter expression. Add $count=true for advanced filters (flag/flagStatus, contains()). Cannot combine with $search.'
-        )
-        .optional();
+      paramSchema[key] = z.string().describe(FILTER_PARAM_DESCRIPTION).optional();
     }
     if (paramSchema['search'] !== undefined || paramSchema['$search'] !== undefined) {
       const key = paramSchema['$search'] !== undefined ? '$search' : 'search';
-      paramSchema[key] = z
-        .string()
-        .describe('KQL search query — wrap value in double quotes. Cannot combine with $filter.')
-        .optional();
+      paramSchema[key] = z.string().describe(SEARCH_PARAM_DESCRIPTION).optional();
     }
     if (paramSchema['select'] !== undefined || paramSchema['$select'] !== undefined) {
       const key = paramSchema['$select'] !== undefined ? '$select' : 'select';
-      paramSchema[key] = z
-        .string()
-        .describe('Comma-separated fields to return, e.g. id,subject,from,receivedDateTime')
-        .optional();
+      paramSchema[key] = z.string().describe(SELECT_PARAM_DESCRIPTION).optional();
     }
     // The spec describes every $expand as "Expand related entities", which says nothing about
     // what is expandable. Models pass non-navigation properties — message body is the one I
@@ -1552,58 +1532,31 @@ export function registerGraphTools(
     // everywhere, so the type is unchanged in practice.
     if (paramSchema['expand'] !== undefined || paramSchema['$expand'] !== undefined) {
       const key = paramSchema['$expand'] !== undefined ? '$expand' : 'expand';
-      paramSchema[key] = z
-        .array(z.string())
-        .describe(
-          'Navigation properties to inline, e.g. attachments on a message or event. Only ' +
-            'navigation properties can be expanded: expanding a non-navigation property such ' +
-            'as a message body fails with "Parsing OData Select and Expand failed", and an ' +
-            'unsupported value may be ignored rather than reported. Request ordinary fields ' +
-            'with $select instead.'
-        )
-        .optional();
+      paramSchema[key] = z.array(z.string()).describe(EXPAND_PARAM_DESCRIPTION).optional();
     }
     if (paramSchema['orderby'] !== undefined || paramSchema['$orderby'] !== undefined) {
       const key = paramSchema['$orderby'] !== undefined ? '$orderby' : 'orderby';
-      paramSchema[key] = z
-        .string()
-        .describe('Sort expression, e.g. receivedDateTime desc')
-        .optional();
+      paramSchema[key] = z.string().describe(ORDERBY_PARAM_DESCRIPTION).optional();
     }
     // The calendar delta tools don't support $top (see TOP_UNSUPPORTED_DELTA_TOOLS) —
     // page size is controlled via Prefer: odata.maxpagesize. Strip top/$top from
     // their schemas so callers can't reach for a parameter that won't work. Other
     // delta tools (message/driveItem/site) do support $top, so leave them alone.
     // Server-side defense-in-depth in executeGraphTool handles stale clients.
-    if (TOP_UNSUPPORTED_DELTA_TOOLS.has(tool.alias)) {
+    if (shouldOmitTopParam(tool.alias)) {
       delete paramSchema['top'];
       delete paramSchema['$top'];
     } else if (paramSchema['top'] !== undefined || paramSchema['$top'] !== undefined) {
       const key = paramSchema['$top'] !== undefined ? '$top' : 'top';
-      paramSchema[key] = z
-        .number()
-        .describe(
-          'Page size (Graph $top). Start small (e.g. 5–15) so responses fit the model context; ' +
-            'raise only if needed. Use $select to return fewer fields per item. ' +
-            'For more rows, use @odata.nextLink from the response instead of a very large $top.'
-        )
-        .optional();
+      paramSchema[key] = z.number().describe(TOP_PARAM_DESCRIPTION).optional();
     }
     if (paramSchema['skip'] !== undefined || paramSchema['$skip'] !== undefined) {
       const key = paramSchema['$skip'] !== undefined ? '$skip' : 'skip';
-      paramSchema[key] = z
-        .number()
-        .describe('Items to skip for pagination. Not supported with $search.')
-        .optional();
+      paramSchema[key] = z.number().describe(SKIP_PARAM_DESCRIPTION).optional();
     }
     if (paramSchema['count'] !== undefined || paramSchema['$count'] !== undefined) {
       const countKey = paramSchema['$count'] !== undefined ? '$count' : 'count';
-      paramSchema[countKey] = z
-        .boolean()
-        .describe(
-          'Set true to enable advanced query mode (ConsistencyLevel: eventual). Required for complex $filter on flag/flagStatus or contains().'
-        )
-        .optional();
+      paramSchema[countKey] = z.boolean().describe(COUNT_PARAM_DESCRIPTION).optional();
     }
 
     // Add account parameter for multi-account mode.
@@ -1611,15 +1564,9 @@ export function registerGraphTools(
     // sees available accounts upfront without a round-trip, but accounts added mid-session via
     // --login are still accepted — getTokenForAccount() handles validation at runtime.
     if (multiAccount) {
-      const accountHint =
-        accountNames.length > 0 ? `Known accounts: ${accountNames.join(', ')}. ` : '';
       paramSchema['account'] = z
         .string()
-        .describe(
-          `${accountHint}Microsoft account email to use for this request. ` +
-            `Required when multiple accounts are configured. ` +
-            `Use the list-accounts tool to discover all currently available accounts.`
-        )
+        .describe(getAccountParamDescription(accountNames))
         .optional();
     }
 
@@ -1641,33 +1588,19 @@ export function registerGraphTools(
     // the LLM/agent sees it upfront.
     const destructive = isDestructiveOperation(tool.method, endpointConfig);
     if (destructive) {
-      paramSchema['confirm'] = z
-        .boolean()
-        .describe(
-          'For destructive operations when the confirm gate is enabled (MS365_MCP_REQUIRE_CONFIRM=true; off by default). ' +
-            'Set to true only after the user has explicitly approved this action. ' +
-            'When the gate is on, calls without confirm: true return { error: "confirmation_required" } without touching user data.'
-        )
-        .optional();
+      paramSchema['confirm'] = z.boolean().describe(CONFIRM_PARAM_DESCRIPTION).optional();
     }
 
     // Add timezone parameter for calendar endpoints that support it
     if (endpointConfig?.supportsTimezone) {
-      paramSchema['timezone'] = z
-        .string()
-        .describe(
-          'IANA timezone name (e.g., "America/New_York", "Europe/London", "Asia/Tokyo") for calendar event times. If not specified, times are returned in UTC.'
-        )
-        .optional();
+      paramSchema['timezone'] = z.string().describe(TIMEZONE_PARAM_DESCRIPTION).optional();
     }
 
     // Add expandExtendedProperties parameter for calendar endpoints that support it
     if (endpointConfig?.supportsExpandExtendedProperties) {
       paramSchema['expandExtendedProperties'] = z
         .boolean()
-        .describe(
-          'When true, expands singleValueExtendedProperties on each event. Use this to retrieve custom extended properties (e.g., sync metadata) stored on calendar events.'
-        )
+        .describe(EXPAND_EXTENDED_PROPERTIES_PARAM_DESCRIPTION)
         .optional();
     }
 
@@ -2055,7 +1988,7 @@ export function registerDiscoveryTools(
     async ({ tool_name }) => {
       const entry = toolsRegistry.get(tool_name);
       if (entry) {
-        const schema = describeToolSchema(entry.tool, entry.config);
+        const schema = describeToolSchema(entry.tool, entry.config, { multiAccount, accountNames });
         return {
           content: [{ type: 'text', text: JSON.stringify(schema, null, 2) }],
         };

--- a/src/lib/param-descriptions.ts
+++ b/src/lib/param-descriptions.ts
@@ -1,0 +1,156 @@
+/**
+ * Single source of truth for the parameter description text that both
+ * `registerGraphTools` (normal MCP registration, wraps these in Zod schemas)
+ * and `describeToolSchema` / `get-tool-schema` (--discovery mode) surface to
+ * an LLM. These parameters carry spec-gap guidance that goes well beyond
+ * what Microsoft's OpenAPI spec says (see the $expand case below), so it is
+ * critical that both code paths describe them identically — an LLM using
+ * --discovery mode should see exactly what an LLM using normal registration
+ * sees. Keeping the text here, instead of inlined at each call site, makes it
+ * structurally impossible for the two paths to drift out of sync again.
+ *
+ * Some of these parameters are conditional (only added to a tool's schema
+ * under certain circumstances); the functions here also encode those
+ * conditions so both call sites apply them identically.
+ */
+import logger from '../logger.js';
+
+/**
+ * Delta tools where Graph does NOT support `$top`. The calendarView delta function
+ * lists `$top` neither as supported nor among its rejected params; page size is
+ * controlled via `Prefer: odata.maxpagesize` instead. By contrast message/driveItem/site
+ * delta explicitly document `$top` support, so it must be preserved for those.
+ * See https://learn.microsoft.com/en-us/graph/api/event-delta
+ */
+export const TOP_UNSUPPORTED_DELTA_TOOLS = new Set([
+  'list-calendar-events-delta',
+  'list-calendar-view-delta',
+]);
+
+/** True when `$top`/`top` must be omitted entirely from a tool's schema. */
+export function shouldOmitTopParam(toolAlias: string): boolean {
+  return TOP_UNSUPPORTED_DELTA_TOOLS.has(toolAlias);
+}
+
+/**
+ * Whether `fetchAllPages` is permitted. Defaults to true; set MS365_MCP_ALLOW_PAGINATION
+ * to 0/false/no to disable multi-page following entirely (returns the first page only).
+ */
+export function paginationAllowed(): boolean {
+  const raw = process.env.MS365_MCP_ALLOW_PAGINATION;
+  if (raw === undefined || raw === '') return true;
+  return !/^(0|false|no)$/i.test(raw.trim());
+}
+
+export const DEFAULT_MAX_PAGES = 100;
+
+/** Reads a positive-integer env var, falling back to `defaultValue` when unset or invalid. */
+export function positiveIntFromEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return defaultValue;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) {
+    logger.warn(`Ignoring invalid ${name}=${JSON.stringify(raw)} (use a positive integer)`);
+    return defaultValue;
+  }
+  return n;
+}
+
+/** Current `fetchAllPages` page cap, honoring MS365_MCP_MAX_PAGES. */
+export function getMaxPages(): number {
+  return positiveIntFromEnv('MS365_MCP_MAX_PAGES', DEFAULT_MAX_PAGES);
+}
+
+/** Whether a tool is eligible for the synthetic `fetchAllPages` parameter. */
+export function isFetchAllPagesApplicable(tool: { method: string; path: string }): boolean {
+  return tool.method.toUpperCase() === 'GET' && tool.path.includes('/') && paginationAllowed();
+}
+
+export const FILTER_PARAM_DESCRIPTION =
+  'OData filter expression. Add $count=true for advanced filters (flag/flagStatus, contains()). Cannot combine with $search.';
+
+export const SEARCH_PARAM_DESCRIPTION =
+  'KQL search query — wrap value in double quotes. Cannot combine with $filter.';
+
+export const SELECT_PARAM_DESCRIPTION =
+  'Comma-separated fields to return, e.g. id,subject,from,receivedDateTime';
+
+// The spec describes every $expand as "Expand related entities", which says nothing about
+// what is expandable. Models pass non-navigation properties — message body is the one I
+// hit repeatedly — and Graph answers 400 "Parsing OData Select and Expand failed".
+export const EXPAND_PARAM_DESCRIPTION =
+  'Navigation properties to inline, e.g. attachments on a message or event. Only ' +
+  'navigation properties can be expanded: expanding a non-navigation property such ' +
+  'as a message body fails with "Parsing OData Select and Expand failed", and an ' +
+  'unsupported value may be ignored rather than reported. Request ordinary fields ' +
+  'with $select instead.';
+
+export const ORDERBY_PARAM_DESCRIPTION = 'Sort expression, e.g. receivedDateTime desc';
+
+export const TOP_PARAM_DESCRIPTION =
+  'Page size (Graph $top). Start small (e.g. 5–15) so responses fit the model context; ' +
+  'raise only if needed. Use $select to return fewer fields per item. ' +
+  'For more rows, use @odata.nextLink from the response instead of a very large $top.';
+
+export const SKIP_PARAM_DESCRIPTION = 'Items to skip for pagination. Not supported with $search.';
+
+export const COUNT_PARAM_DESCRIPTION =
+  'Set true to enable advanced query mode (ConsistencyLevel: eventual). Required for complex $filter on flag/flagStatus or contains().';
+
+export const CONFIRM_PARAM_DESCRIPTION =
+  'For destructive operations when the confirm gate is enabled (MS365_MCP_REQUIRE_CONFIRM=true; off by default). ' +
+  'Set to true only after the user has explicitly approved this action. ' +
+  'When the gate is on, calls without confirm: true return { error: "confirmation_required" } without touching user data.';
+
+export const TIMEZONE_PARAM_DESCRIPTION =
+  'IANA timezone name (e.g., "America/New_York", "Europe/London", "Asia/Tokyo") for calendar event times. If not specified, times are returned in UTC.';
+
+export const EXPAND_EXTENDED_PROPERTIES_PARAM_DESCRIPTION =
+  'When true, expands singleValueExtendedProperties on each event. Use this to retrieve custom extended properties (e.g., sync metadata) stored on calendar events.';
+
+/**
+ * Layer 2 of multi-account support: account names are surfaced in the description
+ * (not as a strict enum) so the LLM sees available accounts upfront without a
+ * round-trip, but accounts added mid-session via --login are still accepted —
+ * getTokenForAccount() handles validation at runtime.
+ */
+export function getAccountParamDescription(accountNames: string[]): string {
+  const accountHint = accountNames.length > 0 ? `Known accounts: ${accountNames.join(', ')}. ` : '';
+  return (
+    `${accountHint}Microsoft account email to use for this request. ` +
+    `Required when multiple accounts are configured. ` +
+    `Use the list-accounts tool to discover all currently available accounts.`
+  );
+}
+
+export function getFetchAllPagesParamDescription(maxPages: number): string {
+  return (
+    `Follow @odata.nextLink and merge up to ${maxPages} pages into one response. ` +
+    'Can return enormous payloads—only when the user explicitly needs a full export. ' +
+    'Prefer a small $top first, then paginate or narrow with $filter/$search.'
+  );
+}
+
+/** Maps a bare or `$`-prefixed OData param name to its shared description text. */
+export function getODataParamDescription(bareName: string): string | undefined {
+  switch (bareName) {
+    case 'filter':
+      return FILTER_PARAM_DESCRIPTION;
+    case 'search':
+      return SEARCH_PARAM_DESCRIPTION;
+    case 'select':
+      return SELECT_PARAM_DESCRIPTION;
+    case 'expand':
+      return EXPAND_PARAM_DESCRIPTION;
+    case 'orderby':
+      return ORDERBY_PARAM_DESCRIPTION;
+    case 'top':
+      return TOP_PARAM_DESCRIPTION;
+    case 'skip':
+      return SKIP_PARAM_DESCRIPTION;
+    case 'count':
+      return COUNT_PARAM_DESCRIPTION;
+    default:
+      return undefined;
+  }
+}

--- a/src/lib/tool-schema.ts
+++ b/src/lib/tool-schema.ts
@@ -2,6 +2,17 @@ import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import type { api } from '../generated/client.js';
 import { isDestructiveOperation, type DestructiveCheckConfig } from './destructive-ops.js';
+import {
+  getODataParamDescription,
+  shouldOmitTopParam,
+  isFetchAllPagesApplicable,
+  getMaxPages,
+  getFetchAllPagesParamDescription,
+  getAccountParamDescription,
+  CONFIRM_PARAM_DESCRIPTION,
+  TIMEZONE_PARAM_DESCRIPTION,
+  EXPAND_EXTENDED_PROPERTIES_PARAM_DESCRIPTION,
+} from './param-descriptions.js';
 
 type ToolEndpoint = (typeof api.endpoints)[number];
 
@@ -13,6 +24,17 @@ type ToolEndpoint = (typeof api.endpoints)[number];
 export interface ToolSchemaConfig extends DestructiveCheckConfig {
   llmTip?: string;
   descriptionOverride?: string;
+  supportsTimezone?: boolean;
+  supportsExpandExtendedProperties?: boolean;
+}
+
+/**
+ * Context describeToolSchema needs to replicate registerGraphTools' conditional,
+ * per-tool synthetic parameters (account) in discovery mode.
+ */
+export interface ToolSchemaContext {
+  multiAccount?: boolean;
+  accountNames?: string[];
 }
 
 function unwrapOptional(schema: z.ZodTypeAny): { inner: z.ZodTypeAny; optional: boolean } {
@@ -24,20 +46,35 @@ function unwrapOptional(schema: z.ZodTypeAny): { inner: z.ZodTypeAny; optional: 
   return { inner: schema, optional: false };
 }
 
+/** Strips a leading `$` so both `filter` and `$filter` map to the same lookup key. */
+function bareParamName(name: string): string {
+  return name.startsWith('$') ? name.slice(1) : name;
+}
+
 /**
  * Returns a JSON Schema describing every parameter a discovery tool accepts,
  * so an agent can construct a correctly-shaped `parameters` object for execute-tool.
  *
- * Includes synthetic runtime params injected by graph-tools.ts that an agent
- * needs to know about — currently `confirm` for destructive operations. Other
- * runtime params (`fetchAllPages`, `account`, `includeHeaders`, ...) are not
- * yet surfaced here; they're optional booleans with safe defaults so omitting
- * them from discovery only costs a feature, not correctness. `confirm` is the
- * exception because the server fails closed without it on destructive tools.
+ * Descriptions for OData query parameters ($filter/$search/$select/$expand/$orderby/
+ * $top/$skip/$count) are overridden with the same spec-gap guidance text
+ * registerGraphTools puts in its Zod schemas — both pull from
+ * lib/param-descriptions.ts so the two paths can't drift apart again. $top/top is
+ * omitted entirely for tools in TOP_UNSUPPORTED_DELTA_TOOLS, mirroring
+ * registerGraphTools' `delete paramSchema['top']`.
+ *
+ * Also includes synthetic runtime params injected by graph-tools.ts that an agent
+ * needs to know about: `confirm` (destructive gate), `fetchAllPages` (GET list
+ * endpoints), `account` (multi-account mode, via `ctx`), `timezone` and
+ * `expandExtendedProperties` (calendar endpoints, via `config`). `includeHeaders`
+ * and `excludeResponse` are intentionally NOT surfaced here — they're the same
+ * static text on every tool (no per-tool override to drift), optional booleans
+ * with safe defaults, so omitting them from discovery only costs a feature, not
+ * correctness.
  */
 export function describeToolSchema(
   tool: ToolEndpoint,
-  config: ToolSchemaConfig | undefined
+  config: ToolSchemaConfig | undefined,
+  ctx: ToolSchemaContext = {}
 ): {
   name: string;
   method: string;
@@ -52,19 +89,25 @@ export function describeToolSchema(
     schema: unknown;
   }>;
 } {
-  const params = (tool.parameters ?? []).map((p) => {
-    const { inner, optional } = unwrapOptional(p.schema as z.ZodTypeAny);
-    const isPath = p.type === 'Path';
-    const jsonSchema = zodToJsonSchema(inner, { target: 'jsonSchema7', $refStrategy: 'none' });
-    const { $schema: _s, ...schema } = jsonSchema as Record<string, unknown>;
-    return {
-      name: p.name,
-      in: p.type as 'Path' | 'Query' | 'Body' | 'Header',
-      required: isPath || !optional,
-      description: p.description,
-      schema,
-    };
-  });
+  const omitTop = shouldOmitTopParam(tool.alias);
+
+  const params = (tool.parameters ?? [])
+    .filter((p) => !(omitTop && bareParamName(p.name) === 'top'))
+    .map((p) => {
+      const { inner, optional } = unwrapOptional(p.schema as z.ZodTypeAny);
+      const isPath = p.type === 'Path';
+      const jsonSchema = zodToJsonSchema(inner, { target: 'jsonSchema7', $refStrategy: 'none' });
+      const { $schema: _s, ...schema } = jsonSchema as Record<string, unknown>;
+      const override =
+        p.type === 'Query' ? getODataParamDescription(bareParamName(p.name)) : undefined;
+      return {
+        name: p.name,
+        in: p.type as 'Path' | 'Query' | 'Body' | 'Header',
+        required: isPath || !optional,
+        description: override ?? p.description,
+        schema,
+      };
+    });
 
   // Surface the destructive-confirm gate so agents in --discovery mode know
   // to pass `confirm: true`. Without this, every destructive tool returns
@@ -74,10 +117,52 @@ export function describeToolSchema(
       name: 'confirm',
       in: 'Query',
       required: false,
-      description:
-        'For destructive operations when the confirm gate is enabled (MS365_MCP_REQUIRE_CONFIRM=true; off by default). ' +
-        'Set to true only after the user has explicitly approved this action. ' +
-        'When the gate is on, calls without confirm: true return { error: "confirmation_required" } without touching user data.',
+      description: CONFIRM_PARAM_DESCRIPTION,
+      schema: { type: 'boolean' },
+    });
+  }
+
+  // Mirrors registerGraphTools: GET list endpoints get a synthetic fetchAllPages param.
+  if (isFetchAllPagesApplicable({ method: tool.method, path: tool.path })) {
+    params.push({
+      name: 'fetchAllPages',
+      in: 'Query',
+      required: false,
+      description: getFetchAllPagesParamDescription(getMaxPages()),
+      schema: { type: 'boolean' },
+    });
+  }
+
+  // Mirrors registerGraphTools: multi-account mode adds an `account` param to every tool.
+  if (ctx.multiAccount) {
+    params.push({
+      name: 'account',
+      in: 'Query',
+      required: false,
+      description: getAccountParamDescription(ctx.accountNames ?? []),
+      schema: { type: 'string' },
+    });
+  }
+
+  // Mirrors registerGraphTools: calendar endpoints that support it get `timezone`.
+  if (config?.supportsTimezone) {
+    params.push({
+      name: 'timezone',
+      in: 'Query',
+      required: false,
+      description: TIMEZONE_PARAM_DESCRIPTION,
+      schema: { type: 'string' },
+    });
+  }
+
+  // Mirrors registerGraphTools: calendar endpoints that support it get
+  // `expandExtendedProperties`.
+  if (config?.supportsExpandExtendedProperties) {
+    params.push({
+      name: 'expandExtendedProperties',
+      in: 'Query',
+      required: false,
+      description: EXPAND_EXTENDED_PROPERTIES_PARAM_DESCRIPTION,
       schema: { type: 'boolean' },
     });
   }

--- a/test/tool-schema.test.ts
+++ b/test/tool-schema.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from 'vitest';
-import { buildToolsRegistry } from '../src/graph-tools.js';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { buildToolsRegistry, registerGraphTools } from '../src/graph-tools.js';
 import { describeToolSchema } from '../src/lib/tool-schema.js';
+import type { GraphClient } from '../src/graph-client.js';
 
 const registry = buildToolsRegistry(false, true);
 
@@ -8,6 +11,48 @@ function schemaFor(name: string) {
   const entry = registry.get(name);
   if (!entry) throw new Error(`Registry missing ${name}`);
   return describeToolSchema(entry.tool, entry.config);
+}
+
+/**
+ * Registers every Graph tool the same way the non-discovery path does (real
+ * endpoints, real endpoints.json config) and returns each tool's actual
+ * registered Zod param schema, keyed by tool name. Used to assert that
+ * describeToolSchema (--discovery mode) produces IDENTICAL descriptions to
+ * what an agent using normal registration would see — the drift this whole
+ * fix exists to prevent.
+ */
+function registeredParamSchemas(
+  multiAccount = false,
+  accountNames: string[] = []
+): Map<string, Record<string, z.ZodTypeAny>> {
+  const server = new McpServer({ name: 'test', version: '1.0.0' });
+  const graphClient = {} as GraphClient;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- registerTool() has many overloads
+  const registerToolSpy = vi.spyOn(server, 'registerTool').mockImplementation((() => {}) as any);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vi.spyOn(server, 'tool').mockImplementation((() => {}) as any);
+
+  // orgMode: true matches `registry` above (buildToolsRegistry(false, true)) so both
+  // sides see the same set of tools (work-scoped tools included).
+  registerGraphTools(
+    server,
+    graphClient,
+    false,
+    undefined,
+    true,
+    undefined,
+    multiAccount,
+    accountNames
+  );
+
+  const map = new Map<string, Record<string, z.ZodTypeAny>>();
+  for (const call of registerToolSpy.mock.calls) {
+    const name = call[0] as string;
+    const inputSchema = (call[1] as { inputSchema: z.AnyZodObject }).inputSchema;
+    map.set(name, inputSchema.shape as Record<string, z.ZodTypeAny>);
+  }
+  registerToolSpy.mockRestore();
+  return map;
 }
 
 describe('describeToolSchema', () => {
@@ -68,5 +113,138 @@ describe('describeToolSchema', () => {
     if (!entry) return;
     const s = describeToolSchema(entry.tool, entry.config);
     expect(s.parameters.find((p) => p.name === 'confirm')).toBeUndefined();
+  });
+});
+
+/**
+ * Regression coverage for the bug where --discovery mode's get-tool-schema showed
+ * the raw, often-useless Microsoft spec text for OData/synthetic parameters while
+ * normal registration (registerGraphTools) showed spec-gap-guidance overrides —
+ * because the two paths built descriptions independently. Both now pull from
+ * lib/param-descriptions.ts, so these assert EXACT equality against what
+ * registerGraphTools actually puts in its Zod schema, not just "looks similar" —
+ * any future edit to one copy without the other would fail these.
+ */
+describe('describeToolSchema parity with registerGraphTools (discovery-mode drift guard)', () => {
+  const registered = registeredParamSchemas();
+
+  function registeredDescription(toolName: string, paramName: string): string | undefined {
+    const shape = registered.get(toolName);
+    if (!shape) throw new Error(`registerGraphTools did not register ${toolName}`);
+    const schema = shape[paramName];
+    if (!schema) return undefined;
+    return schema.description;
+  }
+
+  it('matches $expand description exactly (the instance Codex originally flagged)', () => {
+    const s = schemaFor('list-mail-messages');
+    const discovery = s.parameters.find((p) => p.name === 'expand' || p.name === '$expand');
+    const expected = registeredDescription('list-mail-messages', 'expand');
+    expect(expected).toBeDefined();
+    expect(expected).not.toMatch(/Expand related entities/);
+    expect(discovery?.description).toBe(expected);
+  });
+
+  it('matches $select description exactly', () => {
+    const s = schemaFor('list-mail-messages');
+    const discovery = s.parameters.find((p) => p.name === 'select' || p.name === '$select');
+    const expected = registeredDescription('list-mail-messages', 'select');
+    expect(expected).toBeDefined();
+    expect(discovery?.description).toBe(expected);
+  });
+
+  it('matches $filter, $search, $orderby, $skip, $count descriptions exactly', () => {
+    const s = schemaFor('list-mail-messages');
+    for (const name of ['filter', 'search', 'orderby', 'skip', 'count']) {
+      const discovery = s.parameters.find((p) => p.name === name || p.name === `$${name}`);
+      const expected = registeredDescription('list-mail-messages', name);
+      expect(expected, `expected registerGraphTools to have a ${name} param`).toBeDefined();
+      expect(discovery?.description, `mismatch for ${name}`).toBe(expected);
+    }
+  });
+
+  it('matches $top description exactly on a tool that supports it', () => {
+    const s = schemaFor('list-mail-messages');
+    const discovery = s.parameters.find((p) => p.name === 'top' || p.name === '$top');
+    const expected = registeredDescription('list-mail-messages', 'top');
+    expect(expected).toBeDefined();
+    expect(discovery?.description).toBe(expected);
+  });
+
+  it('omits $top/top entirely for TOP_UNSUPPORTED_DELTA_TOOLS, matching registration', () => {
+    // registerGraphTools does `delete paramSchema['top']` for these tools (Graph's
+    // event-delta doesn't support $top); discovery mode must omit it too, not just
+    // re-describe it, or an agent would try a parameter that silently does nothing.
+    for (const toolName of ['list-calendar-events-delta', 'list-calendar-view-delta']) {
+      const entry = registry.get(toolName);
+      if (!entry) continue;
+      const s = describeToolSchema(entry.tool, entry.config);
+      expect(s.parameters.find((p) => p.name === 'top' || p.name === '$top')).toBeUndefined();
+
+      const registeredShape = registered.get(toolName);
+      expect(registeredShape).toBeDefined();
+      expect(registeredShape).not.toHaveProperty('top');
+      expect(registeredShape).not.toHaveProperty('$top');
+    }
+  });
+
+  it('matches timezone description exactly for a calendar endpoint that supports it', () => {
+    const entry = registry.get('get-calendar-view');
+    if (!entry) throw new Error('registry missing get-calendar-view');
+    const s = describeToolSchema(entry.tool, entry.config);
+    const discovery = s.parameters.find((p) => p.name === 'timezone');
+    const expected = registeredDescription('get-calendar-view', 'timezone');
+    expect(expected).toBeDefined();
+    expect(discovery?.description).toBe(expected);
+  });
+
+  it('matches expandExtendedProperties description exactly for a calendar endpoint that supports it', () => {
+    const entry = registry.get('get-calendar-view');
+    if (!entry) throw new Error('registry missing get-calendar-view');
+    const s = describeToolSchema(entry.tool, entry.config);
+    const discovery = s.parameters.find((p) => p.name === 'expandExtendedProperties');
+    const expected = registeredDescription('get-calendar-view', 'expandExtendedProperties');
+    expect(expected).toBeDefined();
+    expect(discovery?.description).toBe(expected);
+  });
+
+  it('matches fetchAllPages description exactly for a GET list endpoint', () => {
+    const entry = registry.get('list-mail-messages');
+    if (!entry) throw new Error('registry missing list-mail-messages');
+    const s = describeToolSchema(entry.tool, entry.config);
+    const discovery = s.parameters.find((p) => p.name === 'fetchAllPages');
+    const expected = registeredDescription('list-mail-messages', 'fetchAllPages');
+    expect(expected).toBeDefined();
+    expect(discovery?.description).toBe(expected);
+  });
+
+  it('matches confirm description exactly (already shared logic, guarded against future drift)', () => {
+    const entry = registry.get('delete-mail-message');
+    if (!entry) throw new Error('registry missing delete-mail-message');
+    const s = describeToolSchema(entry.tool, entry.config);
+    const discovery = s.parameters.find((p) => p.name === 'confirm');
+    const expected = registeredDescription('delete-mail-message', 'confirm');
+    expect(expected).toBeDefined();
+    expect(discovery?.description).toBe(expected);
+  });
+
+  it('matches account description exactly in multi-account mode', () => {
+    const accountNames = ['user@outlook.com', 'work@company.com'];
+    const multiRegistered = registeredParamSchemas(true, accountNames);
+    const entry = registry.get('list-mail-messages');
+    if (!entry) throw new Error('registry missing list-mail-messages');
+    const s = describeToolSchema(entry.tool, entry.config, { multiAccount: true, accountNames });
+    const discovery = s.parameters.find((p) => p.name === 'account');
+    const registeredSchema = multiRegistered.get('list-mail-messages')?.['account'];
+    expect(registeredSchema).toBeDefined();
+    expect(discovery?.description).toBe(registeredSchema!.description);
+    expect(discovery?.description).toContain('user@outlook.com');
+  });
+
+  it('does NOT expose account param when multiAccount is false', () => {
+    const entry = registry.get('list-mail-messages');
+    if (!entry) throw new Error('registry missing list-mail-messages');
+    const s = describeToolSchema(entry.tool, entry.config);
+    expect(s.parameters.find((p) => p.name === 'account')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- `--discovery` mode's `get-tool-schema` (`describeToolSchema` in `src/lib/tool-schema.ts`) built parameter descriptions straight from the raw, generated-client parameter list, while normal tool registration (`registerGraphTools` in `src/graph-tools.ts`) rewrites several of the same parameters into spec-gap-guidance text every time a tool is registered. The two paths built the same conceptual thing independently, so `describeToolSchema` was frozen at the raw Microsoft spec text and never picked up any override.
- Codex flagged this for `$expand` on an unrelated PR: Microsoft's spec text ("Expand related entities") tells a model nothing, and a merged fix rewrote it — but only in `registerGraphTools`. `--discovery` mode kept showing the useless text regardless. Auditing the rest of the override block found the same risk on every OData parameter it rewrites (`$filter`, `$search`, `$select`, `$orderby`, `$top`, `$skip`, `$count`), plus several synthetic parameters `describeToolSchema` never surfaced at all (`account`, `timezone`, `expandExtendedProperties`, `fetchAllPages`). `$top` also needed the `TOP_UNSUPPORTED_DELTA_TOOLS` exclusion (registerGraphTools deletes it entirely for two delta tools that don't support it) replicated as an omission, not just a re-description.
- Fix: extracted every override's text plus the associated conditions into a new `src/lib/param-descriptions.ts`, consumed by both `registerGraphTools` and `describeToolSchema` so they cannot independently drift again. Also absorbed the `confirm` param's description (previously two independently-maintained copies of identical text) into the same shared source.
- Verified `describeUtilityToolSchema` (download-bytes, get-download-url, ...) is unaffected — it calls `utility.buildSchema(ctx)` directly, the same closure the non-discovery path already uses.

## Test plan

- [x] `npm ci`
- [x] `npm run generate` (regenerated the Graph client from live Microsoft specs; re-ran build+tests after)
- [x] `npm run build`
- [x] `npm run format:check`
- [x] `npx eslint . --quiet`
- [x] `npx vitest run` — 643/643 tests pass across 51 files
- [x] New tests in `test/tool-schema.test.ts` assert `describeToolSchema`'s output matches, byte-for-byte, what `registerGraphTools` actually registers (via a real `McpServer` spy) for `$expand`, `$select`, `$filter`/`$search`/`$orderby`/`$skip`/`$count`, `$top` (including the delta-tool exclusion), `timezone`, `expandExtendedProperties`, `fetchAllPages`, `confirm`, and `account`
- [x] Manual end-to-end proof: built `dist/index.js`, ran it for real with `--discovery` over stdio via the MCP SDK client, called the real `get-tool-schema` tool:
  - `get-mail-message` → `$expand` now returns the fixed navigation-properties guidance (previously would have been the raw "Expand related entities")
  - `list-calendar-events-delta` → `$top`/`top` correctly absent from the parameter list
  - `get-calendar-view` → `timezone` and `expandExtendedProperties` now present with the same text `registerGraphTools` uses
