### PR TITLE
feat(teams): add teams-write preset - send-only counterpart to --read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,11 +553,10 @@ npx @softeria/ms-365-mcp-server --preset outlook
 npx @softeria/ms-365-mcp-server --org-mode --preset teams
 ```
 
-The `teams-write` preset is the send-only counterpart to `--read-only`: send/reply in chats and channels, list chats/teams/channels by name, and activity notifications - no message reading and no byte downloaders. Pair it with `--allowed-scopes` so the token cannot read message content either:
+The `teams-write` preset is the send-only counterpart to `--read-only`: send/reply in chats and channels, list chats/teams/channels by name, and activity notifications - no message reading and no byte downloaders. The requested token is minimal by construction (`Chat.ReadBasic`, the `*.Send` scopes, and basic team/channel listing - nothing that can read message content):
 
 ```bash
-npx @softeria/ms-365-mcp-server --org-mode --preset teams-write \
-  --allowed-scopes 'User.Read Chat.ReadBasic ChatMessage.Send ChannelMessage.Send Team.ReadBasic.All Channel.ReadBasic.All TeamsActivity.Send'
+npx @softeria/ms-365-mcp-server --org-mode --preset teams-write
 ```
 
 ## Dynamic Tool Discovery

--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ npx @softeria/ms-365-mcp-server --preset outlook
 npx @softeria/ms-365-mcp-server --org-mode --preset teams
 ```
 
-The `teams-write` preset is the send-only counterpart to `--read-only`: send/reply in chats and channels, list chats/teams/channels by name, and activity notifications - no message reading and no byte downloaders. The requested token is minimal by construction (`Chat.ReadBasic`, the `*.Send` scopes, and basic team/channel listing - nothing that can read message content):
+The `teams-write` preset is the send-only counterpart to `--read-only`: send in chats, send/reply in channels, list chats/teams/channels by name, and activity notifications - no message reading and no byte downloaders. The requested token is minimal by construction (`Chat.ReadBasic`, the `*.Send` scopes, and basic team/channel listing - nothing that can read message content):
 
 ```bash
 npx @softeria/ms-365-mcp-server --org-mode --preset teams-write

--- a/README.md
+++ b/README.md
@@ -539,9 +539,9 @@ npx @softeria/ms-365-mcp-server --preset mail
 npx @softeria/ms-365-mcp-server --list-presets  # See all available presets
 ```
 
-Available presets: `mail`, `calendar`, `files`, `personal`, `work`, `excel`, `contacts`, `tasks`, `onenote`, `search`, `users`, `outlook`, `onedrive`, `teams`, `all`
+Available presets: `mail`, `calendar`, `files`, `personal`, `work`, `excel`, `contacts`, `tasks`, `onenote`, `search`, `users`, `outlook`, `onedrive`, `teams`, `teams-write`, `all`
 
-Each endpoint in `endpoints.json` declares which presets it belongs to via a `presets` array, so every preset is an exact tool-name allow-list that never over-matches across apps (e.g. `mail` does not include shared-mailbox tools; those are in `work`). The universal binary reader `download-bytes` is included in every preset, so whatever an app returns (a file, an attachment, a photo, a recording) can always be fetched; `get-download-url` (a pre-authenticated URL for drive/SharePoint files) rides with the drive-backed presets. So a preset that can find a file can always read its bytes.
+Each endpoint in `endpoints.json` declares which presets it belongs to via a `presets` array, so every preset is an exact tool-name allow-list that never over-matches across apps (e.g. `mail` does not include shared-mailbox tools; those are in `work`). The universal binary reader `download-bytes` is included in every preset except `teams-write`, so whatever an app returns (a file, an attachment, a photo, a recording) can always be fetched; `get-download-url` (a pre-authenticated URL for drive/SharePoint files) rides with the drive-backed presets. So a preset that can find a file can always read its bytes.
 
 The `outlook`, `onedrive` and `teams` presets are app-scoped: they expose exactly one Microsoft app. Use these for "expose exactly one app" deployments:
 
@@ -551,6 +551,13 @@ npx @softeria/ms-365-mcp-server --preset outlook
 
 # Teams only (requires --org-mode)
 npx @softeria/ms-365-mcp-server --org-mode --preset teams
+```
+
+The `teams-write` preset is the send-only counterpart to `--read-only`: send/reply in chats and channels, list chats/teams/channels by name, and activity notifications - no message reading and no byte downloaders. Pair it with `--allowed-scopes` so the token cannot read message content either:
+
+```bash
+npx @softeria/ms-365-mcp-server --org-mode --preset teams-write \
+  --allowed-scopes 'User.Read Chat.ReadBasic ChatMessage.Send ChannelMessage.Send Team.ReadBasic.All Channel.ReadBasic.All TeamsActivity.Send'
 ```
 
 ## Dynamic Tool Discovery

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -269,11 +269,12 @@ function getEndpointEffectiveLoginScopes(
 function collapseRedundantScopes(scopes: string[]): string[] {
   const scopesSet = new Set(scopes);
 
-  // Scope hierarchy: if we have BOTH a higher scope (ReadWrite) AND lower scopes (Read),
-  // keep only the higher scope since it includes the permissions of the lower scopes.
+  // Scope hierarchy: a higher scope (ReadWrite) includes the permissions of its
+  // lower scopes (Read, ReadBasic), so drop every lower scope that is present -
+  // each on its own, since any subset of them is equally redundant.
   // Do NOT upgrade Read to ReadWrite if we only have Read scopes.
   Object.entries(SCOPE_HIERARCHY).forEach(([higherScope, lowerScopes]) => {
-    if (scopesSet.has(higherScope) && lowerScopes.every((scope) => scopesSet.has(scope))) {
+    if (scopesSet.has(higherScope)) {
       lowerScopes.forEach((scope) => scopesSet.delete(scope));
     }
   });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -113,6 +113,8 @@ interface ScopeHierarchy {
 }
 
 const SCOPE_HIERARCHY: ScopeHierarchy = {
+  'Chat.ReadWrite': ['Chat.Read', 'Chat.ReadBasic'],
+  'Chat.Read': ['Chat.ReadBasic'],
   'Mail.ReadWrite': ['Mail.Read'],
   'Calendars.ReadWrite': ['Calendars.Read'],
   'Files.ReadWrite': ['Files.Read'],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,7 +53,7 @@ program
   )
   .option(
     '--preset <names>',
-    'Use preset tool categories (comma-separated). Available: mail, calendar, files, personal, work, excel, contacts, tasks, onenote, search, users, all'
+    'Use preset tool categories (comma-separated). Available: mail, calendar, files, personal, work, excel, contacts, tasks, onenote, search, users, outlook, onedrive, teams, teams-write, all'
   )
   .option('--list-presets', 'List all available presets and exit')
   .option('--list-permissions', 'List all required Graph API permissions and exit')

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1560,14 +1560,14 @@
     "method": "get",
     "toolName": "list-chats",
     "presets": ["teams", "teams-write", "work"],
-    "workScopes": [["Chat.Read"], ["Chat.ReadBasic"]]
+    "workScopes": ["Chat.ReadBasic"]
   },
   {
     "pathPattern": "/chats/{chat-id}",
     "method": "get",
     "toolName": "get-chat",
     "presets": ["teams", "teams-write", "work"],
-    "workScopes": [["Chat.Read"], ["Chat.ReadBasic"]]
+    "workScopes": ["Chat.ReadBasic"]
   },
   {
     "pathPattern": "/chats/{chat-id}/members",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1559,14 +1559,14 @@
     "pathPattern": "/me/chats",
     "method": "get",
     "toolName": "list-chats",
-    "presets": ["teams", "work"],
+    "presets": ["teams", "teams-write", "work"],
     "workScopes": [["Chat.Read"], ["Chat.ReadBasic"]]
   },
   {
     "pathPattern": "/chats/{chat-id}",
     "method": "get",
     "toolName": "get-chat",
-    "presets": ["teams", "work"],
+    "presets": ["teams", "teams-write", "work"],
     "workScopes": [["Chat.Read"], ["Chat.ReadBasic"]]
   },
   {
@@ -1610,7 +1610,7 @@
     "pathPattern": "/chats/{chat-id}/messages",
     "method": "post",
     "toolName": "send-chat-message",
-    "presets": ["teams", "work"],
+    "presets": ["teams", "teams-write", "work"],
     "workScopes": ["ChatMessage.Send"],
     "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API. To @mention someone, put an <at id=\"0\">Name</at> tag in the html content and add a mentions array to the request body, as a sibling of the body property (not a separate top-level tool parameter): { body: { contentType: 'html', content: 'Hi <at id=\"0\">Name</at>' }, mentions: [{ id: 0, mentionText: 'Name', mentioned: { user: { id: '<aad-user-id>', displayName: 'Name', userIdentityType: 'aadUser' } } }] }. Each mention id must match its <at id> value; include userIdentityType: 'aadUser' or Graph returns 400 'value without a type name'."
   },
@@ -1618,28 +1618,28 @@
     "pathPattern": "/me/joinedTeams",
     "method": "get",
     "toolName": "list-joined-teams",
-    "presets": ["teams", "work"],
+    "presets": ["teams", "teams-write", "work"],
     "workScopes": ["Team.ReadBasic.All"]
   },
   {
     "pathPattern": "/teams/{team-id}",
     "method": "get",
     "toolName": "get-team",
-    "presets": ["teams", "work"],
+    "presets": ["teams", "teams-write", "work"],
     "workScopes": ["Team.ReadBasic.All"]
   },
   {
     "pathPattern": "/teams/{team-id}/channels",
     "method": "get",
     "toolName": "list-team-channels",
-    "presets": ["teams", "work"],
+    "presets": ["teams", "teams-write", "work"],
     "workScopes": ["Channel.ReadBasic.All"]
   },
   {
     "pathPattern": "/teams/{team-id}/channels/{channel-id}",
     "method": "get",
     "toolName": "get-team-channel",
-    "presets": ["teams", "work"],
+    "presets": ["teams", "teams-write", "work"],
     "workScopes": ["Channel.ReadBasic.All"]
   },
   {
@@ -1696,7 +1696,7 @@
     "pathPattern": "/teams/{team-id}/channels/{channel-id}/messages",
     "method": "post",
     "toolName": "send-channel-message",
-    "presets": ["teams", "work"],
+    "presets": ["teams", "teams-write", "work"],
     "workScopes": ["ChannelMessage.Send"],
     "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API. To @mention someone, put an <at id=\"0\">Name</at> tag in the html content and add a mentions array to the request body, as a sibling of the body property (not a separate top-level tool parameter): { body: { contentType: 'html', content: 'Hi <at id=\"0\">Name</at>' }, mentions: [{ id: 0, mentionText: 'Name', mentioned: { user: { id: '<aad-user-id>', displayName: 'Name', userIdentityType: 'aadUser' } } }] }. Each mention id must match its <at id> value; include userIdentityType: 'aadUser' or Graph returns 400 'value without a type name'."
   },
@@ -1704,7 +1704,7 @@
     "pathPattern": "/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies",
     "method": "post",
     "toolName": "reply-to-channel-message",
-    "presets": ["teams", "work"],
+    "presets": ["teams", "teams-write", "work"],
     "workScopes": ["ChannelMessage.Send"],
     "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API. To @mention someone, put an <at id=\"0\">Name</at> tag in the html content and add a mentions array to the request body, as a sibling of the body property (not a separate top-level tool parameter): { body: { contentType: 'html', content: 'Hi <at id=\"0\">Name</at>' }, mentions: [{ id: 0, mentionText: 'Name', mentioned: { user: { id: '<aad-user-id>', displayName: 'Name', userIdentityType: 'aadUser' } } }] }. Each mention id must match its <at id> value; include userIdentityType: 'aadUser' or Graph returns 400 'value without a type name'."
   },
@@ -1783,7 +1783,7 @@
     "pathPattern": "/chats/{chat-id}/messages/{chatMessage-id}/replies",
     "method": "post",
     "toolName": "reply-to-chat-message",
-    "presets": ["teams", "work"],
+    "presets": ["teams", "teams-write", "work"],
     "workScopes": ["ChatMessage.Send"],
     "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API. To @mention someone, put an <at id=\"0\">Name</at> tag in the html content and add a mentions array to the request body, as a sibling of the body property (not a separate top-level tool parameter): { body: { contentType: 'html', content: 'Hi <at id=\"0\">Name</at>' }, mentions: [{ id: 0, mentionText: 'Name', mentioned: { user: { id: '<aad-user-id>', displayName: 'Name', userIdentityType: 'aadUser' } } }] }. Each mention id must match its <at id> value; include userIdentityType: 'aadUser' or Graph returns 400 'value without a type name'."
   },
@@ -2726,7 +2726,7 @@
     "pathPattern": "/me/teamwork/sendActivityNotification",
     "method": "post",
     "toolName": "send-my-activity-notification",
-    "presets": ["teams", "work"],
+    "presets": ["teams", "teams-write", "work"],
     "workScopes": ["TeamsActivity.Send"],
     "contentType": "application/json",
     "llmTip": "Sends a Teams activity feed notification to the current user (the badge + entry in their Activity tab). Body: { topic: { source: 'entityUrl' | 'text', value: <Graph URL or plain text>, webUrl: <required when source='text', click-through URL> }, activityType: <must be declared in the calling Teams app's manifest, OR the reserved 'systemDefault' which provides free-form Actor+Reason text>, previewText: { content: 'short preview' }, templateParameters?: [{ name, value }] (substituted into the manifest's localized notification template), teamsAppId?: <optional disambiguator when multiple installed apps share a Microsoft Entra app ID — fetch via list-my-installed-teams-apps>, chainId?, iconId? }. Use to ping the user with 'action required' notifications from agentic workflows. See https://learn.microsoft.com/graph/teams-send-activityfeednotifications."

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1783,7 +1783,7 @@
     "pathPattern": "/chats/{chat-id}/messages/{chatMessage-id}/replies",
     "method": "post",
     "toolName": "reply-to-chat-message",
-    "presets": ["teams", "teams-write", "work"],
+    "presets": ["teams", "work"],
     "workScopes": ["ChatMessage.Send"],
     "llmTip": "Use contentType 'html' in the body — plain text contentType gets mangled by Graph API. To @mention someone, put an <at id=\"0\">Name</at> tag in the html content and add a mentions array to the request body, as a sibling of the body property (not a separate top-level tool parameter): { body: { contentType: 'html', content: 'Hi <at id=\"0\">Name</at>' }, mentions: [{ id: 0, mentionText: 'Name', mentioned: { user: { id: '<aad-user-id>', displayName: 'Name', userIdentityType: 'aadUser' } } }] }. Each mention id must match its <at id> value; include userIdentityType: 'aadUser' or Graph returns 400 'value without a type name'."
   },

--- a/src/tool-categories.ts
+++ b/src/tool-categories.ts
@@ -19,7 +19,10 @@ const endpointEntries = JSON.parse(
 // which presets it belongs to via its `presets` array, so presets are exact
 // tool-name allow-lists that can't over-match across apps the way the old
 // loose name regexes could (e.g. "mail" also matching shared-mailbox tools).
-const PRESET_META: Record<string, { description: string; requiresOrgMode?: boolean }> = {
+const PRESET_META: Record<
+  string,
+  { description: string; requiresOrgMode?: boolean; omitUniversalUtilities?: boolean }
+> = {
   mail: {
     description: 'Email operations (read, send, manage folders, attachments)',
   },
@@ -66,6 +69,13 @@ const PRESET_META: Record<string, { description: string; requiresOrgMode?: boole
     description: 'Teams app only: chats, channels, meetings and presence',
     requiresOrgMode: true,
   },
+  'teams-write': {
+    description:
+      'Teams send-only: send/reply in chats and channels, list chats/teams/channels by name, activity notifications - no message reading',
+    requiresOrgMode: true,
+    // A write-only preset must not include the generic byte readers.
+    omitUniversalUtilities: true,
+  },
 };
 
 // Utility tools (graph-tools.ts UTILITY_TOOLS) are code-defined, not in endpoints.json, so they
@@ -85,7 +95,7 @@ const UNIVERSAL_UTILITY_TOOLS = ['download-bytes', 'download-bytes-to-file'];
 // universal download-bytes still reads the bytes. parse-teams-url only parses Teams meeting URLs.
 const SCOPED_UTILITY_TOOLS: Record<string, string[]> = {
   'get-download-url': ['files', 'onedrive', 'personal', 'work', 'search'],
-  'parse-teams-url': ['teams', 'work'],
+  'parse-teams-url': ['teams', 'teams-write', 'work'],
 };
 
 // Fail fast if a scoped utility references a preset that does not exist (e.g. a typo like
@@ -111,7 +121,7 @@ function presetPattern(preset: string): RegExp {
   }
   const names = [
     ...endpointNames,
-    ...UNIVERSAL_UTILITY_TOOLS,
+    ...(PRESET_META[preset]?.omitUniversalUtilities ? [] : UNIVERSAL_UTILITY_TOOLS),
     ...Object.entries(SCOPED_UTILITY_TOOLS)
       .filter(([, presets]) => presets.includes(preset))
       .map(([name]) => name),

--- a/test/presets.test.ts
+++ b/test/presets.test.ts
@@ -136,11 +136,12 @@ describe('utility tools in presets', () => {
 
   // download-bytes and download-bytes-to-file are universal Graph binary readers (base64 vs stream
   // to disk), so no preset - current or future - should be able to find a resource without being
-  // able to read its bytes.
+  // able to read its bytes. teams-write is the one deliberate exception: a send-only preset must
+  // not carry byte readers (its own contract test pins that exclusion).
   it.each(['download-bytes', 'download-bytes-to-file'])(
-    '%s is available in every preset (universal binary reader)',
+    '%s is available in every preset except teams-write (universal binary reader)',
     (tool) => {
-      for (const preset of namedPresets) {
+      for (const preset of namedPresets.filter((name) => name !== 'teams-write')) {
         expect(inPreset(preset, tool), `${tool} missing from ${preset}`).toBe(true);
       }
     }

--- a/test/teams-write-preset.test.ts
+++ b/test/teams-write-preset.test.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
-import { TOOL_CATEGORIES } from '../src/tool-categories.js';
+import { buildAllowedScopeDiagnostics } from '../src/auth.js';
+import { getCombinedPresetPattern, TOOL_CATEGORIES } from '../src/tool-categories.js';
 
 // Contract tests for the teams-write preset: it is a security boundary
 // (send-only Teams surface), so its exact tool list, the scopes it can be
@@ -106,5 +107,34 @@ describe('teams-write preset contract', () => {
 
   it('requires org mode', () => {
     expect(TOOL_CATEGORIES['teams-write'].requiresOrgMode).toBe(true);
+  });
+
+  // The pins above assert what endpoints.json declares; this one asserts what
+  // the auth layer actually computes from it - the scopes a login for the
+  // preset would request. This is the README claim, CI-enforced end to end.
+  // (User.Read and offline_access are injected at the OAuth layer, not here.)
+  it('computes exactly the write-only token for the preset', () => {
+    const diagnostics = buildAllowedScopeDiagnostics({
+      enabledTools: getCombinedPresetPattern(['teams-write']),
+      orgMode: true,
+    });
+    const endpointDerived = [...WRITE_ONLY_SCOPES].filter((s) => s !== 'User.Read').sort();
+    expect(diagnostics.effectivePermissions).toEqual(endpointDerived);
+    expect(diagnostics.disabledTools).toEqual([]);
+  });
+});
+
+describe('scope hierarchy collapse', () => {
+  it('drops a lower scope even when its siblings are absent', () => {
+    // list-chats brings Chat.ReadBasic, update-chat-message brings Chat.ReadWrite,
+    // and nothing brings Chat.Read - the collapse must still drop ReadBasic
+    // rather than requiring the full lower tier to be present.
+    const diagnostics = buildAllowedScopeDiagnostics({
+      enabledTools: '^(list-chats|update-chat-message)$',
+      orgMode: true,
+    });
+    expect(diagnostics.effectivePermissions).toContain('Chat.ReadWrite');
+    expect(diagnostics.effectivePermissions).not.toContain('Chat.ReadBasic');
+    expect(diagnostics.effectivePermissions).not.toContain('Chat.Read');
   });
 });

--- a/test/teams-write-preset.test.ts
+++ b/test/teams-write-preset.test.ts
@@ -1,0 +1,107 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { TOOL_CATEGORIES } from '../src/tool-categories.js';
+
+// Contract tests for the teams-write preset: it is a security boundary
+// (send-only Teams surface), so its exact tool list, the scopes it can be
+// satisfied by, and the absence of read/download tools are all pinned here.
+// A change that grows the preset must consciously update this contract.
+
+interface Endpoint {
+  toolName: string;
+  pathPattern: string;
+  method: string;
+  presets?: string[];
+  scopes?: string[] | string[][];
+  workScopes?: string[] | string[][];
+}
+
+const endpoints = JSON.parse(
+  readFileSync(path.join(__dirname, '../src/endpoints.json'), 'utf8')
+) as Endpoint[];
+
+const EXPECTED_TOOLS = [
+  'get-chat',
+  'get-team',
+  'get-team-channel',
+  'list-chats',
+  'list-joined-teams',
+  'list-team-channels',
+  'reply-to-channel-message',
+  'reply-to-chat-message',
+  'send-channel-message',
+  'send-chat-message',
+  'send-my-activity-notification',
+].sort();
+
+// The documented minimal token for the preset (README "teams-write" example).
+const WRITE_ONLY_SCOPES = new Set([
+  'User.Read',
+  'Chat.ReadBasic',
+  'ChatMessage.Send',
+  'ChannelMessage.Send',
+  'Team.ReadBasic.All',
+  'Channel.ReadBasic.All',
+  'TeamsActivity.Send',
+]);
+
+const presetEndpoints = endpoints.filter((e) => e.presets?.includes('teams-write'));
+
+function scopeGroups(endpoint: Endpoint): string[][] {
+  const raw = endpoint.workScopes ?? endpoint.scopes ?? [];
+  return Array.isArray(raw[0]) ? (raw as string[][]) : [raw as string[]];
+}
+
+describe('teams-write preset contract', () => {
+  it('contains exactly the expected endpoints', () => {
+    const names = presetEndpoints.map((e) => e.toolName).sort();
+    expect(names).toEqual(EXPECTED_TOOLS);
+  });
+
+  it('exposes exactly the expected tools via its pattern (utilities included, downloaders excluded)', () => {
+    const pattern = TOOL_CATEGORIES['teams-write'].pattern;
+    for (const tool of [...EXPECTED_TOOLS, 'parse-teams-url']) {
+      expect(tool).toMatch(pattern);
+    }
+    for (const tool of [
+      'download-bytes',
+      'download-bytes-to-file',
+      'get-download-url',
+      'list-chat-messages',
+      'get-chat-message',
+      'list-channel-messages',
+      'list-chat-message-hosted-contents',
+      'get-meeting-transcript-content',
+      'delete-team-channel',
+      'remove-team-member',
+      'update-chat-message',
+      'create-chat',
+    ]) {
+      expect(tool).not.toMatch(pattern);
+    }
+  });
+
+  it('every endpoint is satisfiable by the documented write-only scope set', () => {
+    for (const endpoint of presetEndpoints) {
+      const satisfied = scopeGroups(endpoint).some((group) =>
+        group.every((scope) => WRITE_ONLY_SCOPES.has(scope))
+      );
+      expect(satisfied, `${endpoint.toolName} not satisfiable by write-only scopes`).toBe(true);
+    }
+  });
+
+  it('no endpoint touches message content, hosted contents, transcripts, or recordings', () => {
+    for (const endpoint of presetEndpoints) {
+      if (endpoint.method.toLowerCase() === 'get') {
+        expect(endpoint.pathPattern).not.toMatch(
+          /messages|hostedContents|transcripts|recordings|attachments/i
+        );
+      }
+    }
+  });
+
+  it('requires org mode', () => {
+    expect(TOOL_CATEGORIES['teams-write'].requiresOrgMode).toBe(true);
+  });
+});

--- a/test/teams-write-preset.test.ts
+++ b/test/teams-write-preset.test.ts
@@ -82,12 +82,15 @@ describe('teams-write preset contract', () => {
     }
   });
 
-  it('every endpoint is satisfiable by the documented write-only scope set', () => {
+  it('every endpoint requests write-only scopes by default (primary group)', () => {
     for (const endpoint of presetEndpoints) {
-      const satisfied = scopeGroups(endpoint).some((group) =>
-        group.every((scope) => WRITE_ONLY_SCOPES.has(scope))
-      );
-      expect(satisfied, `${endpoint.toolName} not satisfiable by write-only scopes`).toBe(true);
+      const [primary] = scopeGroups(endpoint);
+      for (const scope of primary) {
+        expect(
+          WRITE_ONLY_SCOPES.has(scope),
+          `${endpoint.toolName} primary scope ${scope} is outside the write-only set`
+        ).toBe(true);
+      }
     }
   });
 

--- a/test/teams-write-preset.test.ts
+++ b/test/teams-write-preset.test.ts
@@ -30,7 +30,6 @@ const EXPECTED_TOOLS = [
   'list-joined-teams',
   'list-team-channels',
   'reply-to-channel-message',
-  'reply-to-chat-message',
   'send-channel-message',
   'send-chat-message',
   'send-my-activity-notification',
@@ -78,6 +77,10 @@ describe('teams-write preset contract', () => {
       'remove-team-member',
       'update-chat-message',
       'create-chat',
+      // Not a real v1.0 operation - Graph returns 404 "Requested API is not
+      // supported" for the /chats/.../replies path family; excluded until the
+      // endpoint is removed entirely.
+      'reply-to-chat-message',
     ]) {
       expect(tool).not.toMatch(pattern);
     }


### PR DESCRIPTION
Closes #631.

Adds a `teams-write` preset: send in chats, send/reply in channels, name-only chat/team/channel listing, and activity notifications — no message reading, and the universal byte downloaders are deliberately excluded (`omitUniversalUtilities`), since `download-bytes` is an arbitrary-Graph-path reader that would undermine the send-only boundary whenever the token is broader than the preset. A contract test pins the exact tool list, the computed token, and the exclusions so the boundary is CI-enforced.

The second commit makes `Chat.ReadBasic` the primary scope for `list-chats`/`get-chat` and models the Chat hierarchy (`ReadWrite` ⊃ `Read` ⊃ `ReadBasic`) in `SCOPE_HIERARCHY`. Result: `--preset teams-write` alone requests a minimal token (no `--allowed-scopes` incantation), while `--preset teams` collapses the basic tier away — no new consent on upgrade.

Note re #633: the OR-group alternatives introduced there are superseded by the hierarchy — an allowlist containing `Chat.Read` now covers a flat `Chat.ReadBasic` requirement — so these endpoints return to a single flat scope. Narrow filters wanting `lastMessagePreview` add `--extra-scopes Chat.Read`.

Review updates:

- `collapseRedundantScopes` now drops each present lower scope independently, removing the partial-tier gap and the key-ordering dependency (regression-tested with the `^(list-chats|update-chat-message)$` repro).
- The contract test additionally pins `buildAllowedScopeDiagnostics(...).effectivePermissions` to exactly the six write-only Graph scopes (`User.Read` and `offline_access` are injected at the OAuth layer, not endpoint-derived).
- `reply-to-chat-message` removed from the preset (10 tools): the `/chats/{id}/messages/{id}/replies` path family is not a real v1.0 API — verified live, `GET` returns 404 `NotFound: "Requested API is not supported. Please check the path."` (request-id `b1e5540e-a32d-4957-a93e-ec2a8762c922`). Removing the endpoint entirely (it is equally dead in `teams`) is left for a separate PR.
- Open question: `$expand=lastMessagePreview` on `list-chats` under a `Chat.ReadBasic`-only token is assumed gated (the `lastMessagePreview` GET documents `Chat.Read` as its floor) but not yet observed empirically — consent for a `ReadBasic`-only token is pending admin approval on my side. Evidence to be pinned here once available.

820/820 tests, lint/format clean.
