### PR TITLE
feat(auth): encrypt the token cache and move it out of the package dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ dist
 # Token cache files
 .token-cache.json
 .selected-account.json
+.cache-key
 
 # Server logs (may contain PII and token metadata)
 logs/

--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ dist
 .token-cache.json
 .selected-account.json
 .cache-key
+*.migrated
 
 # Server logs (may contain PII and token metadata)
 logs/

--- a/README.md
+++ b/README.md
@@ -630,11 +630,23 @@ Environment variables:
 
 ## Token Storage
 
-Authentication tokens are stored using the OS credential store (via keytar) when available. If keytar is not installed or fails (common on headless Linux), the server falls back to file-based storage.
+Authentication tokens are stored in an encrypted file (AES-256-GCM). Only the 32-byte encryption key goes to the OS credential store via keytar.
 
-**Default fallback paths** are relative to the installed package directory. This means tokens can be lost when the package is reinstalled or updated via npm.
+The cache itself is too big for some credential stores to hold - a Windows Credential Manager blob caps out at 2560 bytes and a real token cache is several times that, so on Windows the write could never succeed. A key is 32 bytes regardless of how many accounts are signed in, so this works the same way on every platform.
 
-To persist tokens across updates, set custom paths outside the package directory:
+**Default paths** are in the per-user config directory:
+
+| Platform | Location                                                                  |
+| -------- | ------------------------------------------------------------------------- |
+| Windows  | `%APPDATA%\ms-365-mcp-server\`                                            |
+| macOS    | `~/Library/Application Support/ms-365-mcp-server/`                        |
+| Linux    | `$XDG_CONFIG_HOME/ms-365-mcp-server/` (or `~/.config/ms-365-mcp-server/`) |
+
+Earlier versions defaulted to a path inside the installed package, which under `npx` resolves to a content-hashed cache directory that `npm cache clean` or a version bump throws away. A cache still sitting in the package directory is moved to the new location on first run.
+
+That covers global and local installs, and `npx` when the hash has not changed. It cannot reach a cache left behind in a _previous_ `npx` hash directory, so upgrading an `npx` install one last time means signing in again. Adopting a cache from another directory would mean trusting a directory this package cannot prove it wrote, which is not worth one saved sign-in.
+
+Override the paths if you need to:
 
 ```bash
 export MS365_MCP_TOKEN_CACHE_PATH="$HOME/.config/ms365-mcp/.token-cache.json"
@@ -643,7 +655,11 @@ export MS365_MCP_SELECTED_ACCOUNT_PATH="$HOME/.config/ms365-mcp/.selected-accoun
 
 Parent directories are created automatically. Files are written with `0600` permissions.
 
-> **Security note**: File-based token storage writes sensitive credentials to disk. Ensure the chosen directory has appropriate access controls. The OS credential store (keytar) is preferred when available.
+**Without a credential store** (headless Linux, most containers) the key is written to `.cache-key` next to the cache file, with `0600` permissions. That stops the tokens showing up in a stray `cat`, a backup or an accidental commit. It does not protect against anyone who can already read the directory - the key is right there. Use `MS365_MCP_AUTH_CACHE_COMMAND` below if you need the cache in a real secret store.
+
+If the cache cannot be decrypted - key lost, keychain locked, file modified - you are asked to sign in again rather than the server failing to start. The cache file is left exactly as it was: not deleted, and not overwritten by that new sign-in either. A keychain that is merely locked usually reads fine on the next start, and the cache is still there when it does.
+
+The cost is that the new session is not saved while this lasts, so each start asks you to sign in again. If the key is genuinely gone and the cache will never open, delete `.token-cache.json` to start over - the log says so, and names the path.
 
 > **Hosted/sandboxed environments** (e.g. Anthropic Cowork): Set `MS365_MCP_TOKEN_CACHE_PATH` and `MS365_MCP_SELECTED_ACCOUNT_PATH` to a persistent mount so tokens survive between sessions.
 

--- a/src/lib/cache-encryption.ts
+++ b/src/lib/cache-encryption.ts
@@ -1,0 +1,149 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const ALGORITHM_LABEL = 'A256GCM';
+const ENVELOPE_VERSION = 2;
+const IV_BYTES = 12;
+const TAG_BYTES = 16;
+
+export const CACHE_KEY_BYTES = 32;
+
+/**
+ * The auth cache at rest, encrypted. Only the 32-byte key goes to the keychain, which
+ * is what makes this work on Windows: a Credential Manager blob caps out at 2560 bytes
+ * and a real token cache is several times that, so the cache itself could never be
+ * stored there (issue #602). A key is 32 bytes no matter how many accounts.
+ *
+ * The v1 envelope (`wrapCache`, plaintext `data` plus `savedAt`) is what gets encrypted,
+ * so `savedAt` travels inside the ciphertext and is covered by the GCM tag. Callers see
+ * the same v1 string they always did.
+ *
+ * Both cache files share one key, so each is bound to its purpose through the GCM
+ * additional data. Without that, the files are interchangeable ciphertext: one could be
+ * copied over the other and still authenticate. The version and algorithm are bound too,
+ * as constants rather than as read from the envelope - that separates a v2 ciphertext
+ * from whatever a later version writes, but it is the explicit checks in `decryptCache`,
+ * not the tag, that catch an edited header on this envelope.
+ *
+ * Not defended against: replacing a file with an older, still-valid encryption of itself.
+ * Detecting that needs a counter outside the file, and the payoff is replaying a refresh
+ * token that was already on the same disk.
+ */
+interface EncryptedEnvelope {
+  _cacheEnvelope: true;
+  v: number;
+  alg: string;
+  iv: string;
+  tag: string;
+  data: string;
+}
+
+export function generateCacheKey(): Buffer {
+  return randomBytes(CACHE_KEY_BYTES);
+}
+
+export function parseCacheKey(encoded: string): Buffer {
+  const key = Buffer.from(encoded.trim(), 'base64');
+  if (key.length !== CACHE_KEY_BYTES) {
+    throw new Error(`Auth cache key must be ${CACHE_KEY_BYTES} bytes, got ${key.length}`);
+  }
+  return key;
+}
+
+export function encodeCacheKey(key: Buffer): string {
+  return key.toString('base64');
+}
+
+/**
+ * Ties a ciphertext to what it is, so the two cache files cannot be swapped for each
+ * other and the unauthenticated header cannot be edited.
+ */
+function additionalData(purpose: string): Buffer {
+  return Buffer.from(`ms365:v${ENVELOPE_VERSION}:${ALGORITHM_LABEL}:${purpose}`, 'utf8');
+}
+
+export function encryptCache(plaintext: string, key: Buffer, purpose: string): string {
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  cipher.setAAD(additionalData(purpose));
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const envelope: EncryptedEnvelope = {
+    _cacheEnvelope: true,
+    v: ENVELOPE_VERSION,
+    alg: ALGORITHM_LABEL,
+    iv: iv.toString('base64'),
+    tag: cipher.getAuthTag().toString('base64'),
+    data: ciphertext.toString('base64'),
+  };
+  return JSON.stringify(envelope);
+}
+
+/**
+ * Whether `raw` needs a key before it means anything.
+ *
+ * Keyed off a numeric `v`, which only the encrypted envelope carries - not off the
+ * version being one we understand. A downgrade meeting a newer envelope has to see
+ * ciphertext it cannot read, because the v1 plaintext envelope shares the
+ * `_cacheEnvelope` discriminator: answering false here would hand base64 ciphertext
+ * to MSAL as if it were the cache body.
+ */
+export function isEncryptedCache(raw: string): boolean {
+  return readEnvelope(raw) !== undefined;
+}
+
+/**
+ * Throws on a wrong key, a truncated envelope, a ciphertext written for a different
+ * purpose, or any tampering the GCM tag catches.
+ */
+export function decryptCache(raw: string, key: Buffer, purpose: string): string {
+  const envelope = readEnvelope(raw);
+  if (!envelope) {
+    throw new Error('Auth cache is not an encrypted envelope');
+  }
+  if (envelope.v !== ENVELOPE_VERSION) {
+    throw new Error(`Unsupported auth cache envelope version: ${envelope.v}`);
+  }
+  if (envelope.alg !== ALGORITHM_LABEL) {
+    throw new Error(`Unsupported auth cache algorithm: ${envelope.alg}`);
+  }
+  if (
+    typeof envelope.iv !== 'string' ||
+    typeof envelope.tag !== 'string' ||
+    typeof envelope.data !== 'string'
+  ) {
+    throw new Error('Auth cache envelope is missing iv, tag or data');
+  }
+
+  const iv = Buffer.from(envelope.iv, 'base64');
+  const tag = Buffer.from(envelope.tag, 'base64');
+  if (iv.length !== IV_BYTES || tag.length !== TAG_BYTES) {
+    throw new Error('Auth cache envelope has a malformed iv or tag');
+  }
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAAD(additionalData(purpose));
+  decipher.setAuthTag(tag);
+  return Buffer.concat([
+    decipher.update(Buffer.from(envelope.data, 'base64')),
+    decipher.final(),
+  ]).toString('utf8');
+}
+
+/**
+ * Structural only: a `_cacheEnvelope` carrying a numeric `v`. Whether the version and
+ * the fields are ones we can actually use is {@link decryptCache}'s call, so that an
+ * envelope we cannot read fails loudly instead of being mistaken for plaintext.
+ */
+function readEnvelope(raw: string): Partial<EncryptedEnvelope> | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object') return undefined;
+
+  const candidate = parsed as Partial<EncryptedEnvelope>;
+  if (candidate._cacheEnvelope !== true || typeof candidate.v !== 'number') return undefined;
+  return candidate;
+}

--- a/src/lib/config-paths.ts
+++ b/src/lib/config-paths.ts
@@ -1,0 +1,29 @@
+import os from 'node:os';
+import path from 'node:path';
+
+const APP_DIR_NAME = 'ms-365-mcp-server';
+
+/**
+ * Per-user config directory for anything we need to survive an upgrade.
+ *
+ * The auth cache used to default to a path inside the installed package, which under
+ * npx resolves to `_npx/<hash>/node_modules/...` — a directory `npm cache clean` or a
+ * version bump throws away, taking the refresh token with it (issue #602).
+ */
+export function getConfigDir(): string {
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA?.trim();
+    return path.join(appData || path.join(os.homedir(), 'AppData', 'Roaming'), APP_DIR_NAME);
+  }
+
+  if (process.platform === 'darwin') {
+    return path.join(os.homedir(), 'Library', 'Application Support', APP_DIR_NAME);
+  }
+
+  // XDG requires a relative XDG_CONFIG_HOME to be ignored rather than resolved.
+  const xdg = process.env.XDG_CONFIG_HOME?.trim();
+  if (xdg && path.isAbsolute(xdg)) {
+    return path.join(xdg, APP_DIR_NAME);
+  }
+  return path.join(os.homedir(), '.config', APP_DIR_NAME);
+}

--- a/src/token-cache-storage.ts
+++ b/src/token-cache-storage.ts
@@ -1,7 +1,17 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import fs, { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  decryptCache,
+  encodeCacheKey,
+  encryptCache,
+  generateCacheKey,
+  isEncryptedCache,
+  parseCacheKey,
+} from './lib/cache-encryption.js';
+import { getConfigDir } from './lib/config-paths.js';
 import logger from './logger.js';
 
 export type TokenCacheStorageKey = 'token-cache' | 'selected-account';
@@ -34,11 +44,15 @@ const DEFAULT_AUTH_CACHE_COMMAND_TIMEOUT_MS = 10_000;
 const STDERR_LIMIT = 2048;
 const COMMAND_KILL_GRACE_MS = 1000;
 
+const CACHE_KEY_ACCOUNT = 'cache-key';
+const TOKEN_CACHE_FILE = '.token-cache.json';
+const SELECTED_ACCOUNT_FILE = '.selected-account.json';
+const CACHE_KEY_FILE = '.cache-key';
+
+// Where the cache used to live: inside the installed package. Kept only so an upgrade
+// can move the file out instead of silently forcing a fresh device-code login.
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const FALLBACK_DIR = __dirname;
-const DEFAULT_TOKEN_CACHE_PATH = path.join(FALLBACK_DIR, '..', '.token-cache.json');
-const DEFAULT_SELECTED_ACCOUNT_PATH = path.join(FALLBACK_DIR, '..', '.selected-account.json');
+const LEGACY_DIR = path.join(path.dirname(__filename), '..');
 
 let keytar: typeof import('keytar') | null | undefined = null;
 
@@ -109,12 +123,103 @@ function pickNewestRaw(
 
 export function getTokenCachePath(): string {
   const envPath = process.env.MS365_MCP_TOKEN_CACHE_PATH?.trim();
-  return envPath || DEFAULT_TOKEN_CACHE_PATH;
+  return envPath || path.join(getConfigDir(), TOKEN_CACHE_FILE);
 }
 
 export function getSelectedAccountPath(): string {
   const envPath = process.env.MS365_MCP_SELECTED_ACCOUNT_PATH?.trim();
-  return envPath || DEFAULT_SELECTED_ACCOUNT_PATH;
+  return envPath || path.join(getConfigDir(), SELECTED_ACCOUNT_FILE);
+}
+
+/** Key file sits beside the token cache, so a custom cache path takes it along. */
+export function getCacheKeyPath(): string {
+  return path.join(path.dirname(getTokenCachePath()), CACHE_KEY_FILE);
+}
+
+let legacyPathsMigrated = false;
+
+/**
+ * Move a cache left in the package directory on first use. Skipped for any key the
+ * caller has pointed elsewhere with an env var, and never overwrites a file that
+ * already exists at the new location.
+ */
+function migrateLegacyPaths(): void {
+  if (legacyPathsMigrated) return;
+  legacyPathsMigrated = true;
+  migrateLegacyPathsFrom(LEGACY_DIR);
+}
+
+/**
+ * Deliberately only the directory we are running from.
+ *
+ * An earlier attempt also scanned sibling `_npx/<hash>` trees, since a version bump
+ * leaves the old cache in the tree npx no longer uses. Nothing about a sibling proves
+ * this package wrote it: any npx'd package that merely depends on us produces the same
+ * subpath, so a planted `.token-cache.json` would have been adopted as the user's own
+ * account. That is the shape of GHSA-9w34-3f56-vwmh, and one saved sign-in is not worth
+ * reopening it. An npx user who bumps versions signs in again.
+ */
+export function migrateLegacyPathsFrom(legacyDir: string): void {
+  const moves: Array<[string, string, string | undefined]> = [
+    [TOKEN_CACHE_FILE, getTokenCachePath(), process.env.MS365_MCP_TOKEN_CACHE_PATH?.trim()],
+    [
+      SELECTED_ACCOUNT_FILE,
+      getSelectedAccountPath(),
+      process.env.MS365_MCP_SELECTED_ACCOUNT_PATH?.trim(),
+    ],
+  ];
+
+  for (const [fileName, target, envOverride] of moves) {
+    if (envOverride || existsSync(target)) continue;
+    const legacyPath = path.join(legacyDir, fileName);
+    if (!existsSync(legacyPath) || existsSync(`${legacyPath}.migrated`)) continue;
+
+    let moved = false;
+    try {
+      ensureParentDir(target);
+      fs.renameSync(legacyPath, target);
+      moved = true;
+    } catch {
+      // EXDEV across devices, or a read-only package dir. Copy, then best-effort unlink.
+      try {
+        ensureParentDir(target);
+        fs.copyFileSync(legacyPath, target);
+        moved = true;
+        try {
+          fs.unlinkSync(legacyPath);
+        } catch {
+          // The legacy copy outlives us. Leave a marker so a later run does not migrate
+          // it a second time and resurrect a session the user has since logged out of.
+          logger.warn(`Copied auth cache to ${target} but could not remove ${legacyPath}`);
+          try {
+            fs.writeFileSync(`${legacyPath}.migrated`, '', { mode: 0o600 });
+          } catch {
+            // Nothing else to try; worst case is one repeated migration.
+          }
+        }
+      } catch (copyError) {
+        // The copy error, not the rename one: reporting "cross-device link" when the
+        // copy failed EACCES points the operator at the wrong thing.
+        logger.warn(
+          `Could not migrate auth cache ${fileName} to ${target}: ${(copyError as Error).message}`
+        );
+      }
+    }
+    if (!moved) continue;
+
+    // Outside the move: rename keeps the source mode, and a cache from an old enough
+    // release predates permission hardening. Kept separate so a failing chmod cannot
+    // send an already-moved file down the copy fallback and report a bogus failure.
+    if (tightenPermissions(target)) {
+      logger.info(`Moved auth cache ${fileName} out of the package directory to ${target}`);
+    } else {
+      logger.error(
+        `Moved auth cache ${fileName} to ${target}, but could not make it owner-only. ` +
+          'It holds credentials in plaintext until the next save re-encrypts it - ' +
+          'restrict it by hand, or delete it and sign in again.'
+      );
+    }
+  }
 }
 
 function storageAccountForKey(key: TokenCacheStorageKey): string {
@@ -133,6 +238,23 @@ function assertValidKey(key: TokenCacheStorageKey): void {
   }
 }
 
+/**
+ * Returns whether the file ended up owner-only.
+ *
+ * Windows modes are advisory, so a failure there is not interesting. On POSIX it is: the
+ * file being moved is a plaintext token cache, and one we cannot restrict has to be
+ * reported as such rather than folded into a success message.
+ */
+function tightenPermissions(filePath: string): boolean {
+  try {
+    fs.chmodSync(filePath, 0o600);
+    return true;
+  } catch (error) {
+    logger.warn(`Could not restrict permissions on ${filePath}: ${(error as Error).message}`);
+    return process.platform === 'win32';
+  }
+}
+
 function ensureParentDir(filePath: string): void {
   const dir = path.dirname(filePath);
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
@@ -140,34 +262,410 @@ function ensureParentDir(filePath: string): void {
 
 function writeFileAtomically(filePath: string, value: string): void {
   ensureParentDir(filePath);
-  const tempPath = path.join(
-    path.dirname(filePath),
-    `.${path.basename(filePath)}.${process.pid}.${Date.now()}.tmp`
-  );
+  const tempPath = tempPathFor(filePath);
   fs.writeFileSync(tempPath, value, { mode: 0o600 });
   fs.renameSync(tempPath, filePath);
 }
 
+interface CacheKeyState {
+  /** Every key that might decrypt an existing cache. */
+  keys: Buffer[];
+  /** Where the key file's key sits in `keys`, when there is one. */
+  fileKeyIndex?: number;
+  /**
+   * Whether a new key may be written to the keychain. False when there is no keychain at
+   * all, and false when reading it failed - storing one then would overwrite a key we
+   * merely could not read.
+   */
+  canUseKeychain: boolean;
+}
+
+// Both memoize the in-flight promise rather than the resolved value: several MSAL cache
+// accesses can be in flight at once (see the plugin in auth.ts), and caching only the
+// result lets two of them race past the check and mint competing keys.
+let keyStatePromise: Promise<CacheKeyState> | undefined;
+let encryptionKeyPromise: Promise<Buffer> | undefined;
+
+// Keys whose pre-encryption keychain entry we actually saw, so the cleanup on save is a
+// one-shot rather than a keychain round-trip on every token refresh.
+const legacyKeytarEntries = new Set<TokenCacheStorageKey>();
+
+// Log noise only: which keys have already had the "not persisting" warning. Whether a
+// cache may be overwritten is decided by reading it, never from state kept here - a
+// stale entry costs a missing log line, not a cache.
+const warnedUndecryptable = new Set<TokenCacheStorageKey>();
+
+/** Test seam: all of this is memoized for the process lifetime. */
+export function resetCacheKeyForTests(): void {
+  keyStatePromise = undefined;
+  encryptionKeyPromise = undefined;
+  legacyKeytarEntries.clear();
+  warnedUndecryptable.clear();
+  legacyPathsMigrated = false;
+}
+
+async function clearLegacyKeytarEntry(key: TokenCacheStorageKey): Promise<void> {
+  if (!legacyKeytarEntries.delete(key)) return;
+  try {
+    const kt = await getKeytar();
+    if (kt) {
+      await kt.deletePassword(SERVICE_NAME, storageAccountForKey(key));
+      logger.info(`Removed the pre-encryption keychain entry for ${key}`);
+    }
+  } catch (error) {
+    logger.warn(
+      `Could not remove the legacy keychain entry for ${key}: ${(error as Error).message}`
+    );
+  }
+}
+
+/**
+ * Every key that could decrypt an existing cache. The keychain is the preferred home; 32
+ * bytes fits anywhere, including a Windows credential blob. Where there is no keychain
+ * (headless linux, most containers) the key goes in a 0600 file beside the cache. That
+ * protects against a stray `cat`, a backup or an accidental commit, not against someone
+ * who can already read the file next to it.
+ *
+ * Both homes are collected rather than the first hit winning. A machine that is
+ * sometimes a desktop session and sometimes a container can hold a key in each - a run
+ * without a keychain mints a file key for whichever cache does not exist yet - and
+ * preferring one would make every run discard the other run's cache. It cannot happen
+ * for a cache that is already there: `assertOverwritable` refuses that save long before
+ * a key is needed, so the alternation only arises where one side started from nothing.
+ *
+ * Never mints. A cache that will not decrypt must not cause a replacement key to be
+ * written, because the usual reason is a key that could not be read rather than one that
+ * does not exist.
+ */
+function loadKeyState(): Promise<CacheKeyState> {
+  if (!keyStatePromise) keyStatePromise = readCacheKeys();
+  return keyStatePromise;
+}
+
+async function readCacheKeys(): Promise<CacheKeyState> {
+  const keys: Buffer[] = [];
+  let canUseKeychain = false;
+
+  const kt = await getKeytar();
+  if (kt) {
+    let stored: string | null = null;
+    try {
+      stored = await kt.getPassword(SERVICE_NAME, CACHE_KEY_ACCOUNT);
+      canUseKeychain = true;
+    } catch (error) {
+      // Reaching the keychain failed, which is not the same as there being no key. Leave
+      // canUseKeychain false so a new key goes to a file instead of overwriting this one.
+      logger.warn(`Keychain access failed for the auth cache key: ${(error as Error).message}`);
+    }
+    if (stored) {
+      try {
+        keys.push(parseCacheKey(stored));
+      } catch (error) {
+        logger.warn(
+          `Ignoring unusable auth cache key in the keychain: ${(error as Error).message}`
+        );
+      }
+    }
+  }
+
+  let fileKeyIndex: number | undefined;
+  const keyPath = getCacheKeyPath();
+  if (existsSync(keyPath)) {
+    try {
+      keys.push(parseCacheKey(readFileSync(keyPath, 'utf8')));
+      fileKeyIndex = keys.length - 1;
+    } catch (error) {
+      logger.warn(`Ignoring unusable auth cache key file: ${(error as Error).message}`);
+    }
+  }
+
+  return { keys, fileKeyIndex, canUseKeychain };
+}
+
+/** The key to encrypt with: an existing one if there is any, otherwise a fresh one. */
+function getEncryptionKey(): Promise<Buffer> {
+  if (!encryptionKeyPromise) {
+    encryptionKeyPromise = resolveEncryptionKey().catch((error) => {
+      // Don't let one failed write poison every later save in this process: the next
+      // one should get a fresh attempt rather than the same rejection forever. The key
+      // state goes too, because a mint that stored a key and then failed leaves the
+      // memoized state claiming there is none - the retry would mint over it.
+      encryptionKeyPromise = undefined;
+      keyStatePromise = undefined;
+      throw error;
+    });
+  }
+  return encryptionKeyPromise;
+}
+
+async function resolveEncryptionKey(): Promise<Buffer> {
+  const state = await loadKeyState();
+
+  // The key file wins when both homes hold one. A key file only exists because some run
+  // could not use the keychain, and that run will not be able to read a keychain key
+  // either - encrypting under the keychain key would lock it out on the next alternation
+  // and cost a sign-in every time the environment flips. The file key is the one both
+  // sides can read, so it is what keeps them agreeing.
+  const preferred = state.keys[state.fileKeyIndex ?? 0];
+  if (preferred) return preferred;
+
+  const minted = await persistCacheKey(generateCacheKey(), state.canUseKeychain);
+  // Share it with any later load, which may be looking at a cache this key just wrote.
+  state.keys.unshift(minted);
+  if (state.fileKeyIndex !== undefined) state.fileKeyIndex += 1;
+  return minted;
+}
+
+/**
+ * Store a freshly minted key and return whichever key actually ended up stored. Sibling
+ * processes start up together and can each mint one, so both paths read back the winner
+ * instead of assuming the write was uncontested.
+ */
+async function persistCacheKey(key: Buffer, canUseKeychain: boolean): Promise<Buffer> {
+  const encoded = encodeCacheKey(key);
+
+  if (canUseKeychain) {
+    const kt = await getKeytar();
+    if (kt) {
+      try {
+        await kt.setPassword(SERVICE_NAME, CACHE_KEY_ACCOUNT, encoded);
+        const winner = await kt.getPassword(SERVICE_NAME, CACHE_KEY_ACCOUNT);
+        if (winner && winner !== encoded) {
+          logger.info('Another process stored an auth cache key first, adopting it');
+          return parseCacheKey(winner);
+        }
+        logger.info('Stored a new auth cache key in the system keychain');
+        return key;
+      } catch (error) {
+        logger.warn(`Keychain save failed for the auth cache key: ${(error as Error).message}`);
+      }
+    }
+  }
+
+  const keyPath = getCacheKeyPath();
+  if (createFileExclusively(keyPath, encoded)) {
+    logger.info(
+      `No usable system keychain; auth cache key written to ${keyPath}. ` +
+        'Encryption guards against casual disclosure only when the key sits beside the cache.'
+    );
+    return key;
+  }
+
+  try {
+    const existing = parseCacheKey(readFileSync(keyPath, 'utf8'));
+    logger.info('Another process created the auth cache key file first, adopting it');
+    return existing;
+  } catch (parseError) {
+    // Not a key. Remove it and race for the create again rather than writing over
+    // whatever is there now: the earlier readCacheKeys is memoized from startup and says
+    // nothing about a file that appeared since, which is what produced this collision.
+    // If a sibling wins the retry we adopt theirs, so a valid key is never clobbered.
+    logger.warn(
+      `Replacing an unusable auth cache key file at ${keyPath}: ${(parseError as Error).message}`
+    );
+    try {
+      fs.unlinkSync(keyPath);
+    } catch {
+      // Already gone, or a sibling is mid-replace. The create below settles it.
+    }
+    if (createFileExclusively(keyPath, encoded)) return key;
+    return parseCacheKey(readFileSync(keyPath, 'utf8'));
+  }
+}
+
+/**
+ * Create `filePath` only if it does not exist, with its content already in place.
+ *
+ * `writeFileSync` with `flag: 'wx'` reserves the name and fills it afterwards, so a
+ * sibling can read the file while it is still empty. An empty file does not parse as a
+ * key, which sent that sibling down the replace path and destroyed the key the winner
+ * was about to encrypt under. Linking a fully written temp file publishes name and
+ * content in one step, so a reader sees either nothing or a whole key.
+ */
+function createFileExclusively(filePath: string, contents: string): boolean {
+  ensureParentDir(filePath);
+  const tempPath = tempPathFor(filePath);
+
+  try {
+    fs.writeFileSync(tempPath, contents, { mode: 0o600 });
+    fs.linkSync(tempPath, filePath);
+    return true;
+  } catch (error) {
+    if ((error as { code?: string }).code === 'EEXIST') return false;
+
+    // Filesystems without hard links. Reserve-then-fill reopens the window where a
+    // sibling reads this file empty, calls it corrupt and replaces it, so read back
+    // rather than assuming we still own what we wrote. Returning false sends the caller
+    // to adopt whatever is actually on disk, instead of encrypting under a key that is
+    // no longer anywhere.
+    try {
+      fs.writeFileSync(filePath, contents, { mode: 0o600, flag: 'wx' });
+      return fs.readFileSync(filePath, 'utf8') === contents;
+    } catch (fallbackError) {
+      if ((fallbackError as { code?: string }).code === 'EEXIST') return false;
+      throw fallbackError;
+    }
+  } finally {
+    try {
+      fs.unlinkSync(tempPath);
+    } catch {
+      // Never created, or already linked away. The link, or its absence, is what matters.
+    }
+  }
+}
+
+/**
+ * Random rather than pid plus timestamp: containers sharing a bind-mounted config dir
+ * have separate pid namespaces, so two of them really can be pid 1 in the same
+ * millisecond, and that is exactly when both are minting a key.
+ */
+function tempPathFor(filePath: string): string {
+  return path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${randomBytes(8).toString('hex')}.tmp`
+  );
+}
+
+/**
+ * What is currently at `cachePath`, established by looking rather than by remembering.
+ *
+ * An earlier version set a flag during load and consulted it during save. Every failure
+ * mode nobody had thought of - an unreadable file, a truncated envelope, a delete that
+ * did not happen - skipped the flag and therefore read as "safe to overwrite". Deciding
+ * at the moment of the write, from the file itself, has no such default: anything not
+ * positively identified is `unreadable`, and `unreadable` is never overwritten.
+ */
+type CacheFileState =
+  | { status: 'absent' }
+  | { status: 'plaintext'; raw: string }
+  | { status: 'decrypted'; raw: string }
+  | { status: 'unreadable'; reason: string };
+
+async function readCacheFile(
+  key: TokenCacheStorageKey,
+  cachePath: string
+): Promise<CacheFileState> {
+  let onDisk: string;
+  try {
+    onDisk = readFileSync(cachePath, 'utf8');
+  } catch (error) {
+    // No existsSync first: that races, and a failed read is not the same as no file.
+    if ((error as { code?: string }).code === 'ENOENT') return { status: 'absent' };
+    return { status: 'unreadable', reason: (error as Error).message };
+  }
+
+  // Nothing in it to lose, so treat it as free space rather than something to protect.
+  if (onDisk === '') return { status: 'absent' };
+
+  if (isEncryptedCache(onDisk)) {
+    const { keys } = await loadKeyState();
+    const decrypted = decryptWithAnyKey(onDisk, keys, key);
+    if (decrypted !== undefined) return { status: 'decrypted', raw: decrypted };
+
+    // Drop the memoized key state so the next attempt re-reads the keychain instead of
+    // staying stuck on the key list it saw while the keyring was locked. The encryption
+    // key goes with it: keeping it would let a process re-read the keychain, decrypt a
+    // sibling's cache under the sibling's key, and then write back under its own stale
+    // one - which is stored nowhere, so from then on nobody can read the file and the
+    // refusal below makes that permanent.
+    keyStatePromise = undefined;
+    encryptionKeyPromise = undefined;
+    return { status: 'unreadable', reason: 'no known key opens it' };
+  }
+
+  // Plaintext has to be positively identified. A truncated or corrupt ciphertext also
+  // fails isEncryptedCache, and calling that plaintext both feeds garbage to MSAL and
+  // marks a damaged cache as safe to overwrite. Every genuine legacy format is JSON:
+  // a v1 _cacheEnvelope, or the raw MSAL cache object that predates it.
+  if (isPlainCacheJson(onDisk)) return { status: 'plaintext', raw: onDisk };
+  return { status: 'unreadable', reason: 'not a recognisable auth cache' };
+}
+
+function isPlainCacheJson(raw: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return parsed !== null && typeof parsed === 'object';
+  } catch {
+    return false;
+  }
+}
+
+/** Try every candidate key; undefined when none of them opens the envelope. */
+function decryptWithAnyKey(raw: string, keys: Buffer[], purpose: string): string | undefined {
+  for (const key of keys) {
+    try {
+      return decryptCache(raw, key, purpose);
+    } catch {
+      // Wrong key for this envelope, try the next one.
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Refuse to write over a cache this run could not decrypt.
+ *
+ * Leaving the file alone during load is not enough on its own: the sign-in that follows
+ * a failed load calls save() against the same path. The usual cause is a key that was
+ * unreadable this run rather than gone, and the cache may hold more accounts than the
+ * one just signed back in, so overwriting is the destructive move.
+ *
+ * Nothing is copied aside. A backup file has to be named, cleaned up, kept from
+ * clobbering the previous one and deleted on logout, and every one of those is a way to
+ * lose the thing it was protecting. Not writing is the version with no moving parts.
+ */
+async function assertOverwritable(key: TokenCacheStorageKey, cachePath: string): Promise<void> {
+  const state = await readCacheFile(key, cachePath);
+  if (state.status !== 'unreadable') {
+    warnedUndecryptable.delete(key);
+    return;
+  }
+
+  if (!warnedUndecryptable.has(key)) {
+    warnedUndecryptable.add(key);
+    logger.warn(
+      `Not persisting ${key}: ${cachePath} cannot be read back (${state.reason}), and ` +
+        'overwriting it would discard whatever it holds. A locked keychain usually reads ' +
+        `fine on the next start. If it never does, delete ${cachePath} to start over.`
+    );
+  }
+  throw new Error(`Refusing to overwrite the unreadable auth cache at ${cachePath}`);
+}
+
 export class DefaultTokenCacheStorage implements TokenCacheStorage {
-  readonly description = 'default (keytar+file)';
+  readonly description = 'default (encrypted file)';
   readonly failClosed = false;
 
   async load(key: TokenCacheStorageKey): Promise<string | undefined> {
     assertValidKey(key);
+    migrateLegacyPaths();
+
+    // Pre-encryption releases put the cache itself in the keychain. Read it once more so
+    // an upgrade doesn't log the user out; save() clears it.
     let keytarRaw: string | undefined;
     try {
       const kt = await getKeytar();
       if (kt) {
         keytarRaw = (await kt.getPassword(SERVICE_NAME, storageAccountForKey(key))) ?? undefined;
+        if (keytarRaw) legacyKeytarEntries.add(key);
       }
     } catch (error) {
       logger.warn(`Keychain access failed for ${key}: ${(error as Error).message}`);
     }
 
-    let fileRaw: string | undefined;
     const cachePath = filePathForKey(key);
-    if (existsSync(cachePath)) {
-      fileRaw = readFileSync(cachePath, 'utf8');
+    const state = await readCacheFile(key, cachePath);
+    let fileRaw: string | undefined;
+    if (state.status === 'decrypted' || state.status === 'plaintext') {
+      // plaintext is pre-encryption; save() re-encrypts it
+      fileRaw = state.raw;
+    } else if (state.status === 'unreadable') {
+      // Left exactly as it is. The usual cause is a key we could not read this run - a
+      // locked keyring, a denied prompt - and the next run may read it fine. save()
+      // re-checks and refuses rather than writing over it.
+      logger.warn(
+        `Could not read ${key} back (${state.reason}); leaving it in place and re-authenticating`
+      );
     }
 
     return pickNewestRaw(keytarRaw, fileRaw);
@@ -175,19 +673,18 @@ export class DefaultTokenCacheStorage implements TokenCacheStorage {
 
   async save(key: TokenCacheStorageKey, value: string): Promise<void> {
     assertValidKey(key);
-    try {
-      const kt = await getKeytar();
-      if (kt) {
-        await kt.setPassword(SERVICE_NAME, storageAccountForKey(key), value);
-        return;
-      }
-    } catch (error) {
-      logger.warn(
-        `Keychain save failed for ${key}, falling back to file storage: ${(error as Error).message}`
-      );
-    }
+    migrateLegacyPaths();
 
-    writeFileAtomically(filePathForKey(key), value);
+    const cachePath = filePathForKey(key);
+    // Checked first so an unreadable cache costs nothing, then again immediately before
+    // the write - resolving the key can prompt a keychain, which is time enough for the
+    // file to change. Encryption is synchronous, so nothing moves after the second check.
+    await assertOverwritable(key, cachePath);
+    const encryptionKey = await getEncryptionKey();
+    await assertOverwritable(key, cachePath);
+
+    writeFileAtomically(cachePath, encryptCache(value, encryptionKey, key));
+    await clearLegacyKeytarEntry(key);
   }
 
   async delete(key: TokenCacheStorageKey): Promise<void> {

--- a/test/auth-storage.test.ts
+++ b/test/auth-storage.test.ts
@@ -149,7 +149,7 @@ describe('AuthManager token cache storage', () => {
     const auth = await AuthManager.create(['User.Read']);
 
     const storage = (auth as unknown as { storage: TokenCacheStorage }).storage;
-    expect(storage.description).toBe('default (keytar+file)');
+    expect(storage.description).toBe('default (encrypted file)');
   });
 });
 

--- a/test/cache-encryption.test.ts
+++ b/test/cache-encryption.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CACHE_KEY_BYTES,
+  decryptCache,
+  encodeCacheKey,
+  encryptCache,
+  generateCacheKey,
+  isEncryptedCache,
+  parseCacheKey,
+} from '../src/lib/cache-encryption.js';
+import { wrapCache } from '../src/token-cache-storage.js';
+
+describe('cache encryption', () => {
+  const key = generateCacheKey();
+
+  it('round-trips a v1 envelope through the ciphertext', () => {
+    const plaintext = wrapCache('{"Account":{"uid":"x"}}');
+    const encrypted = encryptCache(plaintext, key, 'token-cache');
+
+    expect(encrypted).not.toContain('Account');
+    expect(decryptCache(encrypted, key, 'token-cache')).toBe(plaintext);
+  });
+
+  it('produces a different ciphertext each time for the same input', () => {
+    const first = encryptCache('same', key, 'token-cache');
+    const second = encryptCache('same', key, 'token-cache');
+
+    expect(first).not.toBe(second);
+    expect(decryptCache(first, key, 'token-cache')).toBe(decryptCache(second, key, 'token-cache'));
+  });
+
+  it('rejects a ciphertext encrypted under a different key', () => {
+    const encrypted = encryptCache('secret', key, 'token-cache');
+
+    expect(() => decryptCache(encrypted, generateCacheKey(), 'token-cache')).toThrow();
+  });
+
+  it('rejects a tampered ciphertext', () => {
+    const envelope = JSON.parse(encryptCache('secret', key, 'token-cache'));
+    const data = Buffer.from(envelope.data, 'base64');
+    data[0] ^= 0xff;
+    envelope.data = data.toString('base64');
+
+    expect(() => decryptCache(JSON.stringify(envelope), key, 'token-cache')).toThrow();
+  });
+
+  it('rejects a swapped iv', () => {
+    const envelope = JSON.parse(encryptCache('secret', key, 'token-cache'));
+    envelope.iv = JSON.parse(encryptCache('other', key, 'token-cache')).iv;
+
+    expect(() => decryptCache(JSON.stringify(envelope), key, 'token-cache')).toThrow();
+  });
+
+  it('rejects a malformed iv or tag rather than passing it to the cipher', () => {
+    const envelope = JSON.parse(encryptCache('secret', key, 'token-cache'));
+
+    expect(() =>
+      decryptCache(JSON.stringify({ ...envelope, iv: 'AAAA' }), key, 'token-cache')
+    ).toThrow(/malformed iv or tag/);
+    expect(() =>
+      decryptCache(JSON.stringify({ ...envelope, tag: 'AAAA' }), key, 'token-cache')
+    ).toThrow(/malformed iv or tag/);
+  });
+
+  // Both cache files share one key, so without the purpose binding either file would
+  // authenticate as the other and could simply be copied over it.
+  describe('purpose binding', () => {
+    it('refuses a ciphertext written for the other cache file', () => {
+      const encrypted = encryptCache('secret', key, 'selected-account');
+
+      expect(() => decryptCache(encrypted, key, 'token-cache')).toThrow();
+    });
+
+    it('still opens under its own purpose', () => {
+      const encrypted = encryptCache('secret', key, 'selected-account');
+
+      expect(decryptCache(encrypted, key, 'selected-account')).toBe('secret');
+    });
+  });
+
+  it('rejects an unknown algorithm', () => {
+    const envelope = { ...JSON.parse(encryptCache('secret', key, 'token-cache')), alg: 'rot13' };
+
+    expect(() => decryptCache(JSON.stringify(envelope), key, 'token-cache')).toThrow(/Unsupported/);
+  });
+
+  // A downgrade must not mistake a newer envelope for plaintext: v1 and v2 share the
+  // _cacheEnvelope discriminator, so falling through would hand MSAL base64 ciphertext.
+  describe('an envelope from a future version', () => {
+    const future = JSON.stringify({
+      ...JSON.parse(encryptCache('secret', key, 'token-cache')),
+      v: 3,
+    });
+
+    it('is still recognised as ciphertext', () => {
+      expect(isEncryptedCache(future)).toBe(true);
+    });
+
+    it('is rejected by name rather than decrypted', () => {
+      expect(() => decryptCache(future, key, 'token-cache')).toThrow(/envelope version: 3/);
+    });
+
+    it('is rejected even when its shape is unrecognisable', () => {
+      const reshaped = JSON.stringify({ _cacheEnvelope: true, v: 4, payload: 'whatever' });
+
+      expect(isEncryptedCache(reshaped)).toBe(true);
+      expect(() => decryptCache(reshaped, key, 'token-cache')).toThrow(/envelope version: 4/);
+    });
+  });
+
+  describe('isEncryptedCache', () => {
+    it('recognises its own output', () => {
+      expect(isEncryptedCache(encryptCache('secret', key, 'token-cache'))).toBe(true);
+    });
+
+    it('does not mistake a v1 plaintext envelope for ciphertext', () => {
+      expect(isEncryptedCache(wrapCache('plaintext'))).toBe(false);
+    });
+
+    it('does not mistake raw MSAL json or garbage for ciphertext', () => {
+      expect(isEncryptedCache('{"Account":{}}')).toBe(false);
+      expect(isEncryptedCache('not json at all')).toBe(false);
+    });
+  });
+
+  describe('key encoding', () => {
+    it('round-trips a generated key', () => {
+      expect(parseCacheKey(encodeCacheKey(key))).toEqual(key);
+    });
+
+    it('tolerates surrounding whitespace from a key file', () => {
+      expect(parseCacheKey(`  ${encodeCacheKey(key)}\n`)).toEqual(key);
+    });
+
+    it('rejects a key of the wrong length', () => {
+      const short = Buffer.alloc(CACHE_KEY_BYTES - 1).toString('base64');
+
+      expect(() => parseCacheKey(short)).toThrow(/must be 32 bytes/);
+    });
+  });
+});

--- a/test/config-paths.test.ts
+++ b/test/config-paths.test.ts
@@ -1,0 +1,74 @@
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getConfigDir } from '../src/lib/config-paths.js';
+
+describe('config dir resolution', () => {
+  const originalPlatform = process.platform;
+
+  function setPlatform(value: string): void {
+    Object.defineProperty(process, 'platform', { value, configurable: true });
+  }
+
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  });
+
+  it('uses APPDATA on windows', () => {
+    setPlatform('win32');
+    vi.stubEnv('APPDATA', 'C:\\Users\\brian\\AppData\\Roaming');
+
+    expect(getConfigDir()).toBe(
+      path.join('C:\\Users\\brian\\AppData\\Roaming', 'ms-365-mcp-server')
+    );
+  });
+
+  it('falls back to the profile path when APPDATA is unset on windows', () => {
+    setPlatform('win32');
+    vi.stubEnv('APPDATA', '');
+
+    expect(getConfigDir()).toBe(path.join(os.homedir(), 'AppData', 'Roaming', 'ms-365-mcp-server'));
+  });
+
+  it('uses Application Support on macos', () => {
+    setPlatform('darwin');
+
+    expect(getConfigDir()).toBe(
+      path.join(os.homedir(), 'Library', 'Application Support', 'ms-365-mcp-server')
+    );
+  });
+
+  it('uses XDG_CONFIG_HOME on linux', () => {
+    setPlatform('linux');
+    vi.stubEnv('XDG_CONFIG_HOME', '/custom/config');
+
+    expect(getConfigDir()).toBe(path.join('/custom/config', 'ms-365-mcp-server'));
+  });
+
+  it('falls back to ~/.config when XDG_CONFIG_HOME is unset', () => {
+    setPlatform('linux');
+    vi.stubEnv('XDG_CONFIG_HOME', '');
+
+    expect(getConfigDir()).toBe(path.join(os.homedir(), '.config', 'ms-365-mcp-server'));
+  });
+
+  // The XDG spec says a relative value must be ignored, not resolved against cwd.
+  it('ignores a relative XDG_CONFIG_HOME', () => {
+    setPlatform('linux');
+    vi.stubEnv('XDG_CONFIG_HOME', 'relative/config');
+
+    expect(getConfigDir()).toBe(path.join(os.homedir(), '.config', 'ms-365-mcp-server'));
+  });
+
+  it('never resolves inside the installed package', () => {
+    for (const platform of ['win32', 'darwin', 'linux']) {
+      setPlatform(platform);
+      expect(getConfigDir()).not.toContain('node_modules');
+    }
+  });
+});

--- a/test/token-cache-encryption.test.ts
+++ b/test/token-cache-encryption.test.ts
@@ -1,0 +1,521 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  encodeCacheKey,
+  encryptCache,
+  generateCacheKey,
+  isEncryptedCache,
+} from '../src/lib/cache-encryption.js';
+
+vi.mock('../src/logger.js', () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+// keytar is a real dependency here, so without this the suite would read and write the
+// developer's actual login keyring.
+const keychain = new Map<string, string>();
+let keytarAvailable = true;
+/** Reads fail while writes still work - a denied prompt rather than a dead keyring. */
+let keytarReadFails = false;
+/** Runs just after a successful setPassword, to stand in for a racing sibling process. */
+let keychainSetHook: (() => void) | undefined;
+const setPasswordCalls: Array<{ account: string; value: string }> = [];
+
+vi.mock('keytar', () => ({
+  default: {
+    getPassword: vi.fn(async (service: string, account: string) => {
+      if (!keytarAvailable) throw new Error('keychain unavailable');
+      if (keytarReadFails) throw new Error('The user denied the keychain prompt.');
+      return keychain.get(`${service}/${account}`) ?? null;
+    }),
+    setPassword: vi.fn(async (service: string, account: string, value: string) => {
+      if (!keytarAvailable) throw new Error('The stub received bad data.');
+      setPasswordCalls.push({ account, value });
+      keychain.set(`${service}/${account}`, value);
+      keychainSetHook?.();
+    }),
+    deletePassword: vi.fn(async (service: string, account: string) => {
+      if (!keytarAvailable) throw new Error('keychain unavailable');
+      return keychain.delete(`${service}/${account}`);
+    }),
+  },
+}));
+
+const { DefaultTokenCacheStorage, getCacheKeyPath, resetCacheKeyForTests, wrapCache, unwrapCache } =
+  await import('../src/token-cache-storage.js');
+const { default: logger } = await import('../src/logger.js');
+
+const SERVICE = 'ms-365-mcp-server';
+
+describe('encrypted token cache storage', () => {
+  const originalPlatform = process.platform;
+  let dir: string;
+  let cachePath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms365-cache-enc-'));
+    cachePath = path.join(dir, '.token-cache.json');
+    keychain.clear();
+    keytarAvailable = true;
+    keytarReadFails = false;
+    keychainSetHook = undefined;
+    setPasswordCalls.length = 0;
+    // The logger mock is created once for the file, so its calls accumulate across tests
+    // unless each one starts from zero.
+    vi.mocked(logger.warn).mockClear();
+    vi.mocked(logger.info).mockClear();
+    resetCacheKeyForTests();
+    vi.stubEnv('MS365_MCP_TOKEN_CACHE_PATH', cachePath);
+    vi.stubEnv('MS365_MCP_SELECTED_ACCOUNT_PATH', path.join(dir, '.selected-account.json'));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes ciphertext to disk and reads it back', async () => {
+    const storage = new DefaultTokenCacheStorage();
+    const value = wrapCache('{"RefreshToken":{"secret":"do-not-leak"}}');
+
+    await storage.save('token-cache', value);
+
+    const onDisk = fs.readFileSync(cachePath, 'utf8');
+    expect(onDisk).not.toContain('do-not-leak');
+    expect(isEncryptedCache(onDisk)).toBe(true);
+    expect(await storage.load('token-cache')).toBe(value);
+  });
+
+  it('keeps only the key in the keychain, never the cache', async () => {
+    const storage = new DefaultTokenCacheStorage();
+
+    await storage.save('token-cache', wrapCache('{"RefreshToken":{}}'));
+
+    expect([...keychain.keys()]).toEqual([`${SERVICE}/cache-key`]);
+    expect(Buffer.from(keychain.get(`${SERVICE}/cache-key`)!, 'base64')).toHaveLength(32);
+  });
+
+  it('writes the cache file with owner-only permissions', async () => {
+    if (process.platform === 'win32') return;
+    const storage = new DefaultTokenCacheStorage();
+
+    await storage.save('token-cache', wrapCache('secret'));
+
+    expect(fs.statSync(cachePath).mode & 0o777).toBe(0o600);
+  });
+
+  describe('without a keychain', () => {
+    beforeEach(() => {
+      keytarAvailable = false;
+    });
+
+    it('falls back to a key file beside the cache and still round-trips', async () => {
+      const storage = new DefaultTokenCacheStorage();
+      const value = wrapCache('{"RefreshToken":{"secret":"do-not-leak"}}');
+
+      await storage.save('token-cache', value);
+
+      const keyPath = getCacheKeyPath();
+      expect(keyPath).toBe(path.join(dir, '.cache-key'));
+      expect(fs.readFileSync(cachePath, 'utf8')).not.toContain('do-not-leak');
+      expect(await storage.load('token-cache')).toBe(value);
+    });
+
+    it('writes the key file with owner-only permissions', async () => {
+      if (process.platform === 'win32') return;
+      await new DefaultTokenCacheStorage().save('token-cache', wrapCache('secret'));
+
+      expect(fs.statSync(getCacheKeyPath()).mode & 0o777).toBe(0o600);
+    });
+
+    it('reuses an existing key file across processes', async () => {
+      await new DefaultTokenCacheStorage().save('token-cache', wrapCache('first'));
+      const key = fs.readFileSync(getCacheKeyPath(), 'utf8');
+
+      resetCacheKeyForTests();
+      const reloaded = await new DefaultTokenCacheStorage().load('token-cache');
+
+      expect(unwrapCache(reloaded!).data).toBe('first');
+      expect(fs.readFileSync(getCacheKeyPath(), 'utf8')).toBe(key);
+    });
+  });
+
+  describe('recovery', () => {
+    it('reports no cache when the key is gone, but leaves the file alone', async () => {
+      await new DefaultTokenCacheStorage().save('token-cache', wrapCache('secret'));
+
+      keychain.clear();
+      resetCacheKeyForTests();
+
+      await expect(new DefaultTokenCacheStorage().load('token-cache')).resolves.toBeUndefined();
+      expect(fs.existsSync(cachePath)).toBe(true);
+    });
+
+    it('does not trust a tampered cache, and still leaves the file alone', async () => {
+      await new DefaultTokenCacheStorage().save('token-cache', wrapCache('secret'));
+      const envelope = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+      const data = Buffer.from(envelope.data, 'base64');
+      data[0] ^= 0xff;
+      fs.writeFileSync(cachePath, JSON.stringify({ ...envelope, data: data.toString('base64') }));
+      resetCacheKeyForTests();
+
+      await expect(new DefaultTokenCacheStorage().load('token-cache')).resolves.toBeUndefined();
+      expect(fs.existsSync(cachePath)).toBe(true);
+    });
+
+    // The whole point of not deleting: a locked keyring is usually temporary, and the
+    // cache has to survive it.
+    it('recovers the cache once a temporarily unreadable keychain works again', async () => {
+      const value = wrapCache('survives-a-locked-keyring');
+      await new DefaultTokenCacheStorage().save('token-cache', value);
+
+      keytarAvailable = false;
+      resetCacheKeyForTests();
+      await expect(new DefaultTokenCacheStorage().load('token-cache')).resolves.toBeUndefined();
+
+      keytarAvailable = true;
+      resetCacheKeyForTests();
+      await expect(new DefaultTokenCacheStorage().load('token-cache')).resolves.toBe(value);
+    });
+
+    // Leaving the file in place achieves nothing on its own: the sign-in that follows
+    // calls save() against the same path.
+    it('refuses to overwrite a cache it could not decrypt', async () => {
+      await new DefaultTokenCacheStorage().save('token-cache', wrapCache('accounts-a-and-b'));
+      const ciphertext = fs.readFileSync(cachePath, 'utf8');
+
+      keytarAvailable = false;
+      resetCacheKeyForTests();
+      const storage = new DefaultTokenCacheStorage();
+      await expect(storage.load('token-cache')).resolves.toBeUndefined();
+
+      await expect(storage.save('token-cache', wrapCache('only-account-a'))).rejects.toThrow(
+        /Refusing to overwrite/
+      );
+      expect(fs.readFileSync(cachePath, 'utf8')).toBe(ciphertext);
+    });
+
+    // The refusal is what makes the recovery real: once the key reads again the original
+    // cache is still exactly where it was.
+    it('still has the original cache after the keychain comes back', async () => {
+      const original = wrapCache('accounts-a-and-b');
+      await new DefaultTokenCacheStorage().save('token-cache', original);
+
+      keytarAvailable = false;
+      resetCacheKeyForTests();
+      const blind = new DefaultTokenCacheStorage();
+      await blind.load('token-cache');
+      await expect(blind.save('token-cache', wrapCache('only-account-a'))).rejects.toThrow();
+
+      keytarAvailable = true;
+      resetCacheKeyForTests();
+      await expect(new DefaultTokenCacheStorage().load('token-cache')).resolves.toBe(original);
+    });
+
+    it('only warns once however many refreshes are refused', async () => {
+      await new DefaultTokenCacheStorage().save('token-cache', wrapCache('secret'));
+      keytarAvailable = false;
+      resetCacheKeyForTests();
+
+      const storage = new DefaultTokenCacheStorage();
+      await storage.load('token-cache');
+      for (let i = 0; i < 3; i += 1) {
+        await expect(storage.save('token-cache', wrapCache(`refresh-${i}`))).rejects.toThrow();
+      }
+
+      const warnings = vi
+        .mocked(logger.warn)
+        .mock.calls.filter(([message]) => String(message).includes('Not persisting'));
+      expect(warnings).toHaveLength(1);
+    });
+
+    // Anything not positively identified must be treated as worth keeping. These are the
+    // cases that used to slip past a flag set during load and get overwritten.
+    it('refuses to overwrite a cache it cannot read at all', async () => {
+      if (process.platform === 'win32') return;
+      await new DefaultTokenCacheStorage().save('token-cache', wrapCache('secret'));
+      const ciphertext = fs.readFileSync(cachePath, 'utf8');
+      fs.chmodSync(cachePath, 0o000);
+
+      try {
+        const storage = new DefaultTokenCacheStorage();
+        await expect(storage.load('token-cache')).resolves.toBeUndefined();
+        await expect(storage.save('token-cache', wrapCache('fresh'))).rejects.toThrow(
+          /Refusing to overwrite/
+        );
+      } finally {
+        fs.chmodSync(cachePath, 0o600);
+      }
+      expect(fs.readFileSync(cachePath, 'utf8')).toBe(ciphertext);
+    });
+
+    it('refuses to overwrite a truncated ciphertext rather than calling it plaintext', async () => {
+      await new DefaultTokenCacheStorage().save('token-cache', wrapCache('secret'));
+      const truncated = fs.readFileSync(cachePath, 'utf8').slice(0, 40);
+      fs.writeFileSync(cachePath, truncated);
+
+      const storage = new DefaultTokenCacheStorage();
+      // Not handed to MSAL as if it were the cache body, either.
+      await expect(storage.load('token-cache')).resolves.toBeUndefined();
+      await expect(storage.save('token-cache', wrapCache('fresh'))).rejects.toThrow(
+        /Refusing to overwrite/
+      );
+      expect(fs.readFileSync(cachePath, 'utf8')).toBe(truncated);
+    });
+
+    it('still overwrites an empty file, which holds nothing to lose', async () => {
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(cachePath, '');
+
+      const storage = new DefaultTokenCacheStorage();
+      const value = wrapCache('fresh');
+      await expect(storage.save('token-cache', value)).resolves.toBeUndefined();
+      expect(await storage.load('token-cache')).toBe(value);
+    });
+
+    // logout and login are both tools in one long-lived process, so a refusal that
+    // outlives the file it was protecting silently swallows the re-login.
+    it('stops refusing once the cache is deleted', async () => {
+      await new DefaultTokenCacheStorage().save('token-cache', wrapCache('secret'));
+      keytarAvailable = false;
+      resetCacheKeyForTests();
+
+      const storage = new DefaultTokenCacheStorage();
+      await storage.load('token-cache');
+      await expect(storage.save('token-cache', wrapCache('blocked'))).rejects.toThrow();
+
+      await storage.delete('token-cache');
+      const afterLogin = wrapCache('signed-in-again');
+      await expect(storage.save('token-cache', afterLogin)).resolves.toBeUndefined();
+      expect(await storage.load('token-cache')).toBe(afterLogin);
+    });
+
+    it('stops refusing when the cache file is removed from underneath it', async () => {
+      await new DefaultTokenCacheStorage().save('token-cache', wrapCache('secret'));
+      keytarAvailable = false;
+      resetCacheKeyForTests();
+
+      const storage = new DefaultTokenCacheStorage();
+      await storage.load('token-cache');
+      await expect(storage.save('token-cache', wrapCache('blocked'))).rejects.toThrow();
+
+      // What the warning tells the user to do.
+      fs.unlinkSync(cachePath);
+      await expect(storage.save('token-cache', wrapCache('fresh'))).resolves.toBeUndefined();
+    });
+
+    it('stops refusing once a load can decrypt again', async () => {
+      const original = wrapCache('secret');
+      await new DefaultTokenCacheStorage().save('token-cache', original);
+      keytarAvailable = false;
+      resetCacheKeyForTests();
+
+      const storage = new DefaultTokenCacheStorage();
+      await storage.load('token-cache');
+      await expect(storage.save('token-cache', wrapCache('blocked'))).rejects.toThrow();
+
+      // Same process, keychain readable again: the next load clears the refusal.
+      keytarAvailable = true;
+      expect(await storage.load('token-cache')).toBe(original);
+      await expect(storage.save('token-cache', wrapCache('rotated'))).resolves.toBeUndefined();
+    });
+
+    // A cache that has nothing to do with this key must still be writable.
+    it('does not block the other storage key', async () => {
+      await new DefaultTokenCacheStorage().save('token-cache', wrapCache('secret'));
+      keytarAvailable = false;
+      resetCacheKeyForTests();
+
+      const storage = new DefaultTokenCacheStorage();
+      await storage.load('token-cache');
+      const account = wrapCache('{"accountId":"x"}');
+
+      await expect(storage.save('selected-account', account)).resolves.toBeUndefined();
+      expect(await storage.load('selected-account')).toBe(account);
+    });
+
+    // A read failure is not proof the key is absent, so it must not be replaced. The
+    // mint has to happen on a cache with no file yet, because a save over an existing
+    // one is refused before it ever gets as far as needing a key.
+    it('does not overwrite the stored key when the keychain cannot be read', async () => {
+      await new DefaultTokenCacheStorage().save('token-cache', wrapCache('secret'));
+      const original = keychain.get(`${SERVICE}/cache-key`);
+
+      keytarReadFails = true;
+      resetCacheKeyForTests();
+      await new DefaultTokenCacheStorage().save('selected-account', wrapCache('{"a":1}'));
+
+      expect(keychain.get(`${SERVICE}/cache-key`)).toBe(original);
+      // The new key went to a file instead, so both are candidates afterwards.
+      expect(fs.existsSync(getCacheKeyPath())).toBe(true);
+    });
+
+    // Desktop session and container against the same config dir end up with a key in
+    // each home. Preferring the keychain key for writing meant the desktop re-encrypted
+    // under a key the container cannot read: one forced login per alternation, forever.
+    it('writes under the key both environments can read', async () => {
+      // Desktop: token-cache under the keychain key.
+      const onDesktop = wrapCache('written-on-desktop');
+      await new DefaultTokenCacheStorage().save('token-cache', onDesktop);
+      expect(keychain.has(`${SERVICE}/cache-key`)).toBe(true);
+
+      // Keyring unreachable. token-cache is protected, but selected-account has no file
+      // yet, so that save mints the second key. Both homes now hold one.
+      keytarAvailable = false;
+      resetCacheKeyForTests();
+      const headless = new DefaultTokenCacheStorage();
+      await expect(headless.save('token-cache', wrapCache('blocked'))).rejects.toThrow();
+      await headless.save('selected-account', wrapCache('{"a":1}'));
+      expect(fs.existsSync(getCacheKeyPath())).toBe(true);
+
+      // Desktop back: reads under the keychain key, but must rewrite under the file key.
+      keytarAvailable = true;
+      resetCacheKeyForTests();
+      const desktop = new DefaultTokenCacheStorage();
+      expect(await desktop.load('token-cache')).toBe(onDesktop);
+      const rewritten = wrapCache('rewritten-on-desktop');
+      await desktop.save('token-cache', rewritten);
+
+      // Which is what the headless side needs in order to read it at all.
+      keytarAvailable = false;
+      resetCacheKeyForTests();
+      expect(await new DefaultTokenCacheStorage().load('token-cache')).toBe(rewritten);
+    });
+  });
+
+  describe('concurrency', () => {
+    // Two cache accesses in flight at once must not each mint a key: the loser's
+    // ciphertext would be unreadable under the winner's key.
+    it('mints one key for concurrent savers rather than one each', async () => {
+      const storage = new DefaultTokenCacheStorage();
+      const tokenValue = wrapCache('a');
+      const accountValue = wrapCache('b');
+
+      await Promise.all([
+        storage.save('token-cache', tokenValue),
+        storage.save('selected-account', accountValue),
+      ]);
+
+      expect(setPasswordCalls.filter((call) => call.account === 'cache-key')).toHaveLength(1);
+      resetCacheKeyForTests();
+      expect(await storage.load('token-cache')).toBe(tokenValue);
+      expect(await storage.load('selected-account')).toBe(accountValue);
+    });
+
+    // The key file must never appear before its contents: a sibling reading it empty
+    // would treat it as corrupt and replace the key it is about to encrypt under.
+    it('never publishes a key file that is empty or partial', async () => {
+      keytarAvailable = false;
+      await new DefaultTokenCacheStorage().save('token-cache', wrapCache('secret'));
+
+      expect(fs.readFileSync(getCacheKeyPath(), 'utf8').trim()).toHaveLength(44);
+      expect(fs.readdirSync(dir).filter((entry) => entry.endsWith('.tmp'))).toEqual([]);
+    });
+
+    it('adopts a valid key file rather than replacing it', async () => {
+      keytarAvailable = false;
+      const sibling = encodeCacheKey(generateCacheKey());
+      fs.writeFileSync(getCacheKeyPath(), sibling, { mode: 0o600 });
+
+      await new DefaultTokenCacheStorage().save('token-cache', wrapCache('secret'));
+
+      expect(fs.readFileSync(getCacheKeyPath(), 'utf8')).toBe(sibling);
+    });
+
+    // A genuinely corrupt key file must not brick every save for the process lifetime.
+    it('replaces a corrupt key file instead of failing forever', async () => {
+      keytarAvailable = false;
+      fs.writeFileSync(getCacheKeyPath(), 'not-a-key', { mode: 0o600 });
+
+      const storage = new DefaultTokenCacheStorage();
+      const value = wrapCache('secret');
+      await expect(storage.save('token-cache', value)).resolves.toBeUndefined();
+
+      resetCacheKeyForTests();
+      expect(await storage.load('token-cache')).toBe(value);
+    });
+
+    // A stale memoized encryption key outliving its key state is unrecoverable: the cache
+    // gets written under a key stored nowhere, and the refusal then makes that permanent.
+    it('does not keep encrypting under a key the keychain no longer holds', async () => {
+      const storage = new DefaultTokenCacheStorage();
+      await storage.save('token-cache', wrapCache('ours'));
+
+      // A sibling mints its own key, overwrites ours in the keychain, and rewrites the
+      // cache under it.
+      const sibling = generateCacheKey();
+      keychain.set(`${SERVICE}/cache-key`, encodeCacheKey(sibling));
+      const theirs = wrapCache('theirs');
+      fs.writeFileSync(cachePath, encryptCache(theirs, sibling, 'token-cache'));
+
+      // First load fails on our stale key state and resets it; the next one succeeds.
+      await expect(storage.load('token-cache')).resolves.toBeUndefined();
+      expect(await storage.load('token-cache')).toBe(theirs);
+
+      // The save that follows must use the sibling's key, not our stale one.
+      const rotated = wrapCache('rotated');
+      await storage.save('token-cache', rotated);
+
+      resetCacheKeyForTests();
+      expect(await new DefaultTokenCacheStorage().load('token-cache')).toBe(rotated);
+    });
+
+    it('adopts the key a sibling process stored first', async () => {
+      const sibling = encodeCacheKey(generateCacheKey());
+      // The sibling lands its key right after ours, so our write-back sees theirs.
+      keychainSetHook = () => {
+        keychainSetHook = undefined;
+        keychain.set(`${SERVICE}/cache-key`, sibling);
+      };
+
+      const value = wrapCache('secret');
+      await new DefaultTokenCacheStorage().save('token-cache', value);
+
+      // We encrypted under the adopted key, so the sibling's key is the only one needed.
+      expect(keychain.get(`${SERVICE}/cache-key`)).toBe(sibling);
+      resetCacheKeyForTests();
+      expect(await new DefaultTokenCacheStorage().load('token-cache')).toBe(value);
+    });
+  });
+
+  describe('migration from the previous format', () => {
+    it('reads a plaintext cache and re-encrypts it on the next save', async () => {
+      const legacy = wrapCache('{"RefreshToken":{"secret":"do-not-leak"}}');
+      fs.writeFileSync(cachePath, legacy);
+      const storage = new DefaultTokenCacheStorage();
+
+      expect(await storage.load('token-cache')).toBe(legacy);
+
+      await storage.save('token-cache', legacy);
+      const onDisk = fs.readFileSync(cachePath, 'utf8');
+      expect(isEncryptedCache(onDisk)).toBe(true);
+      expect(onDisk).not.toContain('do-not-leak');
+    });
+
+    it('adopts a cache still living in the keychain, then clears that entry', async () => {
+      const legacy = wrapCache('{"RefreshToken":{}}');
+      keychain.set(`${SERVICE}/msal-token-cache`, legacy);
+      const storage = new DefaultTokenCacheStorage();
+
+      expect(await storage.load('token-cache')).toBe(legacy);
+
+      await storage.save('token-cache', legacy);
+      expect(keychain.has(`${SERVICE}/msal-token-cache`)).toBe(false);
+      expect(isEncryptedCache(fs.readFileSync(cachePath, 'utf8'))).toBe(true);
+    });
+
+    it('prefers whichever of keychain and disk was written last', async () => {
+      const older = JSON.stringify({ _cacheEnvelope: true, data: 'older', savedAt: 1000 });
+      const newer = JSON.stringify({ _cacheEnvelope: true, data: 'newer', savedAt: 2000 });
+      keychain.set(`${SERVICE}/msal-token-cache`, older);
+      fs.writeFileSync(cachePath, newer);
+
+      const loaded = await new DefaultTokenCacheStorage().load('token-cache');
+
+      expect(unwrapCache(loaded!).data).toBe('newer');
+    });
+  });
+});

--- a/test/token-cache-paths.test.ts
+++ b/test/token-cache-paths.test.ts
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { migrateLegacyPathsFrom } from '../src/token-cache-storage.js';
+
+vi.mock('../src/logger.js', () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+describe('migration off the package directory', () => {
+  const originalPlatform = process.platform;
+  let legacyDir: string;
+  let targetDir: string;
+
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    legacyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms365-legacy-'));
+    targetDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms365-target-'));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    fs.rmSync(legacyDir, { recursive: true, force: true });
+    fs.rmSync(targetDir, { recursive: true, force: true });
+  });
+
+  function useConfigHome(): string {
+    const configHome = path.join(targetDir, 'config');
+    vi.stubEnv('XDG_CONFIG_HOME', configHome);
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    return path.join(configHome, 'ms-365-mcp-server');
+  }
+
+  it('moves both files to the config dir and leaves the package directory clean', () => {
+    fs.writeFileSync(path.join(legacyDir, '.token-cache.json'), 'legacy-cache');
+    fs.writeFileSync(path.join(legacyDir, '.selected-account.json'), 'legacy-account');
+    const appDir = useConfigHome();
+
+    migrateLegacyPathsFrom(legacyDir);
+
+    expect(fs.readFileSync(path.join(appDir, '.token-cache.json'), 'utf8')).toBe('legacy-cache');
+    expect(fs.readFileSync(path.join(appDir, '.selected-account.json'), 'utf8')).toBe(
+      'legacy-account'
+    );
+    expect(fs.existsSync(path.join(legacyDir, '.token-cache.json'))).toBe(false);
+    expect(fs.existsSync(path.join(legacyDir, '.selected-account.json'))).toBe(false);
+  });
+
+  it('never clobbers a cache already at the new location', () => {
+    fs.writeFileSync(path.join(legacyDir, '.token-cache.json'), 'legacy-cache');
+    const appDir = useConfigHome();
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(path.join(appDir, '.token-cache.json'), 'current-cache');
+
+    migrateLegacyPathsFrom(legacyDir);
+
+    expect(fs.readFileSync(path.join(appDir, '.token-cache.json'), 'utf8')).toBe('current-cache');
+  });
+
+  it('leaves the legacy file alone when the path is pinned by env', () => {
+    fs.writeFileSync(path.join(legacyDir, '.token-cache.json'), 'legacy-cache');
+    vi.stubEnv('MS365_MCP_TOKEN_CACHE_PATH', path.join(targetDir, '.token-cache.json'));
+
+    migrateLegacyPathsFrom(legacyDir);
+
+    expect(fs.existsSync(path.join(legacyDir, '.token-cache.json'))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, '.token-cache.json'))).toBe(false);
+  });
+
+  it('does nothing when there is no legacy file to move', () => {
+    const appDir = useConfigHome();
+
+    migrateLegacyPathsFrom(legacyDir);
+
+    expect(fs.existsSync(path.join(appDir, '.token-cache.json'))).toBe(false);
+  });
+});

--- a/test/token-cache-storage.test.ts
+++ b/test/token-cache-storage.test.ts
@@ -85,7 +85,7 @@ describe('token cache storage', () => {
       const storage = await createTokenCacheStorage();
 
       expect(storage).toBeInstanceOf(DefaultTokenCacheStorage);
-      expect(storage.description).toBe('default (keytar+file)');
+      expect(storage.description).toBe('default (encrypted file)');
     });
 
     it('rejects a whitespace-only command for local auth flows', async () => {


### PR DESCRIPTION
Two problems, same file, reported together in #602.

The cache defaulted to a path inside the installed package, so under npx it resolved to %LOCALAPPDATA%\npm-cache\_npx\<hash>\node_modules\... The only durable copy of the refresh token lived in a directory keyed by a content hash of the package spec, and npm cache clean or a version bump discarded it. Defaults now go to the per-user config dir: %APPDATA% on Windows, Application Support on macOS, XDG_CONFIG_HOME elsewhere. A cache left in the package directory is moved on first use. That does not reach a previous npx hash directory, so an npx version bump still costs one sign-in; adopting a cache from a directory we cannot prove we wrote is how GHSA-9w34-3f56-vwmh worked, and one saved sign-in is not worth it.

And on Windows the cache could never reach Credential Manager at all: a credential blob caps at 2560 bytes and a real cache is several times that, so every save logged "The stub received bad data" and fell through to a plaintext file. A key is 32 bytes no matter how many accounts, so the cache files are now AES-256-GCM ciphertext and the keychain holds only the key. Same behaviour on every platform, and no more split store.

The v1 envelope is what gets encrypted, so savedAt travels inside the ciphertext under the GCM tag and callers see the same string as before. Both files share one key, so each is bound to its purpose through the additional data; otherwise they are interchangeable ciphertext and one could be copied over the other. Not defended against: replacing a file with an older, still valid encryption of itself, which needs a counter kept outside the file.

Key lifecycle decides whether people lose their refresh token, so:

- Failing to read the keychain is not the same as there being no key. A locked keyring leaves canUseKeychain false, so a new key goes to a file and never overwrites the one we could not read.
- Both homes are candidates on load, and the file key wins on write. A key file only exists because some run could not use the keychain, and that run cannot read a keychain key either - encrypting under it would cost a sign-in every time the environment flips.
- Key init memoizes the in-flight promise, not the resolved value, so concurrent cache accesses cannot each mint. Across processes the key file is published by linking a fully written temp file, so a reader sees either nothing or a whole key, and the loser adopts the winner's.

Whether the cache may be overwritten is decided by reading it, not by remembering an earlier verdict. Anything not positively identified - an unreadable file, a truncated envelope, an unknown envelope version - counts as worth keeping and is refused, so an unanticipated failure cannot default to "safe to overwrite". The cost is that nothing persists while the cache is unreadable, which means a sign-in per start until the key reads again. The log says so once and names the file to delete if it never does.

Where there is no keychain the key goes in a 0600 file beside the cache. That guards against a stray cat, a backup or an accidental commit, not against someone who can already read the directory. The README says as much rather than dressing it up.

Migration reads a plaintext cache as-is and re-encrypts on next save, and adopts a cache still sitting in the keychain before clearing that entry.

Closes #602