### PR TITLE
feat: support Sites.Selected for direct SharePoint tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,21 @@ CLI value takes precedence over `MS365_MCP_ALLOWED_SCOPES`; if neither is set, t
 
 Scope coverage is hierarchy-aware: for example, `Mail.ReadWrite` covers tools that require `Mail.Read`, and `Files.ReadWrite.All` covers tools that require `Files.Read`.
 
+SharePoint supports two enterprise permission models:
+
+- Broad tenant scopes such as `Sites.Read.All`, `Sites.ReadWrite.All`, and `Sites.Manage.All`.
+- Microsoft Graph `Sites.Selected`, where SharePoint site access is granted to the app on specific site collections and Graph evaluates the signed-in user's own permissions at request time.
+
+The default org-mode behavior continues to request the broad SharePoint scopes used by existing deployments. Enterprises that want selected-site SharePoint access can set an allowlist containing `Sites.Selected` instead of broad `Sites.*.All` scopes. Direct site/list/item tools that target an explicit SharePoint site can run with `Sites.Selected`; tenant-wide SharePoint discovery and search tools still require broad SharePoint scopes.
+
+```bash
+npx @softeria/ms-365-mcp-server \
+  --org-mode \
+  --read-only \
+  --enabled-tools 'sharepoint|site|drive|planner' \
+  --allowed-scopes 'User.Read Files.Read Notes.Read Tasks.Read Sites.Selected'
+```
+
 In HTTP mode, OAuth discovery advertises the effective filtered permissions so clients request the same consent surface. On-Behalf-Of mode (`--obo`) still advertises `api://<clientId>/access_as_user` for protected-resource metadata; `--allowed-scopes` does not override OBO.
 
 ### Requesting extra scopes

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1811,56 +1811,56 @@
     "method": "get",
     "toolName": "get-sharepoint-site",
     "presets": ["work"],
-    "workScopes": ["Sites.Read.All"]
+    "workScopes": [["Sites.Read.All"], ["Sites.Selected"]]
   },
   {
     "pathPattern": "/sites/{site-id}/drives",
     "method": "get",
     "toolName": "list-sharepoint-site-drives",
     "presets": ["work"],
-    "workScopes": ["Sites.Read.All"]
+    "workScopes": [["Sites.Read.All"], ["Sites.Selected"]]
   },
   {
     "pathPattern": "/sites/{site-id}/drives/{drive-id}",
     "method": "get",
     "toolName": "get-sharepoint-site-drive-by-id",
     "presets": ["work"],
-    "workScopes": ["Sites.Read.All"]
+    "workScopes": [["Sites.Read.All"], ["Sites.Selected"]]
   },
   {
     "pathPattern": "/sites/{site-id}/items",
     "method": "get",
     "toolName": "list-sharepoint-site-items",
     "presets": ["work"],
-    "workScopes": ["Sites.Read.All"]
+    "workScopes": [["Sites.Read.All"], ["Sites.Selected"]]
   },
   {
     "pathPattern": "/sites/{site-id}/items/{baseItem-id}",
     "method": "get",
     "toolName": "get-sharepoint-site-item",
     "presets": ["work"],
-    "workScopes": ["Sites.Read.All"]
+    "workScopes": [["Sites.Read.All"], ["Sites.Selected"]]
   },
   {
     "pathPattern": "/sites/{site-id}/lists",
     "method": "get",
     "toolName": "list-sharepoint-site-lists",
     "presets": ["work"],
-    "workScopes": ["Sites.Read.All"]
+    "workScopes": [["Sites.Read.All"], ["Sites.Selected"]]
   },
   {
     "pathPattern": "/sites/{site-id}/lists/{list-id}",
     "method": "get",
     "toolName": "get-sharepoint-site-list",
     "presets": ["work"],
-    "workScopes": ["Sites.Read.All"]
+    "workScopes": [["Sites.Read.All"], ["Sites.Selected"]]
   },
   {
     "pathPattern": "/sites/{site-id}/lists/{list-id}/items",
     "method": "get",
     "toolName": "list-sharepoint-site-list-items",
     "presets": ["work"],
-    "workScopes": ["Sites.Read.All"],
+    "workScopes": [["Sites.Read.All"], ["Sites.Selected"]],
     "llmTip": "Add $expand=fields to include actual column values. Without it, only metadata is returned."
   },
   {
@@ -1868,7 +1868,7 @@
     "method": "get",
     "toolName": "get-sharepoint-site-list-item",
     "presets": ["work"],
-    "workScopes": ["Sites.Read.All"],
+    "workScopes": [["Sites.Read.All"], ["Sites.Selected"]],
     "llmTip": "Add $expand=fields to include actual column values. Without it, only metadata is returned."
   },
   {
@@ -1876,7 +1876,7 @@
     "method": "post",
     "toolName": "create-sharepoint-list-item",
     "presets": ["work"],
-    "workScopes": ["Sites.ReadWrite.All"],
+    "workScopes": [["Sites.ReadWrite.All"], ["Sites.Selected"]],
     "llmTip": "Creates a new item in a SharePoint list. Body: { fields: { Title: 'Item name', ColumnName: 'value', ... } }. Use list-sharepoint-site-lists to find the list ID and get-sharepoint-site-list to discover available columns."
   },
   {
@@ -1884,7 +1884,7 @@
     "method": "patch",
     "toolName": "update-sharepoint-list-item",
     "presets": ["work"],
-    "workScopes": ["Sites.ReadWrite.All"],
+    "workScopes": [["Sites.ReadWrite.All"], ["Sites.Selected"]],
     "llmTip": "Updates fields on an existing list item. Body: { fields: { ColumnName: 'new value' } }. Send only the fields you want to change. Use $expand=fields on get-sharepoint-site-list-item to see current values first."
   },
   {
@@ -1892,7 +1892,7 @@
     "method": "delete",
     "toolName": "delete-sharepoint-list-item",
     "presets": ["work"],
-    "workScopes": ["Sites.ReadWrite.All"],
+    "workScopes": [["Sites.ReadWrite.All"], ["Sites.Selected"]],
     "llmTip": "Deletes a list item permanently. This cannot be undone — the item is moved to the site recycle bin."
   },
   {
@@ -1900,7 +1900,7 @@
     "method": "post",
     "toolName": "create-sharepoint-list",
     "presets": ["work"],
-    "workScopes": ["Sites.Manage.All"],
+    "workScopes": [["Sites.Manage.All"], ["Sites.Selected"]],
     "llmTip": "Creates a new SharePoint list in a site. Body: { displayName: 'My List', description: 'Optional', list: { template: 'genericList' }, columns: [ { name: 'Status', text: {} }, { name: 'Due', dateTime: {} } ] }. Templates include genericList, documentLibrary, tasks, calendar, contacts, links, announcements, survey. Columns can be defined inline at creation; otherwise add them later via create-sharepoint-list-column. Use search-sharepoint-sites or get-sharepoint-site-by-path to find the site ID first."
   },
   {
@@ -1908,7 +1908,7 @@
     "method": "get",
     "toolName": "list-sharepoint-list-columns",
     "presets": ["work"],
-    "workScopes": ["Sites.Read.All"],
+    "workScopes": [["Sites.Read.All"], ["Sites.Selected"]],
     "llmTip": "Lists column definitions for a SharePoint list. Returns each column's id, name, displayName, description, type indicator (text, number, choice, dateTime, person, lookup, boolean, calculated, hyperlinkOrPicture, etc.), required, indexed, hidden, readOnly. Use this to discover the schema before creating or updating list items."
   },
   {
@@ -1916,7 +1916,7 @@
     "method": "post",
     "toolName": "create-sharepoint-list-column",
     "presets": ["work"],
-    "workScopes": ["Sites.Manage.All"],
+    "workScopes": [["Sites.Manage.All"], ["Sites.Selected"]],
     "llmTip": "Creates a new column on a SharePoint list. Body must include name and exactly one column type property: { name: 'Priority', text: {} } or { name: 'DueDate', dateTime: { format: 'dateOnly' } } or { name: 'Status', choice: { choices: ['Open','In Progress','Done'] } }. Other types: number, boolean, currency, hyperlinkOrPicture, personOrGroup, lookup, calculated. Optional: displayName, description, required, indexed, enforceUniqueValues."
   },
   {
@@ -1924,7 +1924,7 @@
     "method": "get",
     "toolName": "get-sharepoint-list-column",
     "presets": ["work"],
-    "workScopes": ["Sites.Read.All"],
+    "workScopes": [["Sites.Read.All"], ["Sites.Selected"]],
     "llmTip": "Gets a specific column definition by ID, including its full type configuration (choices for choice columns, format for dateTime, etc.). Use list-sharepoint-list-columns first to find the column ID."
   },
   {
@@ -1932,7 +1932,7 @@
     "method": "patch",
     "toolName": "update-sharepoint-list-column",
     "presets": ["work"],
-    "workScopes": ["Sites.Manage.All"],
+    "workScopes": [["Sites.Manage.All"], ["Sites.Selected"]],
     "llmTip": "Updates a column definition. Body: { displayName: 'New name', description: 'New description', required: true, ... }. The column type itself (text, choice, etc.) cannot be changed — only its metadata and per-type options (e.g. choices array for a choice column). Send only the fields you want to change."
   },
   {
@@ -1940,7 +1940,7 @@
     "method": "delete",
     "toolName": "delete-sharepoint-list-column",
     "presets": ["work"],
-    "workScopes": ["Sites.Manage.All"],
+    "workScopes": [["Sites.Manage.All"], ["Sites.Selected"]],
     "llmTip": "Deletes a column from a SharePoint list. This is irreversible — all data stored in this column across every list item is lost. Confirm with the user before calling. Cannot delete built-in columns (Title, Created, Modified, etc.)."
   },
   {
@@ -1948,7 +1948,7 @@
     "method": "get",
     "toolName": "get-sharepoint-site-by-path",
     "presets": ["work"],
-    "workScopes": ["Sites.Read.All"]
+    "workScopes": [["Sites.Read.All"], ["Sites.Selected"]]
   },
   {
     "pathPattern": "/sites/delta()",

--- a/test/or-group-scopes.test.ts
+++ b/test/or-group-scopes.test.ts
@@ -108,3 +108,82 @@ describe('copilot-retrieve login + gate (real endpoints.json)', () => {
     expect(scopes).not.toContain('ExternalItem.Read.All');
   });
 });
+
+describe('Sites.Selected SharePoint login + gate (real endpoints.json)', () => {
+  const effective = (allowedScopes?: string, enabledTools = '^get-sharepoint-site$') =>
+    resolveAuthScopes({
+      orgMode: true,
+      readOnly: true,
+      enabledTools,
+      allowedScopes,
+    });
+
+  const disabledTool = (toolName: string, allowedScopes: string) =>
+    buildAllowedScopeDiagnostics({
+      orgMode: true,
+      readOnly: true,
+      enabledTools: `^${toolName}$`,
+      allowedScopes,
+    }).disabledTools.find((t) => t.toolName === toolName);
+
+  it('keeps broad SharePoint scopes as the default login group', () => {
+    const scopes = effective();
+
+    expect(scopes).toEqual(['Sites.Read.All']);
+    expect(scopes).not.toContain('Sites.Selected');
+  });
+
+  it('keeps existing broad-scope deployments enabled', () => {
+    expect(disabledTool('get-sharepoint-site', 'Sites.Read.All')).toBeUndefined();
+    expect(effective('Sites.Read.All')).toEqual(['Sites.Read.All']);
+  });
+
+  it('enables direct SharePoint site tools with selected-site scopes', () => {
+    const scopes = effective('Sites.Selected');
+
+    expect(disabledTool('get-sharepoint-site', 'Sites.Selected')).toBeUndefined();
+    expect(scopes).toEqual(['Sites.Selected']);
+  });
+
+  it('enables selected-site read-only SharePoint tools without requesting broad scopes', () => {
+    const diagnostics = buildAllowedScopeDiagnostics({
+      orgMode: true,
+      readOnly: true,
+      enabledTools:
+        '^(get-sharepoint-site|list-sharepoint-site-drives|get-sharepoint-site-list|get-sharepoint-list-column)$',
+      allowedScopes: 'Sites.Selected',
+    });
+
+    expect(diagnostics.disabledTools).toEqual([]);
+    expect(diagnostics.effectivePermissions).toEqual(['Sites.Selected']);
+    expect(diagnostics.effectivePermissions).not.toContain('Sites.Read.All');
+  });
+
+  it('leaves tenant-wide SharePoint discovery disabled without broad scopes', () => {
+    for (const toolName of [
+      'search-sharepoint-sites',
+      'get-sharepoint-sites-delta',
+      'list-trending-insights',
+    ]) {
+      const disabled = disabledTool(toolName, 'Sites.Selected');
+
+      expect(disabled, toolName).toBeDefined();
+      expect(disabled?.missingScopes, toolName).toContain('Sites.Read.All');
+    }
+  });
+
+  it('leaves Microsoft Search disabled for SharePoint search without broad scopes', () => {
+    const coreSearchScopes = [
+      'Mail.Read',
+      'Calendars.Read',
+      'Files.Read.All',
+      'People.Read',
+      'Chat.Read',
+      'ChannelMessage.Read.All',
+    ].join(' ');
+    const disabled = disabledTool('search-query', `${coreSearchScopes} Sites.Selected`);
+
+    expect(disabled).toBeDefined();
+    expect(disabled?.missingScopes).toContain('Sites.Read.All');
+  });
+});


### PR DESCRIPTION
## What changed

This adds support for using `Sites.Selected` with the direct SharePoint tools. Softeria's `--allowed-scopes` feature exists precisely for enterprise deployments, and `Sites.Selected` is a standard Microsoft least-privilege pattern. This is a gap in the current codebase.

The main use case is tenants that do not want to grant broad SharePoint permissions like `Sites.Read.All`, but still want the MCP server to work against specific SharePoint sites that have been approved for the app.

Existing broad-scope setups should keep working as they do today. I’ve left those as the default login path.

## A couple of details

This only applies to direct SharePoint site/list/item/column tools, where the caller already knows which site they want to work with.

Search and tenant-wide discovery tools still require the broader SharePoint scopes, because `Sites.Selected` does not give the app a tenant-wide site search surface.

## Checked

- `npm run generate`
- `npm test -- --run test/or-group-scopes.test.ts test/scope-derivation.test.ts test/endpoints-validation.test.ts`
- `npm run format:check`
- `npm run build`
- `npm run lint`
- `npm test`