### PR TITLE
feat(teams): offer Chat.ReadBasic as least-privilege scope alternative for list-chats/get-chat

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1560,14 +1560,14 @@
     "method": "get",
     "toolName": "list-chats",
     "presets": ["teams", "work"],
-    "workScopes": ["Chat.Read"]
+    "workScopes": [["Chat.Read"], ["Chat.ReadBasic"]]
   },
   {
     "pathPattern": "/chats/{chat-id}",
     "method": "get",
     "toolName": "get-chat",
     "presets": ["teams", "work"],
-    "workScopes": ["Chat.Read"]
+    "workScopes": [["Chat.Read"], ["Chat.ReadBasic"]]
   },
   {
     "pathPattern": "/chats/{chat-id}/members",


### PR DESCRIPTION
Closes #630.

`list-chats` and `get-chat` currently hard-require `Chat.Read`, which makes them unusable in send-only deployments where the Azure app deliberately has no message-content read grants. Microsoft Graph's documented least-privileged scope for both operations (including `$expand=members`) is `Chat.ReadBasic` — chat topic/type/members, no message bodies.

The OR-group machinery for exactly this (`scopes?: string[] | string[][]`, `getEndpointEffectiveLoginScopes` picking the first group covered by `--allowed-scopes`) already exists in `src/auth.ts` but no endpoint used it. This is the first use — a data-only change:

```json
"workScopes": [["Chat.Read"], ["Chat.ReadBasic"]]
```

**Behavior (verified with `--list-permissions` on the built package):**

| Configuration | Before | After |
|---|---|---|
| `--preset teams` (default) | requests `Chat.Read` | unchanged — primary group first |
| `--allowed-scopes '… Chat.Read …'` | `Chat.Read`, tools enabled | unchanged |
| `--allowed-scopes '… Chat.ReadBasic …'` (no `Chat.Read`) | **tools disabled** | tools enabled, requests `Chat.ReadBasic` |

Under `Chat.ReadBasic`, Graph itself rejects message-content access (`$expand=lastMessagePreview`, `/messages`) — which is the point for write-only deployments.

`npm run verify`: 813/813 tests pass, lint/format clean.
