### PR TITLE
feat: only read app-registration config from .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
 # Microsoft 365 OAuth Configuration
 # Create an Azure AD app registration and get these values:
+#
+# NOTE: .env is read from the directory the server is started in, which the MCP
+# client picks. Only the four variables below are read from it. Everything else
+# (token cache paths, the auth-cache command, Key Vault, logging, HTTP settings)
+# must be set in your shell or MCP client config.
 
 # Your Azure AD App Registration Client ID
 MS365_MCP_CLIENT_ID=your-azure-ad-app-client-id-here
@@ -38,7 +43,8 @@ MS365_MCP_TENANT_ID=common
 # When set, secrets are fetched from Azure Key Vault instead of environment variables.
 # This is useful for production deployments, especially with Azure Container Apps.
 #
-# MS365_MCP_KEYVAULT_URL=https://your-keyvault-name.vault.azure.net
+# Not read from .env - export MS365_MCP_KEYVAULT_URL in the environment instead:
+#   export MS365_MCP_KEYVAULT_URL=https://your-keyvault-name.vault.azure.net
 #
 # Key Vault secret names (store these in your Key Vault):
 #   - ms365-mcp-client-id     (required)
@@ -58,8 +64,10 @@ MS365_MCP_TENANT_ID=common
 # -------------------------------------------------------------------
 # Headless local-MSAL deployments can store token-cache and selected-account
 # metadata with a provider-neutral executable wrapper. The value is a real
-# executable path, not a shell command string; put any provider-specific args
-# inside the wrapper script.
+# executable path (absolute), not a shell command string; put any
+# provider-specific args inside the wrapper script.
 #
-# MS365_MCP_AUTH_CACHE_COMMAND=/path/to/ms365-auth-cache-store
-# MS365_MCP_AUTH_CACHE_COMMAND_TIMEOUT_MS=10000
+# This one starts a process, so it is deliberately NOT read from .env. Export it
+# in the environment that launches the server:
+#   export MS365_MCP_AUTH_CACHE_COMMAND=/path/to/ms365-auth-cache-store
+#   export MS365_MCP_AUTH_CACHE_COMMAND_TIMEOUT_MS=10000

--- a/README.md
+++ b/README.md
@@ -440,6 +440,11 @@ registration:
 
 With these configured, the server will use your custom Azure app instead of the built-in one.
 
+> **Note**: `.env` is read from the directory the server is started in, and the MCP client decides what
+> that is. Only `MS365_MCP_CLIENT_ID`, `MS365_MCP_CLIENT_SECRET`, `MS365_MCP_TENANT_ID` and
+> `MS365_MCP_CLOUD_TYPE` are read from it. Every other variable listed above must be set in your shell
+> or MCP client config; anything else found in a `.env` is ignored with a warning on stderr.
+
 #### 3. Bring Your Own Token (BYOT)
 
 If you are running ms-365-mcp-server as part of a larger system that manages Microsoft OAuth tokens externally, you can

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import 'dotenv/config';
+import { loadEnvFile } from './load-env.js';
 import { parseArgs } from './cli.js';
 import logger from './logger.js';
 import AuthManager, { buildAllowedScopeDiagnostics, resolveAuthScopes } from './auth.js';
@@ -40,6 +40,8 @@ process.on('uncaughtException', (err, origin) => {
 
 async function main(): Promise<void> {
   try {
+    loadEnvFile();
+
     const args = parseArgs();
 
     const includeWorkScopes = args.orgMode || false;

--- a/src/load-env.ts
+++ b/src/load-env.ts
@@ -1,0 +1,84 @@
+/**
+ * Loads a project-local `.env`, but only for plain app config.
+ *
+ * dotenv reads `.env` from `process.cwd()`. For an MCP server that directory is
+ * whatever folder the client happened to launch us in, not necessarily one the
+ * operator controls - clients commonly pass the open workspace through as cwd.
+ * A blanket load therefore lets any file sitting in that folder set *any* of the
+ * server's environment variables, including ones that run a command at startup,
+ * relocate the token cache, or switch off log redaction.
+ *
+ * So the allowlist below is deliberately small: credentials for a custom app
+ * registration, which is all `.env` was ever documented for. Everything else has
+ * to come from the real environment (shell or MCP client config), where only the
+ * operator can set it.
+ *
+ * See GHSA-9w34-3f56-vwmh.
+ */
+
+import { parse } from 'dotenv';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const ENV_FILE_ALLOWLIST = [
+  'MS365_MCP_CLIENT_ID',
+  'MS365_MCP_CLIENT_SECRET',
+  'MS365_MCP_TENANT_ID',
+  'MS365_MCP_CLOUD_TYPE',
+];
+
+export interface LoadEnvFileResult {
+  /** Allowlisted keys taken from the file. */
+  applied: string[];
+  /** Keys present in the file that were refused. */
+  ignored: string[];
+}
+
+export function loadEnvFile(options: { path?: string } = {}): LoadEnvFileResult {
+  // parse() rather than config(): it is a pure text-to-pairs function, so the
+  // file can only ever become key/value pairs. config() decides some of its own
+  // behaviour from the very file we distrust - a DOTENV_CONFIG_DEBUG line inside
+  // .env turns its logging back on and it writes to stdout, which is the
+  // JSON-RPC channel in stdio mode - and it also resolves .env.vault from cwd.
+  const file = options.path ?? path.resolve(process.cwd(), '.env');
+  let fromFile: Record<string, string> = {};
+  try {
+    fromFile = parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    // No .env here, or unreadable. Nothing to apply.
+  }
+
+  const applied: string[] = [];
+  const ignored: string[] = [];
+
+  for (const [key, value] of Object.entries(fromFile)) {
+    if (!ENV_FILE_ALLOWLIST.includes(key)) {
+      ignored.push(key);
+      continue;
+    }
+    // Anything already set came from the operator, so it wins - same precedence
+    // dotenv itself uses.
+    if (process.env[key] !== undefined) {
+      continue;
+    }
+    process.env[key] = value;
+    applied.push(key);
+  }
+
+  // Only our own variables: the advice below does not apply to a DATABASE_URL
+  // that happens to share the file, and naming unrelated secrets on every
+  // startup helps nobody.
+  const ignoredOwn = ignored.filter((key) => key.startsWith('MS365_MCP_'));
+  if (ignoredOwn.length > 0) {
+    // Key names only, never values: a .env is exactly where secrets live.
+    // stderr because stdout is the MCP transport, and the file logger is
+    // invisible in stdio mode.
+    console.error(
+      `[ms365-mcp] Ignored ${ignoredOwn.length} variable(s) from .env: ${[...ignoredOwn].sort().join(', ')}. ` +
+        `Only ${ENV_FILE_ALLOWLIST.join(', ')} are read from .env - ` +
+        `set anything else in your shell or MCP client config.`
+    );
+  }
+
+  return { applied, ignored };
+}

--- a/src/token-cache-storage.ts
+++ b/src/token-cache-storage.ts
@@ -391,6 +391,13 @@ function parseTimeoutMs(value: string | undefined): number {
 }
 
 async function assertCommandUsable(commandPath: string): Promise<void> {
+  // A relative path resolves against cwd, which the client picks and the
+  // operator may never have looked at. Require an absolute one so the value
+  // names a specific executable rather than "whatever is in the current folder".
+  if (!path.isAbsolute(commandPath)) {
+    throw new Error(`${AUTH_CACHE_COMMAND_ENV} must be an absolute path.`);
+  }
+
   let stats: fs.Stats;
   try {
     stats = await fs.promises.stat(commandPath);

--- a/test/load-env.test.ts
+++ b/test/load-env.test.ts
@@ -1,0 +1,162 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ENV_FILE_ALLOWLIST, loadEnvFile } from '../src/load-env.js';
+
+const tempDirs: string[] = [];
+
+function writeEnvFile(contents: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms365-load-env-'));
+  tempDirs.push(dir);
+  const file = path.join(dir, '.env');
+  fs.writeFileSync(file, contents);
+  return file;
+}
+
+describe('loadEnvFile', () => {
+  let originalEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, originalEnv);
+    vi.restoreAllMocks();
+    while (tempDirs.length > 0) {
+      fs.rmSync(tempDirs.pop()!, { recursive: true, force: true });
+    }
+  });
+
+  it('applies allowlisted keys', () => {
+    delete process.env.MS365_MCP_CLIENT_ID;
+    const file = writeEnvFile('MS365_MCP_CLIENT_ID=from-file\n');
+
+    const result = loadEnvFile({ path: file });
+
+    expect(process.env.MS365_MCP_CLIENT_ID).toBe('from-file');
+    expect(result.applied).toEqual(['MS365_MCP_CLIENT_ID']);
+    expect(result.ignored).toEqual([]);
+  });
+
+  // GHSA-9w34-3f56-vwmh: a .env in the launch directory used to be able to set
+  // this, which the server then spawned at startup.
+  it('does not let .env set the auth cache command', () => {
+    delete process.env.MS365_MCP_AUTH_CACHE_COMMAND;
+    const file = writeEnvFile('MS365_MCP_AUTH_CACHE_COMMAND=./evil.sh\n');
+
+    const result = loadEnvFile({ path: file });
+
+    expect(process.env.MS365_MCP_AUTH_CACHE_COMMAND).toBeUndefined();
+    expect(result.ignored).toEqual(['MS365_MCP_AUTH_CACHE_COMMAND']);
+    expect(result.applied).toEqual([]);
+  });
+
+  it('ignores the other security-sensitive keys', () => {
+    const file = writeEnvFile(
+      [
+        'MS365_MCP_TOKEN_CACHE_PATH=/tmp/evil-cache.json',
+        'MS365_MCP_SELECTED_ACCOUNT_PATH=/tmp/evil-account.json',
+        'MS365_MCP_LOG_DIR=/tmp/evil-logs',
+        'MS365_MCP_KEYVAULT_URL=https://evil.example.com',
+        'MS365_MCP_OAUTH_TOKEN=evil-token',
+        'MS365_MCP_REDACT_PII=false',
+        'MS365_MCP_AUDIT_LOG=false',
+      ].join('\n')
+    );
+
+    const result = loadEnvFile({ path: file });
+
+    expect(result.applied).toEqual([]);
+    expect(result.ignored).toHaveLength(7);
+    expect(process.env.MS365_MCP_TOKEN_CACHE_PATH).toBeUndefined();
+    expect(process.env.MS365_MCP_REDACT_PII).toBeUndefined();
+  });
+
+  it('keeps a value already set in the environment', () => {
+    process.env.MS365_MCP_CLIENT_ID = 'from-environment';
+    const file = writeEnvFile('MS365_MCP_CLIENT_ID=from-file\n');
+
+    const result = loadEnvFile({ path: file });
+
+    expect(process.env.MS365_MCP_CLIENT_ID).toBe('from-environment');
+    expect(result.applied).toEqual([]);
+  });
+
+  it('warns with key names but never values', () => {
+    const file = writeEnvFile('MS365_MCP_CLIENT_SECRET_TYPO=super-secret-value\n');
+
+    loadEnvFile({ path: file });
+
+    expect(console.error).toHaveBeenCalledTimes(1);
+    const message = vi.mocked(console.error).mock.calls[0][0] as string;
+    expect(message).toContain('MS365_MCP_CLIENT_SECRET_TYPO');
+    expect(message).not.toContain('super-secret-value');
+  });
+
+  it('stays quiet when everything in the file is allowed', () => {
+    const file = writeEnvFile('MS365_MCP_TENANT_ID=common\n');
+
+    loadEnvFile({ path: file });
+
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  // config() re-read its own debug flag out of the file it had just parsed, so a
+  // DOTENV_CONFIG_DEBUG line inside .env made dotenv log to stdout - the JSON-RPC
+  // channel in stdio mode. parse() cannot do that.
+  it('never writes to stdout, whatever the file says', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const file = writeEnvFile('DOTENV_CONFIG_DEBUG=true\nMS365_MCP_CLIENT_ID=from-file\n');
+
+    loadEnvFile({ path: file });
+
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('names only our own variables in the warning', () => {
+    const file = writeEnvFile(
+      'DATABASE_URL=postgres://user:pw@host/db\nMS365_MCP_LOG_DIR=/tmp/x\n'
+    );
+
+    const result = loadEnvFile({ path: file });
+
+    expect(result.ignored).toEqual(['DATABASE_URL', 'MS365_MCP_LOG_DIR']);
+    expect(console.error).toHaveBeenCalledTimes(1);
+    const message = vi.mocked(console.error).mock.calls[0][0] as string;
+    expect(message).toContain('MS365_MCP_LOG_DIR');
+    expect(message).not.toContain('DATABASE_URL');
+  });
+
+  it('stays quiet when only unrelated variables are ignored', () => {
+    const file = writeEnvFile('DATABASE_URL=postgres://user:pw@host/db\n');
+
+    loadEnvFile({ path: file });
+
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when there is no .env', () => {
+    const result = loadEnvFile({ path: path.join(os.tmpdir(), 'ms365-no-such-file.env') });
+
+    expect(result).toEqual({ applied: [], ignored: [] });
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  // Pinned so that widening the allowlist has to be a deliberate edit here too.
+  it('allows only the documented app-registration config', () => {
+    expect(ENV_FILE_ALLOWLIST).toEqual([
+      'MS365_MCP_CLIENT_ID',
+      'MS365_MCP_CLIENT_SECRET',
+      'MS365_MCP_TENANT_ID',
+      'MS365_MCP_CLOUD_TYPE',
+    ]);
+  });
+});

--- a/test/token-cache-storage.test.ts
+++ b/test/token-cache-storage.test.ts
@@ -102,6 +102,21 @@ describe('token cache storage', () => {
       expect(storage).toBeInstanceOf(DefaultTokenCacheStorage);
     });
 
+    it('rejects a relative command path', async () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms365-cache-test-'));
+      fs.writeFileSync(path.join(dir, 'store'), '#!/bin/sh\nexit 0\n', { mode: 0o700 });
+      const cwd = process.cwd();
+      process.chdir(dir);
+
+      try {
+        vi.stubEnv('MS365_MCP_AUTH_CACHE_COMMAND', './store');
+
+        await expect(createTokenCacheStorage()).rejects.toThrow(/absolute path/);
+      } finally {
+        process.chdir(cwd);
+      }
+    });
+
     it('rejects a missing command path for local auth flows', async () => {
       vi.stubEnv('MS365_MCP_AUTH_CACHE_COMMAND', path.join(os.tmpdir(), 'missing-ms365-cache'));
 


### PR DESCRIPTION
dotenv loaded .env from process.cwd(), which for an MCP server is whatever directory the client launched us in. Any file sitting there could set every MS365_MCP_* variable, including MS365_MCP_AUTH_CACHE_COMMAND, which is spawned at startup before any authentication (GHSA-9w34-3f56-vwmh).

.env is now parsed into a private object and only MS365_MCP_CLIENT_ID, MS365_MCP_CLIENT_SECRET, MS365_MCP_TENANT_ID and MS365_MCP_CLOUD_TYPE are copied into the environment. Everything else is ignored, with a warning on stderr naming our own variables only. MS365_MCP_AUTH_CACHE_COMMAND now also has to be an absolute path.

Uses dotenv's parse() rather than config() so the file can only ever become key/value pairs: config() reads its own debug flag back out of the file it just parsed and logs to stdout, which is the JSON-RPC channel in stdio mode.

Existing setups with other variables in .env have to move them to the shell or MCP client config. MS365_MCP_TOKEN_CACHE_PATH is the one to watch: it silently falls back to the default, so those users will look logged out.