### PR TITLE
fix: redact access token from graph-client request logging

### DIFF
--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -314,7 +314,11 @@ class GraphClient {
 
   async graphRequest(endpoint: string, options: GraphRequestOptions = {}): Promise<McpResponse> {
     try {
-      logger.info(`Calling ${endpoint} with options: ${JSON.stringify(options)}`);
+      // Redact accessToken from log output to prevent credential leakage (#601)
+      const { accessToken: _redacted, ...safeOptions } = options;
+      logger.info(
+        `Calling ${endpoint} with options: ${JSON.stringify(safeOptions)}${_redacted ? ' [accessToken=REDACTED]' : ''}`
+      );
 
       // Use new OAuth-aware request method
       const result = await this.makeRequest(endpoint, options);

--- a/test/graph-client-token-redaction.test.ts
+++ b/test/graph-client-token-redaction.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import logger from '../src/logger.js';
+import GraphClient from '../src/graph-client.js';
+import type { AuthManager } from '../src/auth.js';
+import type { AppSecrets } from '../src/secrets.js';
+
+vi.mock('../src/logger.js', () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+const TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.super-secret-token-value';
+
+describe('graphRequest logging (#601)', () => {
+  let client: GraphClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => ({ value: [] }),
+      text: async () => '{"value":[]}',
+    }) as unknown as typeof fetch;
+
+    client = new GraphClient(
+      { getToken: vi.fn().mockResolvedValue(TOKEN) } as unknown as AuthManager,
+      { cloudType: 'public' } as unknown as AppSecrets
+    );
+  });
+
+  function loggedLines(): string[] {
+    return (logger.info as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
+  }
+
+  it('never writes a per-request access token to the log', async () => {
+    await client.graphRequest('/me/todo/lists', { method: 'GET', accessToken: TOKEN });
+
+    const lines = loggedLines();
+    expect(lines.some((l) => l.includes('/me/todo/lists'))).toBe(true);
+    for (const line of lines) {
+      expect(line).not.toContain(TOKEN);
+    }
+  });
+
+  it('marks the redaction so the log still shows a token was passed', async () => {
+    await client.graphRequest('/me/todo/lists', { method: 'GET', accessToken: TOKEN });
+
+    const line = loggedLines().find((l) => l.startsWith('Calling /me/todo/lists'));
+    expect(line).toContain('[accessToken=REDACTED]');
+  });
+
+  it('leaves the message unmarked when no token was passed', async () => {
+    await client.graphRequest('/me/todo/lists', { method: 'GET' });
+
+    const line = loggedLines().find((l) => l.startsWith('Calling /me/todo/lists'));
+    expect(line).not.toContain('REDACTED');
+    expect(line).toContain('"method":"GET"');
+  });
+});


### PR DESCRIPTION
graphRequest stringified the whole options object, so any per-request accessToken landed in the log file at the default info level. The sibling call site in graph-tools.ts already stripped it before logging; this mirrors that treatment.

Fixes #601