### PR TITLE
fix(security): redact PII/tokens in logs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ Environment variables:
 - `MS365_MCP_CLOUD_TYPE=global|china`: Microsoft cloud environment (alternative to --cloud flag)
 - `LOG_LEVEL`: Set logging level (default: 'info')
 - `SILENT=true|1`: Disable console output
-- `MS365_MCP_REDACT_PII=true|1`: Scrub JWTs, Bearer headers, OAuth token fields, and email addresses from log messages before they are written (default: disabled). Useful when logs are shipped to a central store or shared host.
+- `MS365_MCP_REDACT_PII=false|0`: Disable scrubbing of JWTs, Bearer headers, OAuth token fields, and email addresses from log messages (default: enabled). The server handles live Graph bearer tokens, so redaction is on unless you opt out for fully verbose local debugging.
 - `MS365_MCP_CLIENT_ID`: Custom Azure app client ID (defaults to built-in app)
 - `MS365_MCP_TENANT_ID`: Custom tenant ID (defaults to 'common' for multi-tenant). **Personal Microsoft accounts should set this to `consumers`** - as of June 2026, refresh tokens issued via the default 'common' authority are rejected at the first refresh, so sessions die roughly an hour after login
 - `MS365_MCP_OAUTH_TOKEN`: Pre-existing OAuth token for Microsoft Graph API (BYOT method)

--- a/src/lib/log-redactor.ts
+++ b/src/lib/log-redactor.ts
@@ -1,11 +1,13 @@
 /**
- * Opt-in redaction of sensitive material from log output.
+ * Redaction of sensitive material from log output. On by default.
  *
  * Error messages bubbled up from upstream libraries (MSAL, fetch, the Graph
  * SDK) routinely interpolate request URLs, Authorization headers, and token
  * payloads into their message strings. When those land in a log file or the
- * console they expose bearer/refresh tokens and user identifiers. Enabling
- * `MS365_MCP_REDACT_PII` runs each log message through the patterns below.
+ * console they expose bearer/refresh tokens and user identifiers, and this
+ * server necessarily handles live Graph bearer tokens with mail/calendar/
+ * contacts read-write scopes. Every log message is run through the patterns
+ * below unless an operator explicitly opts out with `MS365_MCP_REDACT_PII=false`.
  *
  * Patterns are intentionally generic (JWTs, Bearer headers, OAuth token
  * fields, email addresses) — no jurisdiction-specific identifiers — so the
@@ -52,10 +54,14 @@ const REDACTIONS: RedactionPattern[] = [
   },
 ];
 
-/** Whether opt-in PII redaction is enabled via MS365_MCP_REDACT_PII=true|1. */
+/**
+ * Whether PII/secret redaction is enabled. On by default; set
+ * MS365_MCP_REDACT_PII=false|0 to opt out and get fully verbose logs.
+ */
 export function redactionEnabled(): boolean {
   const raw = process.env.MS365_MCP_REDACT_PII;
-  return raw === 'true' || raw === '1';
+  if (raw === undefined) return true;
+  return raw !== 'false' && raw !== '0';
 }
 
 /** Applies every redaction pattern to `input` and returns the scrubbed string. */

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -5,9 +5,9 @@ import fs from 'fs';
 import os from 'os';
 import { redactionEnabled, redactSensitive } from './lib/log-redactor.js';
 
-// Opt-in PII/secret redaction (MS365_MCP_REDACT_PII). Runs before the printf
-// so both file and console transports emit scrubbed messages. No-op unless
-// enabled, so default behaviour is unchanged.
+// PII/secret redaction (MS365_MCP_REDACT_PII), on by default. Runs before
+// the printf so both file and console transports emit scrubbed messages.
+// Set MS365_MCP_REDACT_PII=false to opt out and get fully verbose logs.
 const redactFormat = winston.format((info) => {
   if (!redactionEnabled()) return info;
   if (typeof info.message === 'string') {

--- a/test/log-redactor.test.ts
+++ b/test/log-redactor.test.ts
@@ -74,9 +74,9 @@ describe('redactionEnabled', () => {
     else process.env.MS365_MCP_REDACT_PII = prev;
   });
 
-  it('is off by default', () => {
+  it('is on by default', () => {
     delete process.env.MS365_MCP_REDACT_PII;
-    expect(redactionEnabled()).toBe(false);
+    expect(redactionEnabled()).toBe(true);
   });
 
   it('is on for "true" and "1"', () => {
@@ -86,8 +86,15 @@ describe('redactionEnabled', () => {
     expect(redactionEnabled()).toBe(true);
   });
 
-  it('is off for any other value', () => {
-    process.env.MS365_MCP_REDACT_PII = 'yes';
+  it('is off for "false" and "0"', () => {
+    process.env.MS365_MCP_REDACT_PII = 'false';
     expect(redactionEnabled()).toBe(false);
+    process.env.MS365_MCP_REDACT_PII = '0';
+    expect(redactionEnabled()).toBe(false);
+  });
+
+  it('is on for any other value', () => {
+    process.env.MS365_MCP_REDACT_PII = 'yes';
+    expect(redactionEnabled()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

`MS365_MCP_REDACT_PII` defaulted to off. That means every Graph API request logged its full options object — including the live OAuth bearer token — to the log file in plaintext, unless an operator explicitly opted in. The redaction logic (JWTs, `Authorization: Bearer` headers, OAuth token fields, auth codes, email addresses) already existed and is wired into the winston logger; it just never ran unless `MS365_MCP_REDACT_PII=true|1` was set.

This server necessarily handles live Microsoft Graph bearer tokens with mail/calendar/contacts read-write scopes, so logging should be secure-by-default with an explicit opt-out, not an opt-in.

## What changed

- `redactionEnabled()` in `src/lib/log-redactor.ts` now returns `true` unless `MS365_MCP_REDACT_PII` is explicitly set to `false` or `0`.
- Updated the doc comments in `src/lib/log-redactor.ts` and `src/logger.ts` to describe the new default.
- Updated `README.md`'s env var table entry for `MS365_MCP_REDACT_PII` to reflect the new default and the opt-out.
- Updated `test/log-redactor.test.ts` to assert the new default (on when unset, off for `false`/`0`, on for anything else).

## Opting out

Operators who want fully verbose logs for local debugging can set `MS365_MCP_REDACT_PII=false` (or `0`).

## Test plan

- [x] `npm run generate && npm run lint && npm run format:check && npm run build && npm test` all pass (660/660 tests, 0 lint errors)
- [x] `test/log-redactor.test.ts` covers unset (redact on), `true`/`1` (on), `false`/`0` (off), and any other value (on)
