### PR TITLE
ci: type-check with tsc in verify and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,9 @@ jobs:
         run: npm run format:check
 
       # tsup strips types without checking them, so build alone cannot catch type errors
+      # Node 18 skips the @azure/* optional deps (engines >=20), so tsc can't find them
       - name: Type check
+        if: matrix.node-version != '18.x'
         run: npm run typecheck
 
       - name: Build TypeScript

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Check formatting
         run: npm run format:check
 
+      # tsup strips types without checking them, so build alone cannot catch type errors
+      - name: Type check
+        run: npm run typecheck
+
       - name: Build TypeScript
         run: npm run build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
       - run: npm run generate
       - run: npm run lint
       - run: npm run format:check
+      - run: npm run typecheck
       - run: npm run build
       - run: npm test
       - run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "format:check": "prettier --check \"**/*.{ts,mts,js,mjs,json,md}\"",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "verify": "npm run generate && npm run lint && npm run format:check && npm run build && npm run test",
+    "typecheck": "tsc --noEmit",
+    "verify": "npm run generate && npm run lint && npm run format:check && npm run typecheck && npm run build && npm run test",
     "inspector": "npx @modelcontextprotocol/inspector tsx src/index.ts"
   },
   "keywords": [

--- a/src/auth-tools.ts
+++ b/src/auth-tools.ts
@@ -38,7 +38,6 @@ export function registerAuthTools(server: McpServer, authManager: AuthManager): 
                 type: 'text',
                 text: JSON.stringify({
                   status: 'Login successful',
-                  message: 'Browser authentication completed successfully.',
                   ...loginResult,
                 }),
               },

--- a/test/auth-tools.test.ts
+++ b/test/auth-tools.test.ts
@@ -102,6 +102,7 @@ describe('Auth Tools', () => {
         .mockResolvedValueOnce({ success: false, message: 'Not logged in' })
         .mockResolvedValueOnce({
           success: true,
+          message: 'Login successful',
           userData: { displayName: 'Browser User' },
         });
 
@@ -109,8 +110,14 @@ describe('Auth Tools', () => {
 
       expect(authManager.acquireTokenInteractive).toHaveBeenCalled();
       expect(authManager.acquireTokenByDeviceCode).not.toHaveBeenCalled();
-      expect(result.content[0].text).toContain('Login successful');
-      expect(result.content[0].text).toContain('Browser authentication completed');
+      expect(result.content[0].text).toBe(
+        JSON.stringify({
+          status: 'Login successful',
+          success: true,
+          message: 'Login successful',
+          userData: { displayName: 'Browser User' },
+        })
+      );
     });
 
     it('should proceed with login when not already logged in', async () => {


### PR DESCRIPTION
tsup strips types without checking them, so nothing in the pipeline was type-checking the source. Type errors only surfaced when someone ran tsc by hand, which is how the pagination TypeError in #615 was found.

verify did not cover it, and CI does not run verify anyway, it runs the steps individually, so the step goes in both workflows too.

Turning it on found one existing error: the browser-auth branch of the login tool set a message that the loginResult spread right below it always overwrote, since LoginTestResult.message is required on every return path. Dropped the dead line. The test only passed because its mock omitted message, so it asserted a string production never emitted. Made the mock faithful and pinned the real output instead.

Tests stay excluded from tsconfig. Including them surfaces ~156 errors, nearly all partial mocks missing properties, which needs its own pass.