### PR TITLE
feat(mail): add move and update tools for shared mailbox messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ account features (email, calendar, OneDrive, etc.) are available.
 To access shared mailboxes, you need:
 
 1. **Organization mode**: Shared mailbox tools require `--org-mode` flag (work/school accounts only)
-2. **Delegated permissions**: `Mail.Read.Shared` or `Mail.Send.Shared` scopes
+2. **Delegated permissions**: `Mail.Read.Shared` to read, `Mail.ReadWrite.Shared` to create, update or move
+   messages, `Mail.Send.Shared` to send, reply or forward, and `Calendars.Read.Shared` for the shared calendar
+   tools
 3. **Exchange permissions**: The signed-in user must have been granted access to the shared mailbox
 4. **Usage**: Use the shared mailbox's email address as the `user-id` parameter in the shared mailbox tools
 

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -125,6 +125,23 @@
     "workScopes": ["Mail.ReadWrite.Shared"]
   },
   {
+    "pathPattern": "/users/{user-id}/messages/{message-id}/move",
+    "method": "post",
+    "toolName": "move-shared-mailbox-message",
+    "descriptionOverride": "Move a message in another user's mailbox or a shared mailbox to a different folder. The user-id is the mailbox owner's ID or email address, and delegated access to that mailbox is required.",
+    "presets": ["work"],
+    "workScopes": ["Mail.ReadWrite.Shared"],
+    "llmTip": "destinationId accepts folder ID or well-known name (inbox, drafts, sentitems, deleteditems, junkemail, archive)."
+  },
+  {
+    "pathPattern": "/users/{user-id}/messages/{message-id}",
+    "method": "patch",
+    "toolName": "update-shared-mailbox-message",
+    "descriptionOverride": "Update a message in another user's mailbox or a shared mailbox — for example mark it read or unread (isRead), flag it (flag), change its categories or importance, or edit a draft's subject, body, or recipients. The user-id is the mailbox owner's ID or email address, and delegated access to that mailbox is required.",
+    "presets": ["work"],
+    "workScopes": ["Mail.ReadWrite.Shared"]
+  },
+  {
     "pathPattern": "/users/{user-id}/messages/{message-id}/reply",
     "method": "post",
     "toolName": "reply-shared-mailbox-mail",


### PR DESCRIPTION
The shared-mailbox tool family covered list, get, draft, send, reply and forward, but not move or PATCH. The only way to reach those against a shared mailbox was graph-batch, which is an unvalidated passthrough with a far larger blast radius and no per-tool permission granularity.

Also documents Mail.ReadWrite.Shared and Calendars.Read.Shared in the shared mailbox section, which listed neither.

Closes #621