### PR TITLE
fix(schema): inline tool inputSchema $refs so $defs-blind clients work

### DIFF
--- a/src/normalize-tool-schema.ts
+++ b/src/normalize-tool-schema.ts
@@ -1,19 +1,26 @@
 // The MCP SDK converts each tool's Zod inputSchema to JSON Schema with
 // zod-to-json-schema's default `$refStrategy: 'root'`. That emits internal
 // `$ref`s as root-relative JSON pointers (e.g. `#/properties/body/properties/from`)
-// wherever a sub-schema recurses OR is reused by object identity. Strict
-// JSON-Schema backends (e.g. Kimi/Moonshot) reject any `$ref` that does not start
-// with `#/$defs/`, so they refuse the whole tools/list. The SDK hard-codes the
-// conversion options, so we normalize its output here instead: hoist every
-// referenced sub-schema into a top-level `$defs` and repoint the refs. This is
-// content-preserving (refs still resolve to the same schema) and keeps the payload
-// compact, unlike inlining. See issue #571.
+// wherever a sub-schema recurses OR is reused by object identity. The SDK hard-codes
+// the conversion options, so we rewrite its output here.
+//
+// Two clients want opposite things: Kimi/Moonshot rejects any `$ref` not starting with
+// `#/$defs/` (#571), while Open Cowork and the MCP Inspector form can't resolve
+// `#/$defs/` at all (#638). Only a schema with no `$ref` left keeps both happy, so we
+// hoist into `$defs` and then inline right back out.
+//
+// Recursive Graph schemas (OneNote sections, mail and contact folder trees) can't be
+// inlined at all, so those keep their refs and stay broken for #638. Same when the
+// expansion would more than double the schema - not worth the bytes.
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import logger from './logger.js';
 
 type JsonSchema = Record<string, unknown>;
+
+// Past this much growth, keep the $ref form instead.
+const MAX_INLINE_GROWTH = 2;
 
 function unescapePointer(token: string): string {
   return token.replace(/~1/g, '/').replace(/~0/g, '~');
@@ -80,10 +87,101 @@ function repointRefs(node: unknown, nameFor: Map<string, string>): void {
   }
 }
 
+function defRefName(value: unknown): string | null {
+  const prefix = '#/$defs/';
+  return typeof value === 'string' && value.startsWith(prefix) ? value.slice(prefix.length) : null;
+}
+
+function collectDefRefNames(node: unknown, out: Set<string>): void {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const item of node) collectDefRefNames(item, out);
+    return;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    const name = key === '$ref' ? defRefName(value) : null;
+    if (name === null) collectDefRefNames(value, out);
+    else out.add(name);
+  }
+}
+
+// draft-07 (what the SDK declares) ignores keywords next to a `$ref`, 2020-12 conjoins
+// them. Inlining would have to pick one, and either pick changes what some schema
+// accepts - so leave those as refs. zod-to-json-schema emits bare `{$ref}` anyway.
+function collectSiblingRefNames(node: unknown, out: Set<string>): void {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const item of node) collectSiblingRefNames(item, out);
+    return;
+  }
+  const record = node as Record<string, unknown>;
+  const name = defRefName(record.$ref);
+  if (name !== null && Object.keys(record).length > 1) out.add(name);
+  for (const value of Object.values(record)) collectSiblingRefNames(value, out);
+}
+
+// Cyclic means the def can reach itself. Graph's recursive entities (a mail folder whose
+// childFolders are mail folders) land here, plain reuse (start and end sharing
+// dateTimeTimeZone) does not. Few enough defs that the naive walk beats building SCCs.
+function findCyclicDefs(defs: Record<string, unknown>): Set<string> {
+  const edges = new Map<string, Set<string>>();
+  for (const [name, value] of Object.entries(defs)) {
+    const out = new Set<string>();
+    collectDefRefNames(value, out);
+    edges.set(name, out);
+  }
+
+  const cyclic = new Set<string>();
+  for (const start of edges.keys()) {
+    const seen = new Set<string>();
+    const stack = [...(edges.get(start) ?? [])];
+    while (stack.length > 0) {
+      const next = stack.pop()!;
+      if (next === start) {
+        cyclic.add(start);
+        break;
+      }
+      if (seen.has(next)) continue;
+      seen.add(next);
+      for (const onward of edges.get(next) ?? []) stack.push(onward);
+    }
+  }
+  return cyclic;
+}
+
+// Swap every `#/$defs/` ref to an inlinable def for that def's expansion. Pinned defs,
+// and defs we didn't hoist ourselves, are left alone.
+function inlineDefRefs(
+  node: unknown,
+  defs: Record<string, unknown>,
+  pinned: Set<string>,
+  expand: (name: string) => unknown
+): unknown {
+  if (!node || typeof node !== 'object') return node;
+  if (Array.isArray(node)) return node.map((item) => inlineDefRefs(item, defs, pinned, expand));
+
+  const record = node as Record<string, unknown>;
+  const name = defRefName(record.$ref);
+  if (name !== null && name in defs && !pinned.has(name)) {
+    const siblings: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(record)) {
+      if (key !== '$ref') siblings[key] = inlineDefRefs(value, defs, pinned, expand);
+    }
+    return { ...(structuredClone(expand(name)) as Record<string, unknown>), ...siblings };
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    out[key] = inlineDefRefs(value, defs, pinned, expand);
+  }
+  return out;
+}
+
 /**
- * Rewrite a tool inputSchema so every internal `$ref` is anchored under `#/$defs/`.
- * Returns the input untouched when it already complies (the common case), so only
- * the handful of tools with recursive/shared Graph schemas pay any cost.
+ * Rewrite a tool inputSchema so it carries no internal `$ref`, except where a
+ * recursive schema makes that impossible - those keep a `#/$defs/`-anchored ref.
+ * Returns the input untouched when it has no internal refs at all (the common case),
+ * so only the tools with recursive/shared Graph schemas pay any cost.
  */
 export function normalizeToolSchemaRefs<T extends JsonSchema>(schema: T): T {
   const targets = new Set<string>();
@@ -132,9 +230,39 @@ export function normalizeToolSchemaRefs<T extends JsonSchema>(schema: T): T {
   repointRefs(clone, nameFor);
   for (const name of Object.keys(defs)) repointRefs(defs[name], nameFor);
 
+  // Set aside so the inlining walk below doesn't descend into them
   const existingDefs = (clone.$defs as Record<string, unknown> | undefined) ?? {};
+  delete clone.$defs;
+
+  // A cycle keeps a ref no matter what we do, so the schema is broken for #638 either
+  // way - expanding the rest of its defs would just cost bytes for nothing.
+  const pinned = findCyclicDefs(defs);
+  collectSiblingRefNames(clone, pinned);
+  for (const value of Object.values(defs)) collectSiblingRefNames(value, pinned);
+  if (pinned.size > 0) {
+    clone.$defs = { ...existingDefs, ...defs };
+    return clone as T;
+  }
+
+  const memo = new Map<string, unknown>();
+  const expand = (name: string): unknown => {
+    if (memo.has(name)) return memo.get(name);
+    const value = inlineDefRefs(defs[name], defs, pinned, expand);
+    memo.set(name, value);
+    return value;
+  };
+
+  // inlineDefRefs rebuilds rather than mutates, so `clone` can still be the fallback
+  const inlined = inlineDefRefs(clone, defs, pinned, expand) as JsonSchema;
+  if (Object.keys(existingDefs).length > 0) inlined.$defs = existingDefs;
   clone.$defs = { ...existingDefs, ...defs };
-  return clone as T;
+
+  // Some schemas lean on their refs hard - create-sharepoint-list-item hangs 181 ref
+  // sites off 59 defs, so expanding it all blows the tool up ~6x. Past a doubling the
+  // bytes aren't worth the reach.
+  const grewTooMuch =
+    JSON.stringify(inlined).length > JSON.stringify(clone).length * MAX_INLINE_GROWTH;
+  return (grewTooMuch ? clone : inlined) as T;
 }
 
 // Decorate the SDK's tools/list handler so every emitted inputSchema is passed

--- a/src/normalize-tool-schema.ts
+++ b/src/normalize-tool-schema.ts
@@ -87,6 +87,12 @@ function repointRefs(node: unknown, nameFor: Map<string, string>): void {
   }
 }
 
+// Own keys only. A plain `in` reaches Object.prototype, so `#/$defs/constructor` would
+// look like a def we hoisted and hand structuredClone a function.
+function hasDef(defs: Record<string, unknown>, name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(defs, name);
+}
+
 function defRefName(value: unknown): string | null {
   const prefix = '#/$defs/';
   return typeof value === 'string' && value.startsWith(prefix) ? value.slice(prefix.length) : null;
@@ -162,7 +168,7 @@ function inlineDefRefs(
 
   const record = node as Record<string, unknown>;
   const name = defRefName(record.$ref);
-  if (name !== null && name in defs && !pinned.has(name)) {
+  if (name !== null && hasDef(defs, name) && !pinned.has(name)) {
     const siblings: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(record)) {
       if (key !== '$ref') siblings[key] = inlineDefRefs(value, defs, pinned, expand);
@@ -230,7 +236,8 @@ export function normalizeToolSchemaRefs<T extends JsonSchema>(schema: T): T {
   repointRefs(clone, nameFor);
   for (const name of Object.keys(defs)) repointRefs(defs[name], nameFor);
 
-  // Set aside so the inlining walk below doesn't descend into them
+  // Split off the defs we didn't hoist. They stay refs either way, so the walk below
+  // treats them as their own document instead of reaching them from the root.
   const existingDefs = (clone.$defs as Record<string, unknown> | undefined) ?? {};
   delete clone.$defs;
 
@@ -239,6 +246,12 @@ export function normalizeToolSchemaRefs<T extends JsonSchema>(schema: T): T {
   const pinned = findCyclicDefs(defs);
   collectSiblingRefNames(clone, pinned);
   for (const value of Object.values(defs)) collectSiblingRefNames(value, pinned);
+  for (const value of Object.values(existingDefs)) collectSiblingRefNames(value, pinned);
+  // Only a def we hoisted can force our hand. Pinning a kept def's name would bail the
+  // whole schema for nothing, since inlining was never on the table for it.
+  for (const name of [...pinned]) {
+    if (!hasDef(defs, name)) pinned.delete(name);
+  }
   if (pinned.size > 0) {
     clone.$defs = { ...existingDefs, ...defs };
     return clone as T;
@@ -254,7 +267,16 @@ export function normalizeToolSchemaRefs<T extends JsonSchema>(schema: T): T {
 
   // inlineDefRefs rebuilds rather than mutates, so `clone` can still be the fallback
   const inlined = inlineDefRefs(clone, defs, pinned, expand) as JsonSchema;
-  if (Object.keys(existingDefs).length > 0) inlined.$defs = existingDefs;
+  // A kept def can still point at one we hoisted, and `defs` doesn't come along here -
+  // so inline those out too rather than hand back a ref to a def that isn't there.
+  if (Object.keys(existingDefs).length > 0) {
+    inlined.$defs = Object.fromEntries(
+      Object.entries(existingDefs).map(([name, value]) => [
+        name,
+        inlineDefRefs(value, defs, pinned, expand),
+      ])
+    );
+  }
   clone.$defs = { ...existingDefs, ...defs };
 
   // Some schemas lean on their refs hard - create-sharepoint-list-item hangs 181 ref

--- a/test/normalize-tool-schema.test.ts
+++ b/test/normalize-tool-schema.test.ts
@@ -52,7 +52,7 @@ describe('normalizeToolSchemaRefs', () => {
     expect(normalizeToolSchemaRefs(schema)).toBe(schema);
   });
 
-  it('rewrites a root-relative dedup ref into #/$defs and preserves resolution', () => {
+  it('inlines a root-relative dedup ref so no $ref survives', () => {
     // `to` is emitted inline once and referenced by object identity elsewhere.
     const schema = {
       type: 'object',
@@ -62,16 +62,11 @@ describe('normalizeToolSchemaRefs', () => {
       },
     };
     const out = normalizeToolSchemaRefs(schema);
-    const refs = collectRefs(out);
-    expect(refs.length).toBeGreaterThan(0);
-    expect(refs.every((r) => r.startsWith('#/$defs/'))).toBe(true);
-    for (const r of refs) expect(resolvePointer(out, r)).toBeDefined();
-    // The extracted def is the original `from` schema.
-    const to = (out.properties as Record<string, { $ref: string }>).to;
-    expect(resolvePointer(out, to.$ref)).toMatchObject({
-      type: 'object',
-      properties: { email: { type: 'string' } },
-    });
+    expect(collectRefs(out)).toEqual([]);
+    expect(out.$defs).toBeUndefined();
+    const props = out.properties as Record<string, unknown>;
+    expect(props.to).toEqual({ type: 'object', properties: { email: { type: 'string' } } });
+    expect(props.to).toEqual(props.from);
   });
 
   it('rewrites a recursion ref (target is an ancestor of the ref) into valid #/$defs recursion', () => {
@@ -99,7 +94,104 @@ describe('normalizeToolSchemaRefs', () => {
     expect(items.$ref.startsWith('#/$defs/')).toBe(true);
   });
 
-  it('handles nested targets without leaving dangling refs', () => {
+  it('will not inline a ref that carries sibling keywords', () => {
+    // draft-07 drops the sibling, 2020-12 conjoins it. Picking wrong changes what the
+    // schema accepts, so the ref stays a ref.
+    const schema = {
+      type: 'object',
+      properties: {
+        base: { type: 'object', required: ['a'], properties: { a: { type: 'string' } } },
+        derived: { $ref: '#/properties/base', required: ['b'] },
+      },
+    };
+    const out = normalizeToolSchemaRefs(schema);
+    const refs = collectRefs(out);
+    expect(refs.length).toBeGreaterThan(0);
+    expect(refs.every((r) => r.startsWith('#/$defs/'))).toBe(true);
+    for (const r of refs) expect(resolvePointer(out, r)).toBeDefined();
+    expect((out.properties as Record<string, { required: string[] }>).derived.required).toEqual([
+      'b',
+    ]);
+  });
+
+  it('keeps $defs when inlining would more than double the schema', () => {
+    // One fat def behind many ref sites, the create-sharepoint-list-item shape
+    const shared = {
+      type: 'object',
+      properties: Object.fromEntries(
+        Array.from({ length: 40 }, (_, i) => [
+          `field${i}`,
+          { type: 'string', description: 'x'.repeat(40) },
+        ])
+      ),
+    };
+    const properties: Record<string, unknown> = { shared };
+    for (let i = 0; i < 10; i++) properties[`use${i}`] = { $ref: '#/properties/shared' };
+
+    const out = normalizeToolSchemaRefs({ type: 'object', properties });
+    const refs = collectRefs(out);
+    expect(refs.length).toBeGreaterThan(0); // not inlined
+    // Still has to satisfy #571 on the way out.
+    expect(refs.every((r) => r.startsWith('#/$defs/'))).toBe(true);
+    for (const r of refs) expect(resolvePointer(out, r)).toBeDefined();
+  });
+
+  it('still inlines a small def reused many times', () => {
+    // Same shape, tiny def - 10 copies still fit under the cap
+    const properties: Record<string, unknown> = { shared: { type: 'string' } };
+    for (let i = 0; i < 10; i++) properties[`use${i}`] = { $ref: '#/properties/shared' };
+
+    const out = normalizeToolSchemaRefs({ type: 'object', properties });
+    expect(collectRefs(out)).toEqual([]);
+    expect((out.properties as Record<string, unknown>).use7).toEqual({ type: 'string' });
+  });
+
+  it('skips inlining entirely once any def is cyclic', () => {
+    // `wrapper` would expand fine on its own, but `body` recurses so a ref survives
+    // regardless. Expanding wrapper would just add bytes.
+    const schema = {
+      type: 'object',
+      properties: {
+        body: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            childFolders: { type: 'array', items: { $ref: '#/properties/body' } },
+          },
+        },
+        wrapper: { type: 'object', properties: { folder: { $ref: '#/properties/body' } } },
+        alias: { $ref: '#/properties/wrapper' },
+      },
+    };
+    const out = normalizeToolSchemaRefs(schema);
+    expect(Object.keys(out.$defs as object)).toHaveLength(2); // body and wrapper both kept
+    const refs = collectRefs(out);
+    expect(refs.every((r) => r.startsWith('#/$defs/'))).toBe(true);
+    for (const r of refs) expect(resolvePointer(out, r)).toBeDefined();
+  });
+
+  it('keeps both defs when a nested target sits inside a recursive subtree', () => {
+    // Hoisting `childFolders` out of `body` makes the two point at each other, so both
+    // count as cyclic
+    const schema = {
+      type: 'object',
+      properties: {
+        body: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            childFolders: { type: 'array', items: { $ref: '#/properties/body' } },
+          },
+        },
+        sibling: { $ref: '#/properties/body/properties/childFolders' },
+      },
+    };
+    const out = normalizeToolSchemaRefs(schema);
+    expect(Object.keys(out.$defs as object)).toHaveLength(2);
+    for (const r of collectRefs(out)) expect(resolvePointer(out, r)).toBeDefined();
+  });
+
+  it('inlines nested targets without leaving dangling refs', () => {
     const inner = { type: 'object', properties: { v: { type: 'string' } } };
     const schema = {
       type: 'object',
@@ -110,10 +202,10 @@ describe('normalizeToolSchemaRefs', () => {
       },
     };
     const out = normalizeToolSchemaRefs(schema);
-    const refs = collectRefs(out);
-    expect(refs.length).toBeGreaterThanOrEqual(2);
-    expect(refs.every((r) => r.startsWith('#/$defs/'))).toBe(true);
-    for (const r of refs) expect(resolvePointer(out, r)).toBeDefined();
+    expect(collectRefs(out)).toEqual([]);
+    const props = out.properties as Record<string, unknown>;
+    expect(props.b).toEqual(props.a);
+    expect(props.c).toEqual(inner);
   });
 
   it('does not mutate the input schema', () => {
@@ -129,7 +221,7 @@ describe('normalizeToolSchemaRefs', () => {
     expect(JSON.stringify(schema)).toBe(snapshot);
   });
 
-  it('collapses multiple refs to the same target onto one def', () => {
+  it('expands every ref to a shared target into an equal but separate schema', () => {
     const schema = {
       type: 'object',
       properties: {
@@ -139,11 +231,13 @@ describe('normalizeToolSchemaRefs', () => {
       },
     };
     const out = normalizeToolSchemaRefs(schema);
-    expect(Object.keys(out.$defs as object)).toHaveLength(1);
-    const props = out.properties as Record<string, { $ref: string }>;
-    expect(props.to.$ref).toBe(props.cc.$ref);
-    expect(props.to.$ref.startsWith('#/$defs/')).toBe(true);
-    for (const r of collectRefs(out)) expect(resolvePointer(out, r)).toBeDefined();
+    expect(collectRefs(out)).toEqual([]);
+    expect(out.$defs).toBeUndefined();
+    const props = out.properties as Record<string, unknown>;
+    expect(props.to).toEqual(props.from);
+    expect(props.cc).toEqual(props.from);
+    // Equal, but not one shared object - each site owns its copy
+    expect(props.to).not.toBe(props.cc);
   });
 
   it('resolves JSON-pointer ~0/~1 escapes (keys containing ~ and /)', () => {
@@ -155,12 +249,10 @@ describe('normalizeToolSchemaRefs', () => {
       },
     };
     const out = normalizeToolSchemaRefs(schema);
-    const refs = collectRefs(out);
-    expect(refs.every((r) => r.startsWith('#/$defs/'))).toBe(true);
-    for (const r of refs) expect(resolvePointer(out, r)).toBeDefined();
-    expect(
-      resolvePointer(out, (out.properties as Record<string, { $ref: string }>).ref.$ref)
-    ).toMatchObject({ properties: { v: { type: 'string' } } });
+    expect(collectRefs(out)).toEqual([]);
+    expect((out.properties as Record<string, unknown>).ref).toMatchObject({
+      properties: { v: { type: 'string' } },
+    });
   });
 
   it('resolves array-index pointer targets (anyOf/0)', () => {
@@ -174,9 +266,11 @@ describe('normalizeToolSchemaRefs', () => {
       },
     };
     const out = normalizeToolSchemaRefs(schema);
-    const refs = collectRefs(out);
-    expect(refs.every((r) => r.startsWith('#/$defs/'))).toBe(true);
-    for (const r of refs) expect(resolvePointer(out, r)).toBeDefined();
+    expect(collectRefs(out)).toEqual([]);
+    expect((out.properties as Record<string, unknown>).alias).toEqual({
+      type: 'object',
+      properties: { x: { type: 'string' } },
+    });
   });
 
   it('leaves an unresolvable ref untouched rather than dangling it', () => {
@@ -189,14 +283,9 @@ describe('normalizeToolSchemaRefs', () => {
       },
     };
     const out = normalizeToolSchemaRefs(schema);
-    // Every $defs ref we introduce must resolve: we never manufacture a dangling
-    // def ref. A pre-existing unresolvable ref is left exactly as-is (not "fixed"
-    // into a missing $defs target).
-    for (const r of collectRefs(out).filter((x) => x.startsWith('#/$defs/'))) {
-      expect(resolvePointer(out, r)).toBeDefined();
-    }
-    const props = out.properties as Record<string, { $ref: string }>;
-    expect(props.good.$ref.startsWith('#/$defs/')).toBe(true);
+    const props = out.properties as Record<string, { $ref?: string }>;
+    expect(props.good).toEqual({ type: 'object' });
+    // Left exactly as-is, never "fixed" into a $defs target that isn't there
     expect(props.bad.$ref).toBe('#/properties/does/not/exist');
   });
 
@@ -212,11 +301,13 @@ describe('normalizeToolSchemaRefs', () => {
     };
     const out = normalizeToolSchemaRefs(schema);
     const defs = out.$defs as Record<string, unknown>;
-    // The pre-existing def0 must survive intact...
+    // A def we didn't hoist isn't ours to inline, so it and its ref both survive
     expect(defs.def0).toEqual({ const: 'sentinel' });
-    // ...and the newly hoisted schema must land under a different key.
-    const toRef = (out.properties as Record<string, { $ref: string }>).to.$ref;
-    expect(toRef).not.toBe('#/$defs/def0');
+    expect((out.properties as Record<string, { $ref: string }>).existing.$ref).toBe('#/$defs/def0');
+    expect((out.properties as Record<string, unknown>).to).toEqual({
+      type: 'object',
+      properties: { email: { type: 'string' } },
+    });
     for (const r of collectRefs(out)) expect(resolvePointer(out, r)).toBeDefined();
   });
 });

--- a/test/normalize-tool-schema.test.ts
+++ b/test/normalize-tool-schema.test.ts
@@ -310,6 +310,143 @@ describe('normalizeToolSchemaRefs', () => {
     });
     for (const r of collectRefs(out)) expect(resolvePointer(out, r)).toBeDefined();
   });
+
+  it('inlines into a pre-existing def that points at something we hoisted', () => {
+    // `pre` isn't ours to inline, but it reaches `shared`, which is. The hoisted defs
+    // don't survive the inlining, so leaving `pre` alone would dangle its ref.
+    const schema = {
+      type: 'object',
+      properties: {
+        shared: { type: 'object', properties: { email: { type: 'string' } } },
+        a: { $ref: '#/properties/shared' },
+        usesPre: { $ref: '#/$defs/pre' },
+      },
+      $defs: { pre: { type: 'array', items: { $ref: '#/properties/shared' } } },
+    };
+    const out = normalizeToolSchemaRefs(schema);
+    for (const r of collectRefs(out)) expect(resolvePointer(out, r)).toBeDefined();
+    expect((out.$defs as Record<string, unknown>).pre).toEqual({
+      type: 'array',
+      items: { type: 'object', properties: { email: { type: 'string' } } },
+    });
+  });
+
+  it('pins a hoisted def when a pre-existing def refs it with sibling keywords', () => {
+    // Same sibling ambiguity as anywhere else, so it has to pin rather than inline -
+    // and pinning must still leave the hoisted def reachable.
+    const schema = {
+      type: 'object',
+      properties: {
+        shared: { type: 'object', required: ['a'], properties: { a: { type: 'string' } } },
+        usesPre: { $ref: '#/$defs/pre' },
+      },
+      $defs: { pre: { $ref: '#/properties/shared', required: ['b'] } },
+    };
+    const out = normalizeToolSchemaRefs(schema);
+    const refs = collectRefs(out);
+    expect(refs.length).toBeGreaterThan(0);
+    expect(refs.every((r) => r.startsWith('#/$defs/'))).toBe(true);
+    for (const r of refs) expect(resolvePointer(out, r)).toBeDefined();
+    expect((out.$defs as Record<string, { required: string[] }>).pre.required).toEqual(['b']);
+  });
+
+  it('lets a sibling ref between two kept defs through without blocking inlining', () => {
+    // `b` refs `a1` with a sibling, but neither is ours, so neither was ever going to be
+    // inlined. Pinning on their account would bail the schema and strand `shared`.
+    const schema = {
+      type: 'object',
+      $defs: { a1: { type: 'string' }, b: { $ref: '#/$defs/a1', description: 'sibling' } },
+      properties: {
+        shared: { type: 'object', properties: { email: { type: 'string' } } },
+        a: { $ref: '#/properties/shared' },
+        usesB: { $ref: '#/$defs/b' },
+      },
+    };
+    const out = normalizeToolSchemaRefs(schema);
+    expect((out.properties as Record<string, unknown>).a).toEqual({
+      type: 'object',
+      properties: { email: { type: 'string' } },
+    });
+    expect(collectRefs(out).every((r) => r.startsWith('#/$defs/'))).toBe(true);
+    for (const r of collectRefs(out)) expect(resolvePointer(out, r)).toBeDefined();
+  });
+
+  it('does not mistake an Object.prototype key for a def', () => {
+    // `#/$defs/constructor` resolves through the prototype chain under `in`, which would
+    // hand structuredClone a function and throw out of the whole tools/list.
+    const schema = {
+      type: 'object',
+      properties: {
+        shared: { type: 'object', properties: { email: { type: 'string' } } },
+        a: { $ref: '#/properties/shared' },
+        boom: { $ref: '#/$defs/constructor' },
+      },
+    };
+    let out!: typeof schema;
+    expect(() => (out = normalizeToolSchemaRefs(schema))).not.toThrow();
+    expect((out.properties as Record<string, unknown>).boom).toEqual({
+      $ref: '#/$defs/constructor',
+    });
+  });
+
+  it('terminates on a cycle that runs through a pre-existing def', () => {
+    // findCyclicDefs only sees edges between hoisted defs, so this cycle is invisible to
+    // it. Termination rests on refusing to expand a name we didn't hoist.
+    const schema = {
+      type: 'object',
+      properties: {
+        shared: { type: 'object', properties: { back: { $ref: '#/$defs/pre' } } },
+        a: { $ref: '#/properties/shared' },
+        usesPre: { $ref: '#/$defs/pre' },
+      },
+      $defs: { pre: { type: 'array', items: { $ref: '#/properties/shared' } } },
+    };
+    const out = normalizeToolSchemaRefs(schema);
+    for (const r of collectRefs(out)) expect(resolvePointer(out, r)).toBeDefined();
+  });
+
+  it('does not mutate an input that carries a pre-existing $defs', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        shared: { type: 'object', properties: { email: { type: 'string' } } },
+        a: { $ref: '#/properties/shared' },
+        usesPre: { $ref: '#/$defs/pre' },
+      },
+      $defs: { pre: { type: 'array', items: { $ref: '#/properties/shared' } } },
+    };
+    const snapshot = JSON.stringify(schema);
+    normalizeToolSchemaRefs(schema);
+    expect(JSON.stringify(schema)).toBe(snapshot);
+  });
+
+  it('is idempotent, since tools/list re-normalizes on every request', () => {
+    for (const schema of [
+      // inlined outright
+      {
+        type: 'object',
+        properties: {
+          from: { type: 'object', properties: { email: { type: 'string' } } },
+          to: { $ref: '#/properties/from' },
+        },
+      },
+      // pinned by recursion, so refs survive the first pass
+      {
+        type: 'object',
+        properties: {
+          body: {
+            type: 'object',
+            properties: { childFolders: { type: 'array', items: { $ref: '#/properties/body' } } },
+          },
+        },
+      },
+    ]) {
+      const once = normalizeToolSchemaRefs(schema);
+      expect(JSON.stringify(normalizeToolSchemaRefs(structuredClone(once)))).toBe(
+        JSON.stringify(once)
+      );
+    }
+  });
 });
 
 describe('installToolSchemaRefNormalization (end-to-end against the real SDK)', () => {


### PR DESCRIPTION
Open Cowork and the MCP Inspector form can't resolve `#/$defs/` refs at all, so create-calendar-event and 35 other tools are unusable there. Those refs exist because Kimi/Moonshot rejects any ref NOT under `#/$defs/` (#571), so neither anchoring wins - only a schema with no ref left in it satisfies both.

Hoist as before, then inline the defs straight back when nothing stops it. Recursive Graph schemas (OneNote sections, mail and contact folder trees) have no finite inlining, and neither do defs referenced with sibling keywords, where draft-07 and 2020-12 disagree on what the siblings mean. Skipped too when the expansion would more than double the schema, which create-sharepoint-list-item does nearly 6x over. Those keep the `#/$defs/` form and stay broken for #638.

Costs 14.3% of the tools/list payload by default and 7.3% in org-mode. Checked across all 336 org-mode tools: no ref outside `#/$defs/`, none dangling.

Refs #638