### PR TITLE
test: fix audit log mock assertions

### DIFF
--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -2298,7 +2298,6 @@ describe('graph-tools', () => {
         [],
         'Mail.Read'
       );
-      const auditSpy = await spyOnAuditLogger();
       const handler = server.server._requestHandlers.get('tools/call');
 
       await expect(
@@ -2314,7 +2313,7 @@ describe('graph-tools', () => {
         )
       ).rejects.toThrow(/not found/);
 
-      expect(auditSpy).toHaveBeenCalledWith(
+      expect(auditLogMock).toHaveBeenCalledWith(
         expect.objectContaining({
           event: 'tool.denied',
           tool: 'get-drive-item',
@@ -2327,7 +2326,6 @@ describe('graph-tools', () => {
           },
         })
       );
-      auditSpy.mockRestore();
     });
 
     it('discovery hides Graph tools outside the allowed scopes', async () => {
@@ -2415,7 +2413,6 @@ describe('graph-tools', () => {
         undefined,
         'Mail.Read'
       );
-      const auditSpy = await spyOnAuditLogger();
 
       const result = await server.tools.get('execute-tool')!.handler({
         tool_name: 'get-drive-item',
@@ -2424,7 +2421,7 @@ describe('graph-tools', () => {
 
       expect(result.isError).toBe(true);
       expect(JSON.parse(result.content[0].text).error).toMatch(/not found/i);
-      expect(auditSpy).toHaveBeenCalledWith(
+      expect(auditLogMock).toHaveBeenCalledWith(
         expect.objectContaining({
           event: 'tool.denied',
           tool: 'get-drive-item',
@@ -2437,7 +2434,6 @@ describe('graph-tools', () => {
           },
         })
       );
-      auditSpy.mockRestore();
     });
 
     it('audits direct discovery-mode calls to Graph tools denied by allowed scopes', async () => {
@@ -2473,7 +2469,6 @@ describe('graph-tools', () => {
         undefined,
         'Mail.Read'
       );
-      const auditSpy = await spyOnAuditLogger();
       const handler = server.server._requestHandlers.get('tools/call');
 
       await expect(
@@ -2489,7 +2484,7 @@ describe('graph-tools', () => {
         )
       ).rejects.toThrow(/not found/);
 
-      expect(auditSpy).toHaveBeenCalledWith(
+      expect(auditLogMock).toHaveBeenCalledWith(
         expect.objectContaining({
           event: 'tool.denied',
           tool: 'get-drive-item',
@@ -2502,7 +2497,6 @@ describe('graph-tools', () => {
           },
         })
       );
-      auditSpy.mockRestore();
     });
   });
 
@@ -2671,7 +2665,6 @@ describe('graph-tools', () => {
         [],
         '^list-mail-messages$'
       );
-      const auditSpy = await spyOnAuditLogger();
 
       const result = await server.tools.get('execute-tool')!.handler({
         tool_name: 'get-drive-item',
@@ -2680,7 +2673,7 @@ describe('graph-tools', () => {
 
       expect(result.isError).toBe(true);
       expect(JSON.parse(result.content[0].text).error).toMatch(/not found/i);
-      expect(auditSpy).toHaveBeenCalledWith(
+      expect(auditLogMock).toHaveBeenCalledWith(
         expect.objectContaining({
           event: 'tool.denied',
           tool: 'get-drive-item',
@@ -2692,7 +2685,6 @@ describe('graph-tools', () => {
           },
         })
       );
-      auditSpy.mockRestore();
     });
 
     it('utility tools obey the regex too', async () => {


### PR DESCRIPTION
Fixing CI failures in https://github.com/Softeria/ms-365-mcp-server/actions/runs/32066267837/job/95499012220. My apologies about that

```bash
❯ npm run lint

> @softeria/ms-365-mcp-server@0.0.0-development lint
> eslint .


/Users/sharkeyl/repos/cortex/ms-365-mcp-server/src/__tests__/graph-tools.test.ts
    34:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
    45:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
    54:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
    66:42  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
    88:40  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
    99:44  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   135:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   135:60  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   135:70  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   164:17  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   165:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   166:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   166:38  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   175:53  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   176:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   176:38  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   260:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   260:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   297:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   297:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   331:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   331:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   426:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   426:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   464:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   464:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   550:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   550:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   591:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   591:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   628:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   628:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   667:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   667:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   715:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   715:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   726:35  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   764:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   764:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   815:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   815:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   830:35  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   848:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   848:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   883:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   883:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   928:38  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   928:58  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   958:38  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   958:58  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   974:38  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   974:58  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   991:38  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   991:70  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1003:38  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1003:70  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1021:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1021:68  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1060:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1060:68  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1082:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1082:68  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1114:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1114:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1137:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1137:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1180:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1180:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1220:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1220:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1253:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1253:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1286:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1286:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1318:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1318:68  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1339:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1339:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1369:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1369:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1414:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1414:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1459:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1459:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1496:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1496:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1515:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1515:47  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1533:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1533:47  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1572:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1572:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1607:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1607:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1625:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1625:47  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1647:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1647:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1674:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1674:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1703:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1704:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1708:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1736:41  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1736:52  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1744:23  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1745:15  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1787:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1787:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1833:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1833:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1853:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1853:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1873:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1873:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1893:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1893:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1913:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1913:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1933:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1933:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1953:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1953:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1978:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1978:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2007:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2007:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2039:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2039:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2072:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2072:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2107:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2107:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2142:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2142:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2163:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2163:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2189:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2190:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2194:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2253:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2254:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2291:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2292:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2366:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2367:15  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2378:70  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2406:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2407:15  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2462:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2463:15  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2511:40  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2511:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2515:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2525:40  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2525:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2533:54  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2562:40  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2562:60  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2581:40  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2581:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2619:40  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2619:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2622:70  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2659:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2660:15  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2697:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2698:15  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2708:70  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2720:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2721:15  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2731:70  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2745:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2745:47  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2786:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2786:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2789:21  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2818:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2818:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2846:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2846:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2869:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2869:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2896:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2896:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2923:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2923:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2950:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2950:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2974:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2974:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2977:21  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  3001:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  3001:68  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  3033:67  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  3038:68  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  3039:69  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/sharkeyl/repos/cortex/ms-365-mcp-server/src/graph-client.ts
  225:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/sharkeyl/repos/cortex/ms-365-mcp-server/src/lib/tool-schema.ts
  100:24  warning  '_s' is assigned a value but never used  @typescript-eslint/no-unused-vars
  211:22  warning  '_s' is assigned a value but never used  @typescript-eslint/no-unused-vars

/Users/sharkeyl/repos/cortex/ms-365-mcp-server/src/logger.ts
  19:7  warning  '__dirname' is assigned a value but never used  @typescript-eslint/no-unused-vars

/Users/sharkeyl/repos/cortex/ms-365-mcp-server/src/server.ts
  732:50  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  732:62  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/sharkeyl/repos/cortex/ms-365-mcp-server/test-real-calendar.js
   5:10  warning  'registerGraphTools' is defined but never used  @typescript-eslint/no-unused-vars
   6:10  warning  'McpServer' is defined but never used           @typescript-eslint/no-unused-vars
  18:12  warning  'error' is defined but never used               @typescript-eslint/no-unused-vars

/Users/sharkeyl/repos/cortex/ms-365-mcp-server/test/discovery-auth.test.ts
  13:14  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  30:8   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/sharkeyl/repos/cortex/ms-365-mcp-server/test/http-account-param.test.ts
   73:11  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   97:60  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   98:89  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  194:11  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  196:50  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/sharkeyl/repos/cortex/ms-365-mcp-server/test/http-oauth-fix.test.ts
   61:11  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   72:77  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   96:60  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  104:26  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  138:60  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  146:26  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/sharkeyl/repos/cortex/ms-365-mcp-server/test/multi-account.test.ts
   41:73  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   42:89  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   96:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  120:35  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  120:59  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  127:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  164:13  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  166:35  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  166:59  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  207:62  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  213:13  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  215:35  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  215:59  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/sharkeyl/repos/cortex/ms-365-mcp-server/test/odata-nextlink.test.ts
  24:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  45:54  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/sharkeyl/repos/cortex/ms-365-mcp-server/test/toon-pagination.test.ts
  25:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  46:54  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

✖ 236 problems (0 errors, 236 warnings)
```

```bash
❯ npm test -- src/__tests__/graph-tools.test.ts

> @softeria/ms-365-mcp-server@0.0.0-development test
> vitest run src/__tests__/graph-tools.test.ts


 RUN  v4.1.8 /Users/sharkeyl/repos/cortex/ms-365-mcp-server

 ✓ src/__tests__/graph-tools.test.ts (90 tests) 371ms
   ✓ graph-tools (90)
     ✓ audit outcome metadata (5)
       ✓ includes HTTP status on successful Graph tool calls 263ms
       ✓ includes HTTP status and Graph error code on failed Graph tool calls 2ms
       ✓ includes HTTP status on utility tool calls that reach Graph 1ms
       ✓ includes HTTP status and Graph error code on failed utility Graph calls 2ms
       ✓ copies Graph batch outcome metadata into audit events 2ms
     ✓ $count advanced query mode (1)
       ✓ should set ConsistencyLevel: eventual header when $count=true 2ms
     ✓ audit target resources (6)
       ✓ adds target_resource to generated Graph tool audit events 1ms
       ✓ adds target_resource to failed generated Graph tool audit events 1ms
       ✓ derives target_resource from generic ID path parameters 1ms
       ✓ omits target_resource when an ID path parameter is missing 2ms
       ✓ omits SharePoint path parameters from target_resource 1ms
       ✓ omits target_resource for generated broad list/search audit events 1ms
     ✓ fetchAllPages pagination (10)
       ✓ should follow @odata.nextLink and combine results 2ms
       ✓ returns and audits a later-page Graph error instead of partial success 1ms
       ✓ merges all pages under --toon and encodes the combined result once (#560) 1ms
       ✓ does not inject value:[] when fetchAllPages hits a single-object (non-collection) GET 1ms
       ✓ should stop at 100 page limit 2ms
       ✓ pagination env caps (5)
         ✓ should honor MS365_MCP_MAX_PAGES below the default 1ms
         ✓ should honor MS365_MCP_MAX_ITEMS below the default 1ms
         ✓ should not follow nextLink when MS365_MCP_ALLOW_PAGINATION is disabled 1ms
         ✓ should advertise fetchAllPages when pagination is enabled 1ms
         ✓ should reflect MS365_MCP_MAX_PAGES in the fetchAllPages description 1ms
     ✓ parameter describe() overrides (3)
       ✓ should apply custom descriptions to OData parameters 1ms
       ✓ should describe $expand as navigation-properties-only 1ms
       ✓ should describe path params it synthesizes itself 1ms
     ✓ MS365_MCP_MAX_TOP (2)
       ✓ should clamp $top when MS365_MCP_MAX_TOP is set 1ms
       ✓ should pass through $top when MS365_MCP_MAX_TOP is unset 1ms
     ✓ returnDownloadUrl (1)
       ✓ should strip /content from path and return downloadUrl when returnDownloadUrl=true 1ms
     ✓ kebab-case path param normalization (2)
       ✓ should substitute path when LLM passes message-id (kebab) but schema has messageId (camelCase) 3ms
       ✓ should also work when LLM passes messageId (camelCase) directly 1ms
     ✓ supportsTimezone (2)
       ✓ should set Prefer: outlook.timezone header when timezone param provided 1ms
       ✓ should NOT add timezone parameter when supportsTimezone is false/absent 1ms
     ✓ outlook.body-content-type Prefer header (2)
       ✓ should set Prefer: outlook.body-content-type="text" on GET requests 1ms
       ✓ should NOT set Prefer: outlook.body-content-type on POST requests 1ms
     ✓ binary upload bodies (2)
       ✓ decodes base64 body to bytes and sets octet-stream Content-Type 1ms
       ✓ honors endpoints.json contentType override on binary uploads 1ms
     ✓ download-bytes (3)
       ✓ routes a relative Graph path through graphRequest 1ms
       ✓ rejects absolute URLs (Graph paths only) 1ms
       ✓ rejects targets that do not start with / 1ms
     ✓ download-bytes-to-file (7)
       ✓ streams bytes to the output path and returns metadata 2ms
       ✓ rejects a relative outputPath 2ms
       ✓ rejects absolute URLs in target (Graph paths only) 4ms
       ✓ refuses to overwrite an existing file and skips the Graph call 2ms
       ✓ surfaces a Graph error when downloadToFile throws 2ms
       ✓ forwards the resolved account token to downloadToFile in multi-account mode 1ms
       ✓ is registered in stdio mode but hidden in HTTP mode 1ms
     ✓ get-download-url (16)
       ✓ strips /content, fetches item metadata, and returns the pre-authed downloadUrl 1ms
       ✓ forces a JSON body on the metadata request so it works under --toon (#560) 1ms
       ✓ rejects query-shaped targets instead of silently changing request semantics 1ms
       ✓ rejects non-drive Graph targets before making an authenticated request 1ms
       ✓ rejects mail attachment $value paths (no pre-authed URL exists) 1ms
       ✓ rejects calendar event attachment $value paths (no pre-authed URL exists) 1ms
       ✓ rejects group mailbox attachment paths (no pre-authed URL exists) 1ms
       ✓ rejects list-item driveItem relationships until callers provide a drive item path 1ms
       ✓ errors when the resource exposes no downloadUrl 1ms
       ✓ surfaces the underlying Graph error instead of masking it as no-downloadUrl 1ms
       ✓ does not falsely reject drive folders literally named "attachments" 1ms
       ✓ does not falsely reject drive item paths containing messages and attachments folders 1ms
       ✓ allows SharePoint site drive item paths 1ms
       ✓ does not strip a drive item path whose item name is content 1ms
       ✓ rejects meeting recording content paths because Graph returns authenticated bytes 1ms
       ✓ refuses mismatched account param in bearer mode before resolving download URL 1ms
     ✓ allowed scopes filtering (5)
       ✓ registerGraphTools hides Graph tools outside the allowed scopes 1ms
       ✓ audits direct calls to Graph tools denied by allowed scopes 2ms
       ✓ discovery hides Graph tools outside the allowed scopes 2ms
       ✓ audits execute-tool attempts denied by allowed scopes 1ms
       ✓ audits direct discovery-mode calls to Graph tools denied by allowed scopes 1ms
     ✓ discovery mode: utility tools (4)
       ✓ search-tools surfaces download-bytes for "download" queries 1ms
       ✓ get-tool-schema returns the download-bytes parameter schema 2ms
       ✓ execute-tool dispatches to download-bytes for a Graph path 3ms
       ✓ execute-tool reports unknown tool when name matches neither registry 2ms
     ✓ discovery mode: --enabled-tools filter (4)
       ✓ search-tools only surfaces Graph tools matching the regex 1ms
       ✓ audits execute-tool attempts denied by the enabled-tools allow-list 1ms
       ✓ utility tools obey the regex too 1ms
       ✓ invalid regex pattern is ignored, all tools surface 1ms
     ✓ utility tools in read-only mode (1)
       ✓ skips utility tools whose readOnlyHint is not true 1ms
     ✓ destructive operations require confirm: true (9)
       ✓ rejects DELETE without confirm: true and does NOT call Graph 1ms
       ✓ allows DELETE when confirm: true is passed 1ms
       ✓ does NOT send `confirm` to Graph as a query/body parameter 1ms
       ✓ allows GET (read-only) regardless of confirm 1ms
       ✓ allows POST endpoints flagged readOnly without confirm (e.g. find-meeting-times) 1ms
       ✓ does NOT gate when MS365_MCP_REQUIRE_CONFIRM is unset (opt-in, off by default) 1ms
       ✓ does NOT gate when MS365_MCP_REQUIRE_CONFIRM=false (explicit off) 1ms
       ✓ rejects `confirm: false` as not equal to true 1ms
       ✓ exposes confirm in the schema only for destructive tools 1ms
     ✓ isDestructiveOperation (5)
       ✓ returns true for POST, PATCH, PUT, DELETE 1ms
       ✓ is case-insensitive 1ms
       ✓ returns false for GET / HEAD / OPTIONS 1ms
       ✓ returns false for POST endpoints flagged readOnly 1ms
       ✓ still returns true for PATCH/DELETE even if config.readOnly is set (should not happen but defensive) 1ms

 Test Files  1 passed (1)
      Tests  90 passed (90)
   Start at  10:42:45
   Duration  583ms (transform 148ms, setup 14ms, import 84ms, tests 371ms, environment 0ms)
```