### PR TITLE
fix(tools): move a misplaced itemBody into the nested body field

### DIFF
--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -806,6 +806,12 @@ function registerUtilityToolWithMcp(
   );
 }
 
+// Every nested `body` field in the generated clients is an itemBody, so an @odata.type
+// naming it is the only one that belongs inside a body we just moved fields into
+function namesNestedBodyType(value: unknown): boolean {
+  return typeof value === 'string' && value.toLowerCase().endsWith('itembody');
+}
+
 // Dig out the object shape of a Body schema so flattened top-level params can be
 // matched against it (#569). z.lazy (chatMessage etc.) hides it behind _def.getter
 function bodySchemaShape(schema: z.ZodTypeAny | undefined): Record<string, unknown> | null {
@@ -1091,18 +1097,61 @@ async function executeGraphTool(
       }
     }
 
+    // The client passed the nested itemBody's own fields as the whole request body - move
+    // them under the schema's `body` field (#620). Graph body schemas are all-optional, so
+    // the safeParse wrap in `case 'Body'` can't catch this: the inner itemBody parses clean
+    // as the outer type. A key only moves if it belongs to the nested field's own shape;
+    // being unknown to the outer shape means nothing, because generated schemas are trimmed
+    // subsets that passthrough real fields (message.isRead isn't in the shape). Keys are
+    // matched case-insensitively, and anything left behind stays top-level so a stray
+    // sibling can't cost us the repair - or get buried in the body and silently lost
+    if (
+      isPlainObject(body) &&
+      bodyShape != null &&
+      hasOwn(bodyShape, 'body') &&
+      !Object.keys(body).some((k) => k.toLowerCase() === 'body')
+    ) {
+      const nestedShape = bodySchemaShape(bodyShape.body as z.ZodTypeAny);
+      if (nestedShape != null) {
+        const nestedKeys = new Set(Object.keys(nestedShape).map((k) => k.toLowerCase()));
+        const outerKeys = new Set(Object.keys(bodyShape).map((k) => k.toLowerCase()));
+        // Null-prototype accumulators: a literal would route a '__proto__' key through the
+        // legacy setter, dropping the field instead of storing it
+        const nested: Record<string, unknown> = Object.create(null);
+        const kept: Record<string, unknown> = Object.create(null);
+        const annotations: Record<string, unknown> = Object.create(null);
+
+        for (const [key, value] of Object.entries(body)) {
+          const lower = key.toLowerCase();
+          if (key.startsWith('@')) {
+            // An annotation belongs to whatever it names, so only an @odata.type naming the
+            // nested type travels with the moved fields. An outer @odata.type (or an
+            // @odata.etag) describes the entity it is already on and stays put
+            if (lower === '@odata.type' && namesNestedBodyType(value)) {
+              annotations[key] = value;
+            } else {
+              kept[key] = value;
+            }
+          } else if (nestedKeys.has(lower) && !outerKeys.has(lower)) {
+            nested[key] = value;
+          } else {
+            kept[key] = value;
+          }
+        }
+
+        if (Object.keys(nested).length > 0) {
+          body = { ...kept, body: { ...nested, ...annotations } };
+          logger.info(
+            `Moved misplaced fields into nested 'body' for ${tool.alias}: ${Object.keys(nested).join(', ')}`
+          );
+        }
+      }
+    }
+
     if (Object.keys(strayBodyFields).length > 0) {
       if (isPlainObject(body)) {
-        // If none of body's keys are schema fields but the schema has a `body` field
-        // (message.body), the client meant it as that field - nest it. Spread order lets
-        // an explicit body win over stray duplicates in both branches
-        const keys = Object.keys(body);
-        const bodyIsNestedField =
-          bodyShape != null &&
-          hasOwn(bodyShape, 'body') &&
-          keys.length > 0 &&
-          keys.every((k) => !hasOwn(bodyShape, k));
-        body = bodyIsNestedField ? { ...strayBodyFields, body } : { ...strayBodyFields, ...body };
+        // Spread order lets an explicit body win over stray duplicates
+        body = { ...strayBodyFields, ...body };
         logger.info(`Merged flattened body fields: ${Object.keys(strayBodyFields).join(', ')}`);
       } else if (body == null) {
         body = strayBodyFields;

--- a/test/body-field-fallback.test.ts
+++ b/test/body-field-fallback.test.ts
@@ -25,6 +25,8 @@ vi.mock('../src/generated/client.js', async () => {
             {
               name: 'body',
               type: 'Body',
+              // Trimmed like the generated schemas: `isRead` is a real message field that
+              // the spec-derived shape omits and passthrough carries to Graph anyway
               schema: z.object({
                 id: z.string().optional(),
                 createdDateTime: z.string().optional(),
@@ -171,5 +173,169 @@ describe('Flattened body field fallback (issue #569)', () => {
     await handler({ subject: 'Hello', body: {} });
 
     expect(sentBody()).toEqual({ subject: 'Hello' });
+  });
+
+  it('nests a misplaced itemBody when there are no stray fields to merge (issue #620)', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ body: { contentType: 'html', content: '<p>test</p>' } });
+
+    expect(sentBody()).toEqual({ body: { contentType: 'html', content: '<p>test</p>' } });
+  });
+
+  it('leaves a non-object body alone when there are no stray fields', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ body: 'raw string body' });
+
+    const options = (mockGraphClient.graphRequest as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      body: string;
+    };
+    expect(options.body).toBe('raw string body');
+  });
+
+  it('leaves an empty body object alone when there are no stray fields', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ body: {} });
+
+    expect(sentBody()).toEqual({});
+  });
+
+  it('leaves a passthrough field the trimmed schema omits unwrapped (isRead stays top-level)', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ body: { isRead: true } });
+
+    expect(sentBody()).toEqual({ isRead: true });
+  });
+
+  it('moves only the itemBody keys and leaves a foreign sibling top-level', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ body: { contentType: 'html', content: 'Hi', isRead: true } });
+
+    expect(sentBody()).toEqual({ isRead: true, body: { contentType: 'html', content: 'Hi' } });
+  });
+
+  it('nests a misplaced itemBody whose keys arrive in PascalCase', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ subject: 'Hello', body: { Content: 'Hi', ContentType: 'html' } });
+
+    expect(sentBody()).toEqual({
+      subject: 'Hello',
+      body: { Content: 'Hi', ContentType: 'html' },
+    });
+  });
+
+  it('moves an @odata.type that names the itemBody into the body', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({
+      body: { content: 'Hi', contentType: 'html', '@odata.type': '#microsoft.graph.itemBody' },
+    });
+
+    expect(sentBody()).toEqual({
+      body: { content: 'Hi', contentType: 'html', '@odata.type': '#microsoft.graph.itemBody' },
+    });
+  });
+
+  it('leaves an @odata.type that names the outer entity top-level', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({
+      body: { content: 'Hi', '@odata.type': '#microsoft.graph.message' },
+    });
+
+    expect(sentBody()).toEqual({
+      '@odata.type': '#microsoft.graph.message',
+      body: { content: 'Hi' },
+    });
+  });
+
+  it('leaves other OData annotations on the entity they came from', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ body: { content: 'Hi', '@odata.etag': 'W/"abc"' } });
+
+    expect(sentBody()).toEqual({ '@odata.etag': 'W/"abc"', body: { content: 'Hi' } });
+  });
+
+  it('preserves a __proto__ key instead of dropping it through the legacy setter', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ body: JSON.parse('{"content":"Hi","__proto__":{"polluted":true}}') });
+
+    // Built with JSON.parse on both sides: a '__proto__' key in an object literal sets the
+    // prototype instead of becoming an own property, so a literal can't express this
+    expect(sentBody()).toEqual(
+      JSON.parse('{"__proto__":{"polluted":true},"body":{"content":"Hi"}}')
+    );
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('declines to repair when the body carries a case-variant body key', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    const payload = { BODY: { content: 'wrong' }, content: 'intended' };
+    await handler({ body: payload });
+
+    expect(sentBody()).toEqual(payload);
+  });
+
+  it('never clobbers a body that already carries its own body field', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    const message = { body: { contentType: 'text', content: 'real body' }, content: 'stray' };
+    await handler({ body: message });
+
+    expect(sentBody()).toEqual(message);
+  });
+
+  it('leaves a passthrough field unwrapped even when stray fields are present', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ subject: 'Hello', body: { isRead: true } });
+
+    expect(sentBody()).toEqual({ subject: 'Hello', isRead: true });
+  });
+
+  it('nests a misplaced itemBody carrying only content', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ body: { content: 'Hi' } });
+
+    expect(sentBody()).toEqual({ body: { content: 'Hi' } });
+  });
+
+  it('nests a misplaced itemBody carrying only contentType', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ body: { contentType: 'html' } });
+
+    expect(sentBody()).toEqual({ body: { contentType: 'html' } });
+  });
+
+  it('nests a misplaced itemBody while still merging stray fields (issue #569 + #620)', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({
+      subject: 'Hello',
+      body: { contentType: 'html', content: 'Hi' },
+    });
+
+    expect(sentBody()).toEqual({
+      subject: 'Hello',
+      body: { contentType: 'html', content: 'Hi' },
+    });
+  });
+
+  it('does not double-wrap a body the case-Body safeParse already corrected', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ body: { body: { contentType: 'html', content: 'Hi' } } });
+
+    expect(sentBody()).toEqual({ body: { contentType: 'html', content: 'Hi' } });
   });
 });

--- a/test/misplaced-body-wrap.test.ts
+++ b/test/misplaced-body-wrap.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { registerGraphTools } from '../src/graph-tools.js';
+import type { GraphClient } from '../src/graph-client.js';
+
+vi.mock('../src/logger.js', () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+// Runs against the real generated schemas on purpose: the mocked suite in
+// body-field-fallback.test.ts can't show that spec-derived shapes are trimmed subsets,
+// which is exactly what decides whether a body gets nested (#620)
+describe('Misplaced request body wrapping (issue #620)', () => {
+  let mockServer: { tool: ReturnType<typeof vi.fn>; registerTool: ReturnType<typeof vi.fn> };
+  let mockGraphClient: GraphClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockServer = { tool: vi.fn(), registerTool: vi.fn() };
+    mockGraphClient = {
+      graphRequest: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{}' }] }),
+    } as unknown as GraphClient;
+  });
+
+  function getToolHandler(toolName: string) {
+    registerGraphTools(mockServer, mockGraphClient, false, undefined, true);
+    const call = mockServer.registerTool.mock.calls.find((c: unknown[]) => c[0] === toolName);
+    expect(call).toBeDefined();
+    return call![call!.length - 1] as (params: Record<string, unknown>) => Promise<unknown>;
+  }
+
+  function sentBody(): Record<string, unknown> {
+    const options = (mockGraphClient.graphRequest as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      body: string;
+    };
+    return JSON.parse(options.body);
+  }
+
+  it('nests an itemBody passed as the whole body of send-chat-message', async () => {
+    const handler = getToolHandler('send-chat-message');
+
+    await handler({
+      chatId: '19:abc@unq.gbl.spaces',
+      body: { contentType: 'html', content: '<p>test</p>' },
+    });
+
+    expect(sentBody()).toEqual({ body: { contentType: 'html', content: '<p>test</p>' } });
+  });
+
+  it('leaves isRead alone even though the trimmed message schema omits it', async () => {
+    const handler = getToolHandler('update-mail-message');
+
+    await handler({ messageId: 'AAMk123', body: { isRead: true } });
+
+    expect(sentBody()).toEqual({ isRead: true });
+  });
+
+  it('nests an itemBody passed as the whole body of create-draft-email', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    await handler({ body: { contentType: 'text', content: 'Hi there' } });
+
+    expect(sentBody()).toEqual({ body: { contentType: 'text', content: 'Hi there' } });
+  });
+
+  it('leaves the body alone when the outer schema has no body field (send-mail)', async () => {
+    const handler = getToolHandler('send-mail');
+
+    await handler({ body: { contentType: 'html', content: 'Hi' } });
+
+    expect(sentBody()).toEqual({ contentType: 'html', content: 'Hi' });
+  });
+
+  it('never touches graph-batch request bodies', async () => {
+    const handler = getToolHandler('graph-batch');
+
+    const requests = {
+      requests: [
+        { id: '1', method: 'POST', url: '/me/sendMail', body: { content: 'Hi' } },
+        { id: '2', method: 'GET', url: '/me' },
+      ],
+    };
+    await handler({ body: requests });
+
+    expect(sentBody()).toEqual(requests);
+  });
+
+  it('leaves a correctly shaped message body untouched', async () => {
+    const handler = getToolHandler('create-draft-email');
+
+    const message = { subject: 'Hello', body: { contentType: 'text', content: 'Hi there' } };
+    await handler({ body: message });
+
+    expect(sentBody()).toEqual(message);
+  });
+});


### PR DESCRIPTION
An LLM that passes the itemBody as the whole `body` parameter reached Graph unwrapped and failed with 400 Missing body content. The repair for this already existed but only ran inside the stray-field merge branch, so the common shape - a call that misplaces `body` and nothing else - never hit it.

The safeParse wrap in `case 'Body'` cannot catch it either: Graph body schemas are all-optional, so the inner itemBody parses clean as the outer type and the wrap never fires.

Partition the body instead of wrapping it wholesale. A key moves under `body` only when it belongs to the nested field's own shape, matched case-insensitively; anything else stays top-level. Membership in the outer shape is not evidence either way - the generator trims schemas to 25 properties and passes the rest through, so real fields like message.isRead are absent from it and must not be nested.

An @odata.type naming the itemBody travels with the fields it describes; other annotations stay on the entity they arrived on. The block is skipped when the body already carries a `body` key, so an explicit one is never clobbered.

Fixes #620