### PR TITLE
fix(sharepoint): use documented colon route for get-sharepoint-site-by-path

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1944,11 +1944,13 @@
     "llmTip": "Deletes a column from a SharePoint list. This is irreversible — all data stored in this column across every list item is lost. Confirm with the user before calling. Cannot delete built-in columns (Title, Created, Modified, etc.)."
   },
   {
-    "pathPattern": "/sites/{site-id}/getByPath(path='{path}')",
+    "pathPattern": "/sites/{site-id}:/{path}",
     "method": "get",
     "toolName": "get-sharepoint-site-by-path",
     "presets": ["work"],
-    "workScopes": ["Sites.Read.All"]
+    "workScopes": ["Sites.Read.All"],
+    "skipEncoding": ["path"],
+    "llmTip": "Resolve a SharePoint site from its server-relative URL. site-id is the hostname (contoso.sharepoint.com) and path is the site path without a leading slash (sites/marketing, teams/hr). Returns the site object whose id feeds list-sharepoint-site-drives."
   },
   {
     "pathPattern": "/sites/delta()",

--- a/test/sharepoint-site-by-path.test.ts
+++ b/test/sharepoint-site-by-path.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import { registerGraphTools } from '../src/graph-tools.js';
+import type { GraphClient } from '../src/graph-client.js';
+
+vi.mock('../src/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('../src/generated/client-beta.js', () => ({ api: { endpoints: [] } }));
+
+// Mirrors what `npm run generate` emits for this endpoint: the synthesized
+// operation carries both path params, because the colon-addressing path is not
+// in Microsoft's published OpenAPI metadata.
+vi.mock('../src/generated/client.js', () => ({
+  api: {
+    endpoints: [
+      {
+        alias: 'get-sharepoint-site-by-path',
+        method: 'get',
+        path: '/sites/:siteId:/:path',
+        description: 'Resolve a SharePoint site from its server-relative URL.',
+        parameters: [
+          { name: 'siteId', type: 'Path', schema: z.string() },
+          { name: 'path', type: 'Path', schema: z.string() },
+        ],
+      },
+    ],
+  },
+}));
+
+const endpointsPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'src',
+  'endpoints.json'
+);
+const endpoints = JSON.parse(readFileSync(endpointsPath, 'utf8')) as Array<{
+  toolName: string;
+  pathPattern: string;
+  skipEncoding?: string[];
+}>;
+
+describe('get-sharepoint-site-by-path', () => {
+  const entry = endpoints.find((e) => e.toolName === 'get-sharepoint-site-by-path')!;
+
+  it('uses the documented v1.0 colon-addressing route, not the getByPath function', () => {
+    // GET /sites/{hostname}:/{relative-path} per
+    // https://learn.microsoft.com/graph/api/site-getbypath
+    // The OData function form `/sites/{site-id}/getByPath(path='{path}')` is in the
+    // CSDL metadata but returns 400 "Error in query syntax" against v1.0.
+    expect(entry.pathPattern).toBe('/sites/{site-id}:/{path}');
+    expect(entry.pathPattern).not.toContain('getByPath');
+  });
+
+  it('declares skipEncoding for path so the relative path keeps its separators', () => {
+    expect(entry.skipEncoding).toContain('path');
+  });
+
+  describe('URL construction', () => {
+    let mockServer: { tool: ReturnType<typeof vi.fn>; registerTool: ReturnType<typeof vi.fn> };
+    let mockGraphClient: GraphClient;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mockServer = { tool: vi.fn(), registerTool: vi.fn() };
+      mockGraphClient = {
+        graphRequest: vi.fn().mockResolvedValue({
+          content: [{ type: 'text', text: JSON.stringify({ id: 'site-id' }) }],
+        }),
+      } as unknown as GraphClient;
+    });
+
+    function getToolHandler(toolName: string) {
+      // orgMode (5th arg) must be true: this endpoint declares only workScopes,
+      // so it is skipped entirely in personal mode.
+      registerGraphTools(mockServer, mockGraphClient, false, undefined, true);
+      const call = mockServer.registerTool.mock.calls.find((c: unknown[]) => c[0] === toolName);
+      expect(call).toBeDefined();
+      return call![call!.length - 1] as (params: Record<string, unknown>) => Promise<unknown>;
+    }
+
+    it('builds /sites/{hostname}:/{relative-path} without percent-encoding the separators', async () => {
+      const handler = getToolHandler('get-sharepoint-site-by-path');
+
+      await handler({ siteId: 'contoso.sharepoint.com', path: 'sites/marketing' });
+
+      const calledPath = (mockGraphClient.graphRequest as ReturnType<typeof vi.fn>).mock
+        .calls[0][0] as string;
+      expect(calledPath).toContain('/sites/contoso.sharepoint.com:/sites/marketing');
+      // The regression this guards: encodeURIComponent turning the relative path
+      // into %2Fsites%2Fmarketing, which Graph rejects.
+      expect(calledPath).not.toContain('%2F');
+    });
+
+    it('handles a nested site path', async () => {
+      const handler = getToolHandler('get-sharepoint-site-by-path');
+
+      await handler({ siteId: 'contoso.sharepoint.com', path: 'teams/hr/benefits' });
+
+      const calledPath = (mockGraphClient.graphRequest as ReturnType<typeof vi.fn>).mock
+        .calls[0][0] as string;
+      expect(calledPath).toContain('/sites/contoso.sharepoint.com:/teams/hr/benefits');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #606.

`get-sharepoint-site-by-path` returns `400 Bad Request - Error in query syntax` for every parameter shape, so the tool can never succeed. Two independent defects, both fixed by one `endpoints.json` change.

## 1. The route form

The endpoint was generated from the OData function in the CSDL metadata:

```
/sites/{site-id}/getByPath(path='{path}')
```

[Get a site resource by path](https://learn.microsoft.com/graph/api/site-getbypath?view=graph-rest-1.0) documents the v1.0 request as colon addressing:

```http
GET /sites/{hostname}:/{relative-path}
```

`pathPattern` now points at that form.

## 2. Missing `parameters` → path separators percent-encoded

This one is independent and would still bite on a working route.

`get-sharepoint-site-by-path` was the only one of its neighbours generated **without** a `parameters` array:

| alias | had `parameters` |
|---|---|
| `get-sharepoint-site` | yes |
| `list-sharepoint-site-drives` | yes |
| `get-sharepoint-site-by-path` | **no** |

With `parameterDefinitions = tool.parameters || []` empty, `paramDef` is `undefined` and both params fall through to the untyped fallback in `executeGraphTool`, which `encodeURIComponent`s them — so the relative path became `%2Fsites%2Fmarketing` *inside the OData string literal*.

Because the colon path is absent from Microsoft's published spec, the generator's existing synthesis branch in `simplified-openapi.mjs` now supplies the operation, and derives both path params from the `{...}` placeholders. Regenerating produces:

```js
{
  method: 'get',
  path: '/sites/:siteId:/:path',
  alias: 'get-sharepoint-site-by-path',
  parameters: [
    { name: 'siteId', type: 'Path', schema: z.string().describe('Path parameter: site-id') },
    { name: 'path',   type: 'Path', schema: z.string().describe('Path parameter: path') },
  ],
}
```

Typed `Path` params alone still encode, so the change adds `"skipEncoding": ["path"]` — the same mechanism already used for `address` and `q`.

## Verification

- `npm run generate` → the entry regenerates with both typed path params (shown above).
- `npm test` → **664 passed** (660 existing + 4 new). `npm run lint` clean (warnings pre-existing), `npm run format:check` clean.
- New `test/sharepoint-site-by-path.test.ts` pins both halves: that `pathPattern` is the colon form and never contains `getByPath`, and that the built URL is `/sites/contoso.sharepoint.com:/sites/marketing` with no `%2F`.
- **Negative control** — dropping `skipEncoding` makes the new tests fail with exactly the old broken URL, so the test isn't vacuous:
  ```
  Received: "/sites/contoso.sharepoint.com:/sites%2Fmarketing"
  ```

What I could **not** verify: a live Graph call through a patched build, which needs a full OAuth flow against a modified deployment. What I did confirm against live Graph (v1.0, `Sites.Read.All`, org mode) is that colon addressing resolves the site while the `getByPath` form fails — `get-sharepoint-site` with a composite `hostname:/sites/<name>` id returns 200 for the same site that yields `Error in query syntax` through this tool, across four parameter shapes with four distinct Graph request-ids.

## Known limitation

`path` is expected without a leading slash (`sites/marketing`, not `/sites/marketing`); a leading slash produces `:://` and would fail. The added `llmTip` states the expected shape. Normalising it would mean touching `executeGraphTool` rather than config, so I left it out of this PR — happy to add it if you'd prefer the tool be lenient.

If you'd rather drop the tool entirely — `get-sharepoint-site` with a composite id already covers path lookup — say so and I'll swap this for a removal.
