### PR TITLE
fix(auth): keep silent refresh off stale duplicate refresh tokens

### DIFF
--- a/src/auth-tools.ts
+++ b/src/auth-tools.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import AuthManager from './auth.js';
+import logger from './logger.js';
 import { getRequestTokens } from './request-context.js';
 
 export function registerAuthTools(server: McpServer, authManager: AuthManager): void {
@@ -45,8 +46,16 @@ export function registerAuthTools(server: McpServer, authManager: AuthManager): 
           };
         }
 
+        // resolve() is the device-code callback: it fires as soon as there is a code to
+        // show, because the user cannot enter a code this tool is still holding. Anything
+        // that fails after that - a rejected account, a cache write that never landed -
+        // arrives with this promise already settled, so reject() is a no-op. The log and
+        // the failure `verify login` reports are what surface it (issue #648).
         const text = await new Promise<string>((resolve, reject) => {
-          authManager.acquireTokenByDeviceCode(resolve).catch(reject);
+          authManager.acquireTokenByDeviceCode(resolve).catch((error: Error) => {
+            logger.error(`Device code login failed after the code was issued: ${error.message}`);
+            reject(error);
+          });
         });
         return {
           content: [

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url';
 import path from 'path';
 import { getSecrets, type AppSecrets } from './secrets.js';
 import { getCloudEndpoints, getDefaultClientId } from './cloud-config.js';
+import { dedupeRefreshTokens } from './lib/cache-dedupe.js';
 import {
   createTokenCacheStorage,
   DefaultTokenCacheStorage,
@@ -56,6 +57,77 @@ function createMsalConfig(secrets: AppSecrets): Configuration {
 }
 
 /**
+ * Duplicate refresh tokens are a property of the cache, not of one read, so the warning
+ * belongs to the process rather than to every access that reloads the same file.
+ */
+const warnedDuplicateRefreshTokens = new Set<string>();
+
+/** Test seam: the warnings above are deduplicated for the process lifetime. */
+export function resetRefreshTokenWarningsForTests(): void {
+  warnedDuplicateRefreshTokens.clear();
+}
+
+function pruneDuplicateRefreshTokens(data: string): string {
+  const result = dedupeRefreshTokens(data);
+
+  for (const drop of result.dropped) {
+    const signature = `${drop.environment}->${drop.keptEnvironment}`;
+    if (warnedDuplicateRefreshTokens.has(signature)) continue;
+    warnedDuplicateRefreshTokens.add(signature);
+    logger.warn(
+      `Dropped a stale refresh token cached under ${drop.environment}, keeping the one under ` +
+        `${drop.keptEnvironment}. MSAL treats those as the same account and spends whichever it ` +
+        `finds first, which is what strands a sign-in on a months-old token (issue #648).`
+    );
+  }
+
+  if (result.ambiguous > 0 && !warnedDuplicateRefreshTokens.has('ambiguous')) {
+    warnedDuplicateRefreshTokens.add('ambiguous');
+    logger.warn(
+      `The auth cache holds ${result.ambiguous} set(s) of duplicate refresh tokens with nothing to ` +
+        `say which is current, so they were left alone. If silent refresh keeps failing for an ` +
+        `account, log out and sign in again to clear them.`
+    );
+  }
+
+  return result.data;
+}
+
+/** How long to wait before a second look at the cache, when the first came up short. */
+const PERSISTENCE_RECHECK_MS = 150;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Refresh token secrets a serialized cache holds for one account. `undefined` means the
+ * blob did not read back as a cache at all, which is not the same as holding no tokens.
+ */
+function persistedRefreshTokens(cacheJson: string, homeAccountId: string): Set<string> | undefined {
+  let refreshTokens: unknown;
+  try {
+    const parsed: unknown = JSON.parse(cacheJson);
+    if (typeof parsed !== 'object' || parsed === null) return undefined;
+    refreshTokens = (parsed as { RefreshToken?: unknown }).RefreshToken;
+  } catch {
+    return undefined;
+  }
+
+  const secrets = new Set<string>();
+  // A cache with no refresh tokens at all is readable and simply empty.
+  if (typeof refreshTokens !== 'object' || refreshTokens === null) return secrets;
+
+  for (const entity of Object.values(refreshTokens as Record<string, unknown>)) {
+    if (typeof entity !== 'object' || entity === null) continue;
+    const credential = entity as { home_account_id?: string; secret?: string };
+    if (credential.home_account_id !== homeAccountId) continue;
+    if (credential.secret) secrets.add(credential.secret);
+  }
+  return secrets;
+}
+
+/**
  * Builds an MSAL cache plugin that keeps the file-backed token cache coherent across
  * concurrent processes. In the common stdio deployment several MCP server processes share
  * one token cache file. Microsoft rotates refresh tokens on silent refresh, so without this
@@ -63,7 +135,8 @@ function createMsalConfig(secrets: AppSecrets): Configuration {
  * refresh token on disk (invalid_grant / no_tokens_found). See issue #545.
  *
  * MSAL invokes beforeCacheAccess/afterCacheAccess around every cache operation, so:
- *  - beforeCacheAccess reloads the newest persisted cache into MSAL right before each access
+ *  - beforeCacheAccess reloads the newest persisted cache into MSAL right before each access,
+ *    collapsing duplicate refresh tokens on the way in (see cache-dedupe, issue #648)
  *  - afterCacheAccess persists (atomically, via storage) only when MSAL changed the cache
  * This preserves the existing cache envelope (wrapCache) and the storage provider's
  * fail-closed semantics.
@@ -83,7 +156,7 @@ export function buildDiskCoherencyCachePlugin(storage: TokenCacheStorage): ICach
       try {
         const cacheRaw = await storage.load('token-cache');
         if (cacheRaw) {
-          context.tokenCache.deserialize(unwrapCache(cacheRaw).data);
+          context.tokenCache.deserialize(pruneDuplicateRefreshTokens(unwrapCache(cacheRaw).data));
         }
       } catch (error) {
         logger.error(`Error reloading token cache: ${(error as Error).message}`);
@@ -606,6 +679,7 @@ class AuthManager {
   private expectedUsername: string | null;
   private expectedHomeAccountId: string | null;
   private storage: TokenCacheStorage;
+  private loginPersistenceError: string | null;
 
   constructor(
     config: Configuration,
@@ -630,6 +704,7 @@ class AuthManager {
     this.tokenExpiry = null;
     this.selectedAccountId = null;
     this.useInteractiveAuth = false;
+    this.loginPersistenceError = null;
     this.expectedUsername = this.normalizeExpectedUsername(expectedAccount?.expectedUsername);
     this.expectedHomeAccountId = this.normalizeExpectedHomeAccountId(
       expectedAccount?.expectedHomeAccountId
@@ -661,7 +736,9 @@ class AuthManager {
     try {
       const cacheRaw = await this.storage.load('token-cache');
       if (cacheRaw) {
-        this.msalApp.getTokenCache().deserialize(unwrapCache(cacheRaw).data);
+        this.msalApp
+          .getTokenCache()
+          .deserialize(pruneDuplicateRefreshTokens(unwrapCache(cacheRaw).data));
       }
 
       // Load selected account
@@ -853,6 +930,127 @@ class AuthManager {
     );
   }
 
+  private async readPersistedRefreshTokens(
+    homeAccountId: string
+  ): Promise<Set<string> | undefined> {
+    const cacheRaw = await this.storage.load('token-cache');
+    return cacheRaw
+      ? persistedRefreshTokens(unwrapCache(cacheRaw).data, homeAccountId)
+      : new Set<string>();
+  }
+
+  /**
+   * Records why a sign-in could not be confirmed, then throws.
+   *
+   * The message has to outlive the throw. On the MCP `login` path the tool has already
+   * returned - it resolves as soon as there is a device code to show - so this rejection
+   * has nowhere to go, and `verify login` is where the user looks next. Clearing the
+   * in-memory token stops that check from answering out of memory and calling it a
+   * success (issue #648).
+   */
+  private failLoginPersistence(account: AccountInfo, reason: string): never {
+    const message = `Signed in as '${this.describeAccount(account)}', but ${reason}`;
+    this.loginPersistenceError = message;
+    this.accessToken = null;
+    this.tokenExpiry = null;
+    logger.error(message);
+    throw new Error(message);
+  }
+
+  /** Refresh token secrets MSAL holds for an account right now, before anything reloads. */
+  private inMemoryRefreshTokens(homeAccountId: string): Set<string> {
+    const secrets = new Set<string>();
+    const cache = this.msalApp.getTokenCache() as {
+      getKVStore?: () => Record<string, unknown>;
+    };
+    // Absent on a stubbed cache, and on any MSAL that stops exposing it. Returning
+    // nothing turns the check below into a no-op rather than a false alarm.
+    const store = cache.getKVStore?.();
+    if (!store) return secrets;
+
+    for (const entity of Object.values(store)) {
+      if (typeof entity !== 'object' || entity === null) continue;
+      const credential = entity as {
+        credentialType?: string;
+        homeAccountId?: string;
+        secret?: string;
+      };
+      if (credential.credentialType !== 'RefreshToken') continue;
+      if (credential.homeAccountId !== homeAccountId) continue;
+      if (credential.secret) secrets.add(credential.secret);
+    }
+    return secrets;
+  }
+
+  /**
+   * Confirms the refresh token MSAL just issued actually reached the cache.
+   *
+   * Persistence is best-effort by design: DefaultTokenCacheStorage is not fail-closed, so
+   * afterCacheAccess swallows a refused or failed write and the sign-in still reports
+   * success. The account then works for exactly one access token lifetime - the one held
+   * in memory - and every silent refresh afterwards falls back to whatever stale token is
+   * still on disk. Nothing surfaces that until it has been happening for weeks, by which
+   * point the stale token has aged past Entra's 90-day inactivity limit and the account is
+   * dead (issue #648). Cheaper to read the cache back once than to debug that later.
+   */
+  private async assertLoginPersisted(account: AccountInfo | null | undefined): Promise<void> {
+    // A new attempt supersedes whatever the last one concluded.
+    this.loginPersistenceError = null;
+    if (!account) return;
+
+    // Everything MSAL holds for the account, which after a cache reload is the disk
+    // contents plus whatever this sign-in just added. The whole set has to survive the
+    // write: checking that *some* of it did would be satisfied by the very stale token
+    // this exists to catch, since that one is already on disk.
+    const issued = this.inMemoryRefreshTokens(account.homeAccountId);
+    if (issued.size === 0) return;
+
+    let persisted: Set<string> | undefined;
+    try {
+      persisted = await this.readPersistedRefreshTokens(account.homeAccountId);
+      if (persisted && ![...issued].every((secret) => persisted!.has(secret))) {
+        // The cache is last-writer-wins across processes rather than locked (issue #545),
+        // so this read can land between a sibling's save and its own reload. One more look
+        // is cheaper than telling someone a good sign-in was lost.
+        await delay(PERSISTENCE_RECHECK_MS);
+        persisted = await this.readPersistedRefreshTokens(account.homeAccountId);
+      }
+    } catch (error) {
+      this.failLoginPersistence(
+        account,
+        `the auth cache could not be read back (${(error as Error).message}), so the sign-in cannot ` +
+          `be confirmed as saved. It would stop working when this access token expires. Fix the cache ` +
+          `location, then log in again.`
+      );
+    }
+
+    if (persisted === undefined) {
+      this.failLoginPersistence(
+        account,
+        `the auth cache did not read back as a usable cache, so the sign-in cannot be confirmed as ` +
+          `saved. It would stop working when this access token expires. Check the log for ` +
+          `'Not persisting token-cache'.`
+      );
+    }
+
+    if (![...issued].every((secret) => persisted.has(secret))) {
+      this.failLoginPersistence(
+        account,
+        `the refresh token was not written to the auth cache, so access would stop working when this ` +
+          `access token expires. The log says why - look for 'Not persisting token-cache' or ` +
+          `'Error saving token cache'.`
+      );
+    }
+
+    if (persisted.size > 1) {
+      logger.warn(
+        `The auth cache holds ${persisted.size} refresh tokens for '${this.describeAccount(account)}'. ` +
+          `MSAL spends whichever it finds first, so a stale one can win (issue #648). Log out and sign ` +
+          `in again if silent refresh starts failing.`
+      );
+    }
+  }
+
   async setOAuthToken(token: string): Promise<void> {
     this.oauthToken = token;
     this.isOAuthMode = true;
@@ -949,6 +1147,7 @@ class AuthManager {
       this.accessToken = response?.accessToken || null;
       this.tokenExpiry = response?.expiresOn ? new Date(response.expiresOn).getTime() : null;
       await this.rejectUnexpectedLoginAccount(response?.account);
+      await this.assertLoginPersisted(response?.account);
 
       // Set the newly authenticated account as selected if no account is currently selected
       if (!this.selectedAccountId && response?.account) {
@@ -1001,6 +1200,7 @@ class AuthManager {
       this.accessToken = response?.accessToken || null;
       this.tokenExpiry = response?.expiresOn ? new Date(response.expiresOn).getTime() : null;
       await this.rejectUnexpectedLoginAccount(response?.account);
+      await this.assertLoginPersisted(response?.account);
 
       // Set the newly authenticated account as selected if no account is currently selected
       if (!this.selectedAccountId && response?.account) {
@@ -1021,6 +1221,14 @@ class AuthManager {
   async testLogin(): Promise<LoginTestResult> {
     try {
       logger.info('Testing login...');
+      // A sign-in whose tokens never reached the cache reports its failure here: on the
+      // MCP login path the tool had already returned by the time that was known, and this
+      // is where the user is told to look next (issue #648).
+      if (this.loginPersistenceError) {
+        logger.error(`Login test failed - ${this.loginPersistenceError}`);
+        return { success: false, message: this.loginPersistenceError };
+      }
+
       const token = await this.getToken();
 
       if (!token) {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -6,7 +6,12 @@ import { fileURLToPath } from 'url';
 import path from 'path';
 import { getSecrets, type AppSecrets } from './secrets.js';
 import { getCloudEndpoints, getDefaultClientId } from './cloud-config.js';
-import { dedupeRefreshTokens } from './lib/cache-dedupe.js';
+import {
+  dedupeRefreshTokens,
+  type CanonicalKeyFor,
+  type DroppedRefreshToken,
+  type RefreshTokenDedupe,
+} from './lib/cache-dedupe.js';
 import {
   createTokenCacheStorage,
   DefaultTokenCacheStorage,
@@ -62,13 +67,60 @@ function createMsalConfig(secrets: AppSecrets): Configuration {
  */
 const warnedDuplicateRefreshTokens = new Set<string>();
 
+/**
+ * Accounts whose duplicate refresh tokens the last load could not rank. Per account, not
+ * one flag for the cache: the remedy is a logout, which drops every account, so blaming
+ * A's failure on B's duplicate would talk someone into signing all of them out.
+ */
+let unresolvedDuplicateAccounts = new Set<string>();
+
 /** Test seam: the warnings above are deduplicated for the process lifetime. */
 export function resetRefreshTokenWarningsForTests(): void {
   warnedDuplicateRefreshTokens.clear();
+  unresolvedDuplicateAccounts = new Set<string>();
 }
 
-function pruneDuplicateRefreshTokens(data: string): string {
-  const result = dedupeRefreshTokens(data);
+/**
+ * MSAL's own key builder, reached through the NodeStorage behind the token cache.
+ *
+ * Not exported from the package root and deep imports are blocked, so this hop is the only
+ * way to ask MSAL instead of reimplementing its format - and reimplementing the format is
+ * what made this mess. Anything unexpected returns undefined, which skips the pass.
+ */
+function canonicalKeyResolver(tokenCache: unknown): CanonicalKeyFor | undefined {
+  const storage = (tokenCache as { storage?: { generateCredentialKey?: unknown } })?.storage;
+  const generate = storage?.generateCredentialKey;
+  if (typeof generate !== 'function') return undefined;
+
+  return (entity) => {
+    if (!entity.home_account_id || !entity.environment || !entity.client_id) return undefined;
+    try {
+      const key = (generate as (c: unknown) => unknown).call(storage, {
+        homeAccountId: entity.home_account_id,
+        environment: entity.environment,
+        credentialType: 'RefreshToken',
+        clientId: entity.client_id,
+        ...(entity.family_id ? { familyId: entity.family_id } : {}),
+        // Each of these owns a segment of the key. MSAL does not put them on refresh tokens
+        // today, but a serialized entity can carry them, and dropping them would map two
+        // different credentials onto one key - and then this deletes a live one
+        ...(entity.realm ? { realm: entity.realm } : {}),
+        ...(entity.target ? { target: entity.target } : {}),
+        ...(entity.token_type ? { tokenType: entity.token_type } : {}),
+        secret: entity.secret ?? '',
+      });
+      return typeof key === 'string' ? key : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+}
+
+function pruneDuplicateRefreshTokens(data: string, tokenCache?: unknown): RefreshTokenDedupe {
+  const result = dedupeRefreshTokens(
+    data,
+    tokenCache === undefined ? undefined : canonicalKeyResolver(tokenCache)
+  );
 
   for (const drop of result.dropped) {
     const signature = `${drop.environment}->${drop.keptEnvironment}`;
@@ -81,6 +133,8 @@ function pruneDuplicateRefreshTokens(data: string): string {
     );
   }
 
+  unresolvedDuplicateAccounts = new Set(result.ambiguousAccounts);
+
   if (result.ambiguous > 0 && !warnedDuplicateRefreshTokens.has('ambiguous')) {
     warnedDuplicateRefreshTokens.add('ambiguous');
     logger.warn(
@@ -90,7 +144,27 @@ function pruneDuplicateRefreshTokens(data: string): string {
     );
   }
 
-  return result.data;
+  return result;
+}
+
+/**
+ * Removes the dropped entries from the store MSAL actually reads.
+ *
+ * `deserialize` merges into the key-value store instead of replacing it, so a key removed
+ * from the blob survives in the store `getRefreshToken` reads - and `serialize()` writes it
+ * straight back out. Pruning the blob alone only works while that store is still empty,
+ * which is the first access after startup and nothing else (issue #648).
+ *
+ * `getKVStore()` hands back the live object so deleting sticks. Not via setCache: that
+ * emits a change event, and a prune is no reason to force a write.
+ */
+function dropFromKVStore(tokenCache: unknown, dropped: DroppedRefreshToken[]): void {
+  if (dropped.length === 0) return;
+  const store = (tokenCache as { getKVStore?: () => Record<string, unknown> }).getKVStore?.();
+  if (!store) return;
+  for (const drop of dropped) {
+    delete store[drop.key];
+  }
 }
 
 /** How long to wait before a second look at the cache, when the first came up short. */
@@ -156,7 +230,12 @@ export function buildDiskCoherencyCachePlugin(storage: TokenCacheStorage): ICach
       try {
         const cacheRaw = await storage.load('token-cache');
         if (cacheRaw) {
-          context.tokenCache.deserialize(pruneDuplicateRefreshTokens(unwrapCache(cacheRaw).data));
+          const pruned = pruneDuplicateRefreshTokens(
+            unwrapCache(cacheRaw).data,
+            context.tokenCache
+          );
+          context.tokenCache.deserialize(pruned.data);
+          dropFromKVStore(context.tokenCache, pruned.dropped);
         }
       } catch (error) {
         logger.error(`Error reloading token cache: ${(error as Error).message}`);
@@ -634,6 +713,29 @@ export function describeAuthError(error: unknown): string {
   return (error as Error).message;
 }
 
+/**
+ * Hint for a silent refresh that failed while the cache still holds duplicates nothing
+ * could rank.
+ *
+ * The duplicate is logged already, but a stuck user reads `verify login`, not the log. And
+ * the obvious move - log in again - is the one that cannot help: it adds a token next to
+ * the stale one, which still sorts first. Only logout clears it, by deleting the cache
+ * file, and nothing says so anywhere (issue #648).
+ */
+export function duplicateRefreshTokenHint(
+  account: AccountInfo | null | undefined,
+  unresolvedAccounts: ReadonlySet<string>
+): string | null {
+  if (!account || !unresolvedAccounts.has(account.homeAccountId)) {
+    return null;
+  }
+  return (
+    'The auth cache holds more than one refresh token for this account and nothing indicates ' +
+    'which is current, so a stale one may be winning. Logging in again will not clear it - run ' +
+    'logout first, then log in.'
+  );
+}
+
 /** Home tenant id shared by all personal Microsoft accounts (MSA). */
 const MSA_HOME_TENANT_ID = '9188040d-6c67-4c5b-b112-36a304b66dad';
 
@@ -679,7 +781,11 @@ class AuthManager {
   private expectedUsername: string | null;
   private expectedHomeAccountId: string | null;
   private storage: TokenCacheStorage;
-  private loginPersistenceError: string | null;
+  /**
+   * A sign-in this process could not confirm reached the cache, plus which account it was
+   * about - with several cached, one account's failure must not answer for another (#648).
+   */
+  private loginPersistence: { homeAccountId: string; message: string } | null;
 
   constructor(
     config: Configuration,
@@ -704,7 +810,7 @@ class AuthManager {
     this.tokenExpiry = null;
     this.selectedAccountId = null;
     this.useInteractiveAuth = false;
-    this.loginPersistenceError = null;
+    this.loginPersistence = null;
     this.expectedUsername = this.normalizeExpectedUsername(expectedAccount?.expectedUsername);
     this.expectedHomeAccountId = this.normalizeExpectedHomeAccountId(
       expectedAccount?.expectedHomeAccountId
@@ -736,9 +842,10 @@ class AuthManager {
     try {
       const cacheRaw = await this.storage.load('token-cache');
       if (cacheRaw) {
-        this.msalApp
-          .getTokenCache()
-          .deserialize(pruneDuplicateRefreshTokens(unwrapCache(cacheRaw).data));
+        const tokenCache = this.msalApp.getTokenCache();
+        const pruned = pruneDuplicateRefreshTokens(unwrapCache(cacheRaw).data, tokenCache);
+        tokenCache.deserialize(pruned.data);
+        dropFromKVStore(tokenCache, pruned.dropped);
       }
 
       // Load selected account
@@ -940,6 +1047,20 @@ class AuthManager {
   }
 
   /**
+   * The cache as it stood before a sign-in, so the check afterwards can tell a write that
+   * never happened from one a sibling overwrote. The account is not known until the sign-in
+   * returns, so keep the whole blob and filter later. Best-effort.
+   */
+  private async snapshotPersistedCache(): Promise<string | undefined> {
+    try {
+      const cacheRaw = await this.storage.load('token-cache');
+      return cacheRaw ? unwrapCache(cacheRaw).data : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
    * Records why a sign-in could not be confirmed, then throws.
    *
    * The message has to outlive the throw. On the MCP `login` path the tool has already
@@ -950,7 +1071,7 @@ class AuthManager {
    */
   private failLoginPersistence(account: AccountInfo, reason: string): never {
     const message = `Signed in as '${this.describeAccount(account)}', but ${reason}`;
-    this.loginPersistenceError = message;
+    this.loginPersistence = { homeAccountId: account.homeAccountId, message };
     this.accessToken = null;
     this.tokenExpiry = null;
     logger.error(message);
@@ -992,10 +1113,19 @@ class AuthManager {
    * still on disk. Nothing surfaces that until it has been happening for weeks, by which
    * point the stale token has aged past Entra's 90-day inactivity limit and the account is
    * dead (issue #648). Cheaper to read the cache back once than to debug that later.
+   *
+   * `before` is the cache ahead of the sign-in. Demanding the issued token on disk is right
+   * until you remember the cache is last-writer-wins, not locked (issue #545): a sibling
+   * mid-refresh can rotate the same credential just after this one saved. That leaves a
+   * live token that isn't ours, which is a working account. The failure is a write that
+   * left no trace at all.
    */
-  private async assertLoginPersisted(account: AccountInfo | null | undefined): Promise<void> {
+  private async assertLoginPersisted(
+    account: AccountInfo | null | undefined,
+    before: string | undefined
+  ): Promise<void> {
     // A new attempt supersedes whatever the last one concluded.
-    this.loginPersistenceError = null;
+    this.loginPersistence = null;
     if (!account) return;
 
     // Everything MSAL holds for the account, which after a cache reload is the disk
@@ -1034,11 +1164,30 @@ class AuthManager {
     }
 
     if (![...issued].every((secret) => persisted.has(secret))) {
-      this.failLoginPersistence(
-        account,
-        `the refresh token was not written to the auth cache, so access would stop working when this ` +
-          `access token expires. The log says why - look for 'Not persisting token-cache' or ` +
-          `'Error saving token cache'.`
+      // A secret that is on disk now and wasn't before: someone else wrote a fresh
+      // credential, so the account still works. Has to be an *addition* - a set that merely
+      // differs proves nothing, since a sibling that only pruned a duplicate changes the
+      // set without writing, and the survivor could be the stale token we're hunting.
+      // No snapshot is not an escape hatch either.
+      const beforeSecrets =
+        before === undefined ? undefined : persistedRefreshTokens(before, account.homeAccountId);
+      const supersededByAnotherProcess =
+        beforeSecrets !== undefined && [...persisted].some((secret) => !beforeSecrets.has(secret));
+
+      if (!supersededByAnotherProcess) {
+        this.failLoginPersistence(
+          account,
+          `the refresh token was not written to the auth cache, so access would stop working when this ` +
+            `access token expires. The log says why - look for 'Not persisting token-cache' or ` +
+            `'Error saving token cache'.`
+        );
+      }
+
+      logger.warn(
+        `Another process rewrote the auth cache for '${this.describeAccount(account)}' during sign-in. ` +
+          `The refresh token on disk is not the one just issued, but it was not there before this ` +
+          `sign-in either, so something wrote a live credential and the sign-in counts as saved ` +
+          `(issue #545).`
       );
     }
 
@@ -1083,7 +1232,15 @@ class AuthManager {
         // clobber a newer rotation a sibling process wrote in the meantime (issue #545).
         return this.accessToken;
       } catch (error) {
-        const hint = consumersAuthorityHint(error, currentAccount, this.config.auth.authority);
+        // Duplicate hint second: the authority one explains the rejection, this one explains
+        // why logging in again won't stick
+        const hint =
+          [
+            consumersAuthorityHint(error, currentAccount, this.config.auth.authority),
+            duplicateRefreshTokenHint(currentAccount, unresolvedDuplicateAccounts),
+          ]
+            .filter(Boolean)
+            .join(' ') || null;
         logger.error(
           `Silent token acquisition failed: ${describeAuthError(error)}${hint ? ` ${hint}` : ''}`
         );
@@ -1141,13 +1298,14 @@ class AuthManager {
     try {
       logger.info('Requesting device code...');
       logger.info(`Requesting scopes: ${this.scopes.join(', ')}`);
+      const before = await this.snapshotPersistedCache();
       const response = await this.msalApp.acquireTokenByDeviceCode(deviceCodeRequest);
       logger.info(`Granted scopes: ${response?.scopes?.join(', ') || 'none'}`);
       logger.info('Device code login successful');
       this.accessToken = response?.accessToken || null;
       this.tokenExpiry = response?.expiresOn ? new Date(response.expiresOn).getTime() : null;
       await this.rejectUnexpectedLoginAccount(response?.account);
-      await this.assertLoginPersisted(response?.account);
+      await this.assertLoginPersisted(response?.account, before);
 
       // Set the newly authenticated account as selected if no account is currently selected
       if (!this.selectedAccountId && response?.account) {
@@ -1194,13 +1352,14 @@ class AuthManager {
     try {
       logger.info('Requesting interactive browser login...');
       logger.info(`Requesting scopes: ${this.scopes.join(', ')}`);
+      const before = await this.snapshotPersistedCache();
       const response = await this.msalApp.acquireTokenInteractive(interactiveRequest);
       logger.info(`Granted scopes: ${response?.scopes?.join(', ') || 'none'}`);
       logger.info('Interactive browser login successful');
       this.accessToken = response?.accessToken || null;
       this.tokenExpiry = response?.expiresOn ? new Date(response.expiresOn).getTime() : null;
       await this.rejectUnexpectedLoginAccount(response?.account);
-      await this.assertLoginPersisted(response?.account);
+      await this.assertLoginPersisted(response?.account, before);
 
       // Set the newly authenticated account as selected if no account is currently selected
       if (!this.selectedAccountId && response?.account) {
@@ -1218,15 +1377,31 @@ class AuthManager {
     }
   }
 
+  /**
+   * Whether the recorded failure is about the account this check would test.
+   *
+   * An explicit selection is the only thing that says "not asking about that sign-in".
+   * Resolving the account is not: a failed sign-in never reaches the auto-select and its
+   * account is usually missing from the cache anyway, so getCurrentAccount falls back to
+   * whichever is first and gives the neighbour a clean bill of health (issue #648).
+   */
+  private loginPersistenceAppliesToCurrentAccount(): boolean {
+    if (!this.loginPersistence) return false;
+    return (
+      this.selectedAccountId === null ||
+      this.selectedAccountId === this.loginPersistence.homeAccountId
+    );
+  }
+
   async testLogin(): Promise<LoginTestResult> {
     try {
       logger.info('Testing login...');
       // A sign-in whose tokens never reached the cache reports its failure here: on the
       // MCP login path the tool had already returned by the time that was known, and this
       // is where the user is told to look next (issue #648).
-      if (this.loginPersistenceError) {
-        logger.error(`Login test failed - ${this.loginPersistenceError}`);
-        return { success: false, message: this.loginPersistenceError };
+      if (this.loginPersistence && this.loginPersistenceAppliesToCurrentAccount()) {
+        logger.error(`Login test failed - ${this.loginPersistence.message}`);
+        return { success: false, message: this.loginPersistence.message };
       }
 
       const token = await this.getToken();
@@ -1294,6 +1469,8 @@ class AuthManager {
       this.accessToken = null;
       this.tokenExpiry = null;
       this.selectedAccountId = null;
+      // Every account is gone, so the recorded failure goes with them (issue #648)
+      this.loginPersistence = null;
 
       await this.storage.delete('token-cache');
       await this.storage.delete('selected-account');
@@ -1324,6 +1501,11 @@ class AuthManager {
     // Clear cached tokens to force refresh with new account
     this.accessToken = null;
     this.tokenExpiry = null;
+    // Switching away retires the failure. Switching *to* it keeps it, which is the whole
+    // point of tracking which account it was about
+    if (this.loginPersistence && this.loginPersistence.homeAccountId !== account.homeAccountId) {
+      this.loginPersistence = null;
+    }
 
     logger.info(`Selected account: ${account.username} (${account.homeAccountId})`);
     return true;
@@ -1334,6 +1516,12 @@ class AuthManager {
 
     try {
       await this.msalApp.getTokenCache().removeAccount(account);
+
+      // Keyed on the removed account, not the selected one - a failed sign-in never got as
+      // far as auto-selecting itself, so the selection says nothing here (issue #648)
+      if (this.loginPersistence?.homeAccountId === account.homeAccountId) {
+        this.loginPersistence = null;
+      }
 
       // If this was the selected account, clear the selection
       if (this.selectedAccountId === account.homeAccountId) {

--- a/src/lib/cache-dedupe.ts
+++ b/src/lib/cache-dedupe.ts
@@ -12,13 +12,12 @@
  * crosses Entra's 90-day inactivity limit (issue #648).
  *
  * The survivor is the entry in whatever environment MSAL last wrote under *for that same
- * credential owner*. Access tokens carry `cached_at` and a `client_id`, so the newest one
- * belonging to the owner names it; a family (FOCI) refresh token is shared across clients
- * and has no single owner's access tokens to rank it, so it falls back to the account
- * entities. Deleting a live credential costs a re-login, so every case that does not point
- * at exactly one winner - no signal, two environments stamped at the same instant, a
- * preferred environment matching no entry - leaves the group exactly as it is. A duplicate
- * left alone is no worse off than it already was.
+ * credential owner*, ranked by `cached_at` on that owner's access tokens - the only dated
+ * signal in the cache. Account entities are deliberately not a fallback: no recency, no
+ * link to the last rotation, so ranking by them is a guess, and a wrong guess here is
+ * invisible - the user is signed out, signs back in, and never reports it. So anything
+ * that doesn't point at exactly one winner is left exactly as it is. A duplicate left
+ * alone is no worse off than it already was.
  */
 
 interface SerializedEntity {
@@ -28,6 +27,10 @@ interface SerializedEntity {
   family_id?: string;
   cached_at?: string;
   secret?: string;
+  /** All three take part in MSAL's credential key, so all three must reach the resolver. */
+  realm?: string;
+  target?: string;
+  token_type?: string;
 }
 
 type EntityDict = Record<string, SerializedEntity>;
@@ -39,6 +42,8 @@ interface SerializedCache {
 }
 
 export interface DroppedRefreshToken {
+  /** Removing it from the blob is not enough on its own - see dropFromKVStore in auth.ts. */
+  key: string;
   environment: string;
   keptEnvironment: string;
 }
@@ -48,6 +53,11 @@ export interface RefreshTokenDedupe {
   dropped: DroppedRefreshToken[];
   /** Groups holding several tokens that no signal could rank. Left untouched. */
   ambiguous: number;
+  /**
+   * home_account_ids owning those groups - one account can own several. Warning about a
+   * cache is one thing, telling a *particular* account to log out is another.
+   */
+  ambiguousAccounts: string[];
 }
 
 interface EnvironmentChoice {
@@ -57,12 +67,8 @@ interface EnvironmentChoice {
   tied: boolean;
 }
 
-interface EnvironmentPreferences {
-  /** Keyed `${home_account_id} ${client_id}`: where that one client last wrote. */
-  byOwner: Map<string, EnvironmentChoice>;
-  /** Keyed home_account_id, and only where the account entities agree on one environment. */
-  byAccount: Map<string, string>;
-}
+/** Keyed `${home_account_id} ${client_id}`: where that one client last wrote. */
+type EnvironmentPreferences = Map<string, EnvironmentChoice>;
 
 /** A refresh token group: every entry MSAL would consider interchangeable. */
 interface RefreshTokenGroup {
@@ -113,41 +119,76 @@ function environmentPreferences(cache: SerializedCache): EnvironmentPreferences 
     }
   }
 
-  // Accounts are rewritten on every login, so their environment is a decent second
-  // opinion - but only where the account itself was not left duplicated across aliases.
-  const byAccount = new Map<string, string>();
-  if (isDict(cache.Account)) {
-    const seen = new Map<string, Set<string>>();
-    for (const entity of Object.values(cache.Account)) {
-      const home = entity?.home_account_id;
-      const environment = entity?.environment;
-      if (!home || !environment) continue;
-      let environments = seen.get(home);
-      if (!environments) seen.set(home, (environments = new Set()));
-      environments.add(environment);
-    }
-    for (const [home, environments] of seen) {
-      const only = [...environments][0];
-      if (environments.size === 1 && only) byAccount.set(home, only);
-    }
-  }
-
-  return { byOwner, byAccount };
+  return byOwner;
 }
 
 function preferredEnvironment(
   preferences: EnvironmentPreferences,
   group: RefreshTokenGroup
 ): string | undefined {
-  const choice = preferences.byOwner.get(groupKey(group.homeAccountId, group.owner));
-  if (choice && !choice.tied) return choice.environment;
-  // Nothing owner-specific: either a family token, a client with no access tokens left,
-  // or a tie. The account entities are the only account-wide signal remaining.
-  return preferences.byAccount.get(group.homeAccountId);
+  const choice = preferences.get(groupKey(group.homeAccountId, group.owner));
+  // No dated signal (family token, or the access tokens are gone), or a tie, which says
+  // just as little. Both leave the group alone - there is deliberately no fallback
+  if (!choice || choice.tied) return undefined;
+  return choice.environment;
 }
 
-export function dedupeRefreshTokens(cacheJson: string): RefreshTokenDedupe {
-  const unchanged: RefreshTokenDedupe = { data: cacheJson, dropped: [], ambiguous: 0 };
+/** The key MSAL would write for an entity now, or undefined. The caller owns MSAL, not us. */
+export type CanonicalKeyFor = (entity: SerializedEntity) => string | undefined;
+
+/**
+ * Collapse entries that are the same credential written under two different MSAL key
+ * formats.
+ *
+ * MSAL's credential key changed shape across majors: msal-node 3.x wrote
+ * `<home>-<env>-refreshtoken-<client>----`, 5.x writes one dash fewer. An upgrade leaves
+ * the old entry behind, MSAL still matches it (the filter tests fields, not key shape),
+ * and `getRefreshToken` returns whichever comes first - so every login after that writes a
+ * token the account never gets to use. Same dead end as the environment aliases below, and
+ * the environment ranking is blind to it since both entries share an environment.
+ *
+ * The key format is the recency signal: identical fields resolve to one canonical key, so
+ * whoever is stored *at* it is what today's MSAL wrote and the rest are leftovers. Nothing
+ * goes unless that occupant is really there - a lone old-format entry is the only copy of
+ * a working credential, and MSAL reads it fine.
+ */
+function dropSupersededKeyFormats(
+  refreshTokens: EntityDict,
+  canonicalKeyFor: CanonicalKeyFor
+): DroppedRefreshToken[] {
+  const byCanonical = new Map<string, string[]>();
+  for (const [key, entity] of Object.entries(refreshTokens)) {
+    if (!isEntity(entity)) continue;
+    const canonical = canonicalKeyFor(entity);
+    if (!canonical) continue;
+    byCanonical.set(canonical, [...(byCanonical.get(canonical) ?? []), key]);
+  }
+
+  const dropped: DroppedRefreshToken[] = [];
+  for (const [canonical, keys] of byCanonical) {
+    if (keys.length < 2 || !keys.includes(canonical)) continue;
+    for (const key of keys) {
+      if (key === canonical) continue;
+      dropped.push({
+        key,
+        environment: refreshTokens[key]?.environment ?? 'unknown',
+        keptEnvironment: refreshTokens[canonical]?.environment ?? 'unknown',
+      });
+    }
+  }
+  return dropped;
+}
+
+export function dedupeRefreshTokens(
+  cacheJson: string,
+  canonicalKeyFor?: CanonicalKeyFor
+): RefreshTokenDedupe {
+  const unchanged: RefreshTokenDedupe = {
+    data: cacheJson,
+    dropped: [],
+    ambiguous: 0,
+    ambiguousAccounts: [],
+  };
 
   let cache: SerializedCache;
   try {
@@ -160,6 +201,13 @@ export function dedupeRefreshTokens(cacheJson: string): RefreshTokenDedupe {
 
   const refreshTokens = cache.RefreshToken;
   if (!isDict(refreshTokens)) return unchanged;
+
+  // First, because a superseded key format is a fact about the entry, not a guess about
+  // which credential is newer. Leaves the ranking below less to guess at
+  const supersededDrops = canonicalKeyFor
+    ? dropSupersededKeyFormats(refreshTokens, canonicalKeyFor)
+    : [];
+  for (const drop of supersededDrops) delete refreshTokens[drop.key];
 
   // A family (FOCI) token and an app-specific one are separate credentials that MSAL
   // looks up separately, so they group apart rather than competing.
@@ -177,12 +225,21 @@ export function dedupeRefreshTokens(cacheJson: string): RefreshTokenDedupe {
   // Duplicates are the rare case, so nothing walks the access tokens - the bulk of a real
   // cache - until there is a group that actually needs ranking.
   const duplicated = [...groups.values()].filter((group) => group.keys.length > 1);
-  if (duplicated.length === 0) return unchanged;
+  if (duplicated.length === 0) {
+    return supersededDrops.length > 0
+      ? {
+          data: JSON.stringify(cache),
+          dropped: supersededDrops,
+          ambiguous: 0,
+          ambiguousAccounts: [],
+        }
+      : unchanged;
+  }
 
   const preferences = environmentPreferences(cache);
-  const dropped: DroppedRefreshToken[] = [];
-  const remove: string[] = [];
+  const dropped: DroppedRefreshToken[] = [...supersededDrops];
   let ambiguous = 0;
+  const ambiguousAccounts = new Set<string>();
 
   for (const group of duplicated) {
     const keep = preferredEnvironment(preferences, group);
@@ -191,21 +248,25 @@ export function dedupeRefreshTokens(cacheJson: string): RefreshTokenDedupe {
       : [];
     if (!keep || winners.length !== 1) {
       ambiguous += 1;
+      ambiguousAccounts.add(group.homeAccountId);
       continue;
     }
 
     for (const key of group.keys) {
       if (key === winners[0]) continue;
-      remove.push(key);
       dropped.push({
+        key,
         environment: refreshTokens[key]?.environment ?? 'unknown',
         keptEnvironment: keep,
       });
     }
   }
 
-  if (remove.length === 0) return { data: cacheJson, dropped, ambiguous };
+  const unranked = [...ambiguousAccounts];
+  if (dropped.length === 0) {
+    return { data: cacheJson, dropped, ambiguous, ambiguousAccounts: unranked };
+  }
 
-  for (const key of remove) delete refreshTokens[key];
-  return { data: JSON.stringify(cache), dropped, ambiguous };
+  for (const drop of dropped) delete refreshTokens[drop.key];
+  return { data: JSON.stringify(cache), dropped, ambiguous, ambiguousAccounts: unranked };
 }

--- a/src/lib/cache-dedupe.ts
+++ b/src/lib/cache-dedupe.ts
@@ -1,0 +1,211 @@
+/**
+ * Collapse duplicate refresh tokens in a serialized MSAL cache.
+ *
+ * MSAL matches a cached refresh token to an account by environment *alias*, so entries
+ * under `login.microsoftonline.com` and `login.windows.net` both answer for the same
+ * account. `CacheManager.getRefreshToken` then returns whichever comes first in key
+ * order, with no recency tie-break and no error, so a leftover entry from an earlier
+ * environment wins every refresh - permanently. Nothing prunes the loser either: the
+ * cache plugin reloads the file before each access, and MSAL's merge only drops keys the
+ * in-memory state has lost, which is the same file it just read. A fresh login writes a
+ * new token, the old one keeps being spent, and the account dies for good once that one
+ * crosses Entra's 90-day inactivity limit (issue #648).
+ *
+ * The survivor is the entry in whatever environment MSAL last wrote under *for that same
+ * credential owner*. Access tokens carry `cached_at` and a `client_id`, so the newest one
+ * belonging to the owner names it; a family (FOCI) refresh token is shared across clients
+ * and has no single owner's access tokens to rank it, so it falls back to the account
+ * entities. Deleting a live credential costs a re-login, so every case that does not point
+ * at exactly one winner - no signal, two environments stamped at the same instant, a
+ * preferred environment matching no entry - leaves the group exactly as it is. A duplicate
+ * left alone is no worse off than it already was.
+ */
+
+interface SerializedEntity {
+  home_account_id?: string;
+  environment?: string;
+  client_id?: string;
+  family_id?: string;
+  cached_at?: string;
+  secret?: string;
+}
+
+type EntityDict = Record<string, SerializedEntity>;
+
+interface SerializedCache {
+  Account?: unknown;
+  AccessToken?: unknown;
+  RefreshToken?: unknown;
+}
+
+export interface DroppedRefreshToken {
+  environment: string;
+  keptEnvironment: string;
+}
+
+export interface RefreshTokenDedupe {
+  data: string;
+  dropped: DroppedRefreshToken[];
+  /** Groups holding several tokens that no signal could rank. Left untouched. */
+  ambiguous: number;
+}
+
+interface EnvironmentChoice {
+  environment: string;
+  cachedAt: number;
+  /** Two environments stamped at the same instant, which ranks neither. */
+  tied: boolean;
+}
+
+interface EnvironmentPreferences {
+  /** Keyed `${home_account_id} ${client_id}`: where that one client last wrote. */
+  byOwner: Map<string, EnvironmentChoice>;
+  /** Keyed home_account_id, and only where the account entities agree on one environment. */
+  byAccount: Map<string, string>;
+}
+
+/** A refresh token group: every entry MSAL would consider interchangeable. */
+interface RefreshTokenGroup {
+  homeAccountId: string;
+  /** family_id for a FOCI token, otherwise client_id. */
+  owner: string;
+  keys: string[];
+}
+
+function isDict(value: unknown): value is EntityDict {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Narrows to the entity itself, where isDict would resolve fields through the dict's index. */
+function isEntity(value: unknown): value is SerializedEntity {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function groupKey(homeAccountId: string, owner: string): string {
+  return `${homeAccountId} ${owner}`;
+}
+
+/**
+ * Where MSAL last wrote, per credential owner. An access token's `cached_at` is the only
+ * timestamp in the cache - refresh token entities carry none - so it is what tells current
+ * from stale. Access tokens are always per-client, so they are collected per-client too:
+ * ranking one client's refresh tokens by another client's access tokens would happily
+ * delete a token that is still the live one for its own client.
+ */
+function environmentPreferences(cache: SerializedCache): EnvironmentPreferences {
+  const byOwner = new Map<string, EnvironmentChoice>();
+  if (isDict(cache.AccessToken)) {
+    for (const entity of Object.values(cache.AccessToken)) {
+      const home = entity?.home_account_id;
+      const environment = entity?.environment;
+      const client = entity?.client_id;
+      if (!home || !environment || !client) continue;
+      const cachedAt = Number(entity.cached_at);
+      if (!Number.isFinite(cachedAt)) continue;
+
+      const key = groupKey(home, client);
+      const best = byOwner.get(key);
+      if (!best || cachedAt > best.cachedAt) {
+        byOwner.set(key, { environment, cachedAt, tied: false });
+      } else if (cachedAt === best.cachedAt && environment !== best.environment) {
+        best.tied = true;
+      }
+    }
+  }
+
+  // Accounts are rewritten on every login, so their environment is a decent second
+  // opinion - but only where the account itself was not left duplicated across aliases.
+  const byAccount = new Map<string, string>();
+  if (isDict(cache.Account)) {
+    const seen = new Map<string, Set<string>>();
+    for (const entity of Object.values(cache.Account)) {
+      const home = entity?.home_account_id;
+      const environment = entity?.environment;
+      if (!home || !environment) continue;
+      let environments = seen.get(home);
+      if (!environments) seen.set(home, (environments = new Set()));
+      environments.add(environment);
+    }
+    for (const [home, environments] of seen) {
+      const only = [...environments][0];
+      if (environments.size === 1 && only) byAccount.set(home, only);
+    }
+  }
+
+  return { byOwner, byAccount };
+}
+
+function preferredEnvironment(
+  preferences: EnvironmentPreferences,
+  group: RefreshTokenGroup
+): string | undefined {
+  const choice = preferences.byOwner.get(groupKey(group.homeAccountId, group.owner));
+  if (choice && !choice.tied) return choice.environment;
+  // Nothing owner-specific: either a family token, a client with no access tokens left,
+  // or a tie. The account entities are the only account-wide signal remaining.
+  return preferences.byAccount.get(group.homeAccountId);
+}
+
+export function dedupeRefreshTokens(cacheJson: string): RefreshTokenDedupe {
+  const unchanged: RefreshTokenDedupe = { data: cacheJson, dropped: [], ambiguous: 0 };
+
+  let cache: SerializedCache;
+  try {
+    const parsed: unknown = JSON.parse(cacheJson);
+    if (!isDict(parsed)) return unchanged;
+    cache = parsed as SerializedCache;
+  } catch {
+    return unchanged;
+  }
+
+  const refreshTokens = cache.RefreshToken;
+  if (!isDict(refreshTokens)) return unchanged;
+
+  // A family (FOCI) token and an app-specific one are separate credentials that MSAL
+  // looks up separately, so they group apart rather than competing.
+  const groups = new Map<string, RefreshTokenGroup>();
+  for (const [key, entity] of Object.entries(refreshTokens)) {
+    if (!isEntity(entity)) continue;
+    const home = entity.home_account_id;
+    const owner = entity.family_id || entity.client_id;
+    if (!home || !owner) continue;
+    const group = groups.get(groupKey(home, owner));
+    if (group) group.keys.push(key);
+    else groups.set(groupKey(home, owner), { homeAccountId: home, owner, keys: [key] });
+  }
+
+  // Duplicates are the rare case, so nothing walks the access tokens - the bulk of a real
+  // cache - until there is a group that actually needs ranking.
+  const duplicated = [...groups.values()].filter((group) => group.keys.length > 1);
+  if (duplicated.length === 0) return unchanged;
+
+  const preferences = environmentPreferences(cache);
+  const dropped: DroppedRefreshToken[] = [];
+  const remove: string[] = [];
+  let ambiguous = 0;
+
+  for (const group of duplicated) {
+    const keep = preferredEnvironment(preferences, group);
+    const winners = keep
+      ? group.keys.filter((key) => refreshTokens[key]?.environment === keep)
+      : [];
+    if (!keep || winners.length !== 1) {
+      ambiguous += 1;
+      continue;
+    }
+
+    for (const key of group.keys) {
+      if (key === winners[0]) continue;
+      remove.push(key);
+      dropped.push({
+        environment: refreshTokens[key]?.environment ?? 'unknown',
+        keptEnvironment: keep,
+      });
+    }
+  }
+
+  if (remove.length === 0) return { data: cacheJson, dropped, ambiguous };
+
+  for (const key of remove) delete refreshTokens[key];
+  return { data: JSON.stringify(cache), dropped, ambiguous };
+}

--- a/test/token-cache-roundtrip.test.ts
+++ b/test/token-cache-roundtrip.test.ts
@@ -6,6 +6,7 @@ import { PublicClientApplication } from '@azure/msal-node';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import AuthManager, {
   buildDiskCoherencyCachePlugin,
+  duplicateRefreshTokenHint,
   resetRefreshTokenWarningsForTests,
 } from '../src/auth.js';
 import { dedupeRefreshTokens } from '../src/lib/cache-dedupe.js';
@@ -58,6 +59,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
   resetCacheKeyForTests();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
@@ -136,6 +138,18 @@ interface NodeStorageLike {
   ) => { secret: string } | null;
 }
 
+/** Refresh token secrets in the key-value store that actually answers getRefreshToken. */
+function kvRefreshSecrets(tokenCache: { getKVStore: () => Record<string, unknown> }): string[] {
+  return Object.values(tokenCache.getKVStore())
+    .filter(
+      (entity): entity is { credentialType: string; secret: string } =>
+        typeof entity === 'object' &&
+        entity !== null &&
+        (entity as { credentialType?: string }).credentialType === 'RefreshToken'
+    )
+    .map((entity) => entity.secret);
+}
+
 async function readRefreshTokens(storage: TokenCacheStorage): Promise<Record<string, string>> {
   const raw = await storage.load('token-cache');
   const parsed = JSON.parse(unwrapCache(raw as string).data) as {
@@ -183,6 +197,129 @@ describe('token cache round-trip through the real MSAL cache', () => {
     await plugin.afterCacheAccess!(ctx);
 
     expect(Object.values(await readRefreshTokens(storage))).toContain('RT-NEW');
+  });
+
+  it('prunes the store MSAL reads, not only the blob it was handed', async () => {
+    // A fresh PublicClientApplication per test can't reach this: the process already holds
+    // both, because nothing could rank them when it first loaded. deserialize() merges into
+    // the key-value store instead of replacing it, so pruning the blob alone leaves the
+    // stale entry answering getRefreshToken (issue #648)
+    const disk = (accessTokens: Record<string, unknown>) =>
+      wrapCache(
+        JSON.stringify({
+          Account: {
+            [`${HOME_ID}-${ALIAS_ENV}-utid-a`]: accountEntity(ALIAS_ENV),
+            [`${HOME_ID}-${CURRENT_ENV}-utid-a`]: accountEntity(CURRENT_ENV),
+          },
+          IdToken: {},
+          AccessToken: accessTokens,
+          RefreshToken: {
+            [refreshTokenKey(ALIAS_ENV)]: refreshTokenEntity(ALIAS_ENV, 'RT-FROM-MAY'),
+            [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-FROM-AUGUST'),
+          },
+          AppMetadata: {},
+        })
+      );
+
+    const storage = new DefaultTokenCacheStorage();
+    await storage.save('token-cache', disk({}));
+
+    const { tokenCache, nodeStorage } = buildApp(storage);
+    const plugin = buildDiskCoherencyCachePlugin(storage);
+
+    await plugin.beforeCacheAccess!(context(tokenCache, false));
+    expect(kvRefreshSecrets(tokenCache).sort()).toEqual(['RT-FROM-AUGUST', 'RT-FROM-MAY']);
+
+    // A sign-in lands an access token, which is what finally names the live environment.
+    await storage.save(
+      'token-cache',
+      disk({ [accessTokenKey(CURRENT_ENV)]: accessTokenEntity(CURRENT_ENV, '1755000000') })
+    );
+
+    const ctx = context(tokenCache, true);
+    await plugin.beforeCacheAccess!(ctx);
+
+    expect(kvRefreshSecrets(tokenCache)).toEqual(['RT-FROM-AUGUST']);
+    expect(
+      nodeStorage.getRefreshToken(
+        { homeAccountId: HOME_ID, environment: CURRENT_ENV } as AccountInfo,
+        false,
+        'corr-1'
+      )?.secret
+    ).toBe('RT-FROM-AUGUST');
+
+    // And the drop must not come back the moment anything persists.
+    await plugin.afterCacheAccess!(ctx);
+    expect(Object.values(await readRefreshTokens(storage))).toEqual(['RT-FROM-AUGUST']);
+  });
+
+  it('asks the real MSAL for its key format and clears the superseded entry', async () => {
+    // Real PublicClientApplication, real affected cache. Also the canary for the NodeStorage
+    // hop: if MSAL drops generateCredentialKey the resolver goes quiet, nothing is pruned,
+    // and this fails instead of silently going back to spending the stale token
+    const legacyKey = `${refreshTokenKey(CURRENT_ENV)}-`;
+    const storage = new DefaultTokenCacheStorage();
+    await storage.save(
+      'token-cache',
+      wrapCache(
+        JSON.stringify({
+          Account: { [`${HOME_ID}-${CURRENT_ENV}-utid-a`]: accountEntity(CURRENT_ENV) },
+          IdToken: {},
+          AccessToken: {},
+          RefreshToken: {
+            [legacyKey]: refreshTokenEntity(CURRENT_ENV, 'RT-FROM-MAY'),
+            [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-FROM-AUGUST'),
+          },
+          AppMetadata: {},
+        })
+      )
+    );
+
+    const { tokenCache, nodeStorage } = buildApp(storage);
+    const plugin = buildDiskCoherencyCachePlugin(storage);
+    const ctx = context(tokenCache, true);
+    await plugin.beforeCacheAccess!(ctx);
+
+    expect(kvRefreshSecrets(tokenCache)).toEqual(['RT-FROM-AUGUST']);
+    expect(
+      nodeStorage.getRefreshToken(
+        { homeAccountId: HOME_ID, environment: CURRENT_ENV } as AccountInfo,
+        false,
+        'corr-1'
+      )?.secret
+    ).toBe('RT-FROM-AUGUST');
+
+    await plugin.afterCacheAccess!(ctx);
+    expect(Object.values(await readRefreshTokens(storage))).toEqual(['RT-FROM-AUGUST']);
+  });
+
+  it('keeps realm-scoped credentials apart when it asks MSAL for the key', async () => {
+    // The real canonicalKeyResolver, not a stub. realm owns a key segment, so a resolver
+    // that drops it maps these two onto one key and deletes the one not sitting at it -
+    // a live credential, gone. MSAL lowercases the key it builds
+    const scopedKey = `${HOME_ID}-${CURRENT_ENV}-refreshtoken-${CLIENT_ID}-tenant-b--`;
+    const storage = new DefaultTokenCacheStorage();
+    await storage.save(
+      'token-cache',
+      wrapCache(
+        JSON.stringify({
+          Account: { [`${HOME_ID}-${CURRENT_ENV}-utid-a`]: accountEntity(CURRENT_ENV) },
+          IdToken: {},
+          AccessToken: {},
+          RefreshToken: {
+            [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-NO-REALM'),
+            [scopedKey]: { ...refreshTokenEntity(CURRENT_ENV, 'RT-TENANT-B'), realm: 'tenant-b' },
+          },
+          AppMetadata: {},
+        })
+      )
+    );
+
+    const { tokenCache } = buildApp(storage);
+    const plugin = buildDiskCoherencyCachePlugin(storage);
+    await plugin.beforeCacheAccess!(context(tokenCache, false));
+
+    expect(kvRefreshSecrets(tokenCache).sort()).toEqual(['RT-NO-REALM', 'RT-TENANT-B']);
   });
 
   it('collapses alias-environment duplicates so the newest refresh token wins', async () => {
@@ -289,21 +426,25 @@ describe('dedupeRefreshTokens', () => {
     expect(result.ambiguous).toBe(0);
   });
 
-  it('falls back to the account environment when there is no access token to date', () => {
+  it('will not let an account entity rank a group with no dated signal', () => {
+    // An account entity has no recency and no link to the last rotation, so it can't say
+    // which of these is live. A wrong guess is invisible: signed out, signs back in, never
+    // reported
     const cache = JSON.stringify({
       Account: { [`${HOME_ID}-${CURRENT_ENV}-utid-a`]: accountEntity(CURRENT_ENV) },
       AccessToken: {},
       RefreshToken: {
-        [refreshTokenKey(ALIAS_ENV)]: refreshTokenEntity(ALIAS_ENV, 'RT-STALE'),
-        [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-CURRENT'),
+        [refreshTokenKey(ALIAS_ENV)]: refreshTokenEntity(ALIAS_ENV, 'RT-ONE'),
+        [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-TWO'),
       },
     });
 
     const result = dedupeRefreshTokens(cache);
-    const kept = JSON.parse(result.data) as { RefreshToken: Record<string, { secret: string }> };
 
-    expect(Object.values(kept.RefreshToken).map((entity) => entity.secret)).toEqual(['RT-CURRENT']);
-    expect(result.dropped).toEqual([{ environment: ALIAS_ENV, keptEnvironment: CURRENT_ENV }]);
+    expect(result.data).toBe(cache);
+    expect(result.dropped).toEqual([]);
+    expect(result.ambiguous).toBe(1);
+    expect(result.ambiguousAccounts).toEqual([HOME_ID]);
   });
 
   it('keeps what the newest access token points at, not whatever was written last', () => {
@@ -326,12 +467,36 @@ describe('dedupeRefreshTokens', () => {
     const kept = JSON.parse(result.data) as { RefreshToken: Record<string, { secret: string }> };
 
     expect(Object.values(kept.RefreshToken).map((entity) => entity.secret)).toEqual(['RT-NEWEST']);
-    expect(result.dropped).toEqual([{ environment: CURRENT_ENV, keptEnvironment: ALIAS_ENV }]);
+    expect(result.dropped).toEqual([
+      { key: refreshTokenKey(CURRENT_ENV), environment: CURRENT_ENV, keptEnvironment: ALIAS_ENV },
+    ]);
   });
 
   it('treats two environments stamped at the same instant as unrankable', () => {
     const cache = JSON.stringify({
       Account: {},
+      AccessToken: {
+        [accessTokenKey(ALIAS_ENV)]: accessTokenEntity(ALIAS_ENV, '1755000000'),
+        [accessTokenKey(CURRENT_ENV)]: accessTokenEntity(CURRENT_ENV, '1755000000'),
+      },
+      RefreshToken: {
+        [refreshTokenKey(ALIAS_ENV)]: refreshTokenEntity(ALIAS_ENV, 'RT-ONE'),
+        [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-TWO'),
+      },
+    });
+
+    const result = dedupeRefreshTokens(cache);
+
+    expect(result.data).toBe(cache);
+    expect(result.dropped).toEqual([]);
+    expect(result.ambiguous).toBe(1);
+  });
+
+  it('does not let the account environment break an access token tie', () => {
+    // A tie plus a single account entity, which is the shape the other tie test misses by
+    // passing Account: {}. Neither may break the tie
+    const cache = JSON.stringify({
+      Account: { [`${HOME_ID}-${CURRENT_ENV}-utid-a`]: accountEntity(CURRENT_ENV) },
       AccessToken: {
         [accessTokenKey(ALIAS_ENV)]: accessTokenEntity(ALIAS_ENV, '1755000000'),
         [accessTokenKey(CURRENT_ENV)]: accessTokenEntity(CURRENT_ENV, '1755000000'),
@@ -374,11 +539,124 @@ describe('dedupeRefreshTokens', () => {
     expect(Object.values(kept.RefreshToken).map((entity) => entity.secret)).toEqual(['RT-LIVE']);
   });
 
+  // msal-node 3.x wrote one trailing segment more than 5.x does. Both shapes reference the
+  // same credential, so the environment ranking is blind to them (identical environments).
+  const LEGACY_KEY = `${refreshTokenKey(CURRENT_ENV)}-`;
+  const canonicalKeyFor = (entity: { client_id?: string; family_id?: string }) =>
+    entity.client_id ? refreshTokenKey(CURRENT_ENV, entity.client_id) : undefined;
+
+  it('drops an entry left under a superseded MSAL key format', () => {
+    // Taken from a real affected cache: same account, same client, same environment, two
+    // key shapes, and the stale one sorting first so MSAL spends it every time.
+    const cache = JSON.stringify({
+      Account: { [`${HOME_ID}-${CURRENT_ENV}-utid-a`]: accountEntity(CURRENT_ENV) },
+      AccessToken: {},
+      RefreshToken: {
+        [LEGACY_KEY]: refreshTokenEntity(CURRENT_ENV, 'RT-FROM-MAY'),
+        [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-FROM-AUGUST'),
+      },
+    });
+
+    const result = dedupeRefreshTokens(cache, canonicalKeyFor);
+    const kept = JSON.parse(result.data) as { RefreshToken: Record<string, { secret: string }> };
+
+    expect(Object.values(kept.RefreshToken).map((e) => e.secret)).toEqual(['RT-FROM-AUGUST']);
+    expect(result.dropped).toEqual([
+      { key: LEGACY_KEY, environment: CURRENT_ENV, keptEnvironment: CURRENT_ENV },
+    ]);
+    expect(result.ambiguous).toBe(0);
+  });
+
+  it('leaves a lone superseded entry alone rather than orphaning the only credential', () => {
+    // Upgraded but not signed in since. MSAL still reads this fine; dropping it would cost
+    // a sign-in for no reason.
+    const cache = JSON.stringify({
+      Account: {},
+      AccessToken: {},
+      RefreshToken: { [LEGACY_KEY]: refreshTokenEntity(CURRENT_ENV, 'RT-ONLY-COPY') },
+    });
+
+    const result = dedupeRefreshTokens(cache, canonicalKeyFor);
+
+    expect(result.data).toBe(cache);
+    expect(result.dropped).toEqual([]);
+  });
+
+  it('keeps both when neither entry sits at the canonical key', () => {
+    // Two superseded formats and no current one, after crossing two MSAL majors without
+    // signing in. The drop loop keeps only the canonical key, so without the occupant guard
+    // this empties the account
+    const olderKey = `${refreshTokenKey(CURRENT_ENV)}--`;
+    const cache = JSON.stringify({
+      Account: {},
+      AccessToken: {},
+      RefreshToken: {
+        [olderKey]: refreshTokenEntity(CURRENT_ENV, 'RT-OLDEST'),
+        [LEGACY_KEY]: refreshTokenEntity(CURRENT_ENV, 'RT-OLDER'),
+      },
+    });
+
+    const result = dedupeRefreshTokens(cache, canonicalKeyFor);
+    const kept = JSON.parse(result.data) as { RefreshToken: Record<string, unknown> };
+
+    expect(result.dropped).toEqual([]);
+    expect(Object.keys(kept.RefreshToken)).toHaveLength(2);
+  });
+
+  it('does not collapse credentials that differ in a key-forming field', () => {
+    // realm, target and tokenType each own a segment of the key. A resolver that ignores
+    // them collapses two different credentials into one. This resolver is the faithful one
+    const faithful = (entity: { client_id?: string; realm?: string }) =>
+      entity.client_id
+        ? `${HOME_ID}-${CURRENT_ENV}-refreshtoken-${entity.client_id}-${entity.realm ?? ''}--`
+        : undefined;
+    const scopedKey = `${HOME_ID}-${CURRENT_ENV}-refreshtoken-${CLIENT_ID}-tenant-b--`;
+    const cache = JSON.stringify({
+      Account: {},
+      AccessToken: {},
+      RefreshToken: {
+        [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-NO-REALM'),
+        [scopedKey]: { ...refreshTokenEntity(CURRENT_ENV, 'RT-TENANT-B'), realm: 'tenant-b' },
+      },
+    });
+
+    const result = dedupeRefreshTokens(cache, faithful);
+    const kept = JSON.parse(result.data) as { RefreshToken: Record<string, { secret: string }> };
+
+    expect(result.dropped).toEqual([]);
+    expect(
+      Object.values(kept.RefreshToken)
+        .map((e) => e.secret)
+        .sort()
+    ).toEqual(['RT-NO-REALM', 'RT-TENANT-B']);
+  });
+
+  it('does nothing about key formats when no resolver is supplied', () => {
+    const cache = JSON.stringify({
+      Account: {},
+      AccessToken: {},
+      RefreshToken: {
+        [LEGACY_KEY]: refreshTokenEntity(CURRENT_ENV, 'RT-FROM-MAY'),
+        [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-FROM-AUGUST'),
+      },
+    });
+
+    // Same input as the first case: without MSAL to ask, this is the old behaviour, an
+    // unrankable pair left exactly as it was.
+    const result = dedupeRefreshTokens(cache);
+
+    expect(result.data).toBe(cache);
+    expect(result.ambiguous).toBe(1);
+  });
+
   it('preserves sections it does not model when it rewrites the cache', () => {
     const cache = JSON.stringify({
       Account: { [`${HOME_ID}-${CURRENT_ENV}-utid-a`]: accountEntity(CURRENT_ENV) },
       IdToken: { 'id-key': { home_account_id: HOME_ID, secret: 'ID-TOKEN' } },
-      AccessToken: {},
+      // A dated signal, so this exercises the rewrite rather than the leave-alone path.
+      AccessToken: {
+        [accessTokenKey(CURRENT_ENV)]: accessTokenEntity(CURRENT_ENV, '1755000000'),
+      },
       RefreshToken: {
         [refreshTokenKey(ALIAS_ENV)]: refreshTokenEntity(ALIAS_ENV, 'RT-STALE'),
         [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-CURRENT'),
@@ -397,6 +675,31 @@ describe('dedupeRefreshTokens', () => {
   });
 });
 
+describe('duplicateRefreshTokenHint', () => {
+  const account = { homeAccountId: HOME_ID } as AccountInfo;
+  const other = { homeAccountId: 'uid-b.utid-b' } as AccountInfo;
+
+  it('says nothing when there is no unresolved duplicate', () => {
+    expect(duplicateRefreshTokenHint(account, new Set())).toBeNull();
+  });
+
+  it('names logout, because logging in again provably cannot clear it', () => {
+    const hint = duplicateRefreshTokenHint(account, new Set([HOME_ID]));
+    expect(hint).toMatch(/logout/);
+    expect(hint).toMatch(/will not clear it/);
+  });
+
+  it("stays quiet about another account's duplicates", () => {
+    // The remedy it names is a logout, which deletes every account's tokens. Attaching B's
+    // ambiguity to A's unrelated failure would talk someone into signing all of them out.
+    expect(duplicateRefreshTokenHint(other, new Set([HOME_ID]))).toBeNull();
+  });
+
+  it('says nothing when there is no current account to attribute it to', () => {
+    expect(duplicateRefreshTokenHint(null, new Set([HOME_ID]))).toBeNull();
+  });
+});
+
 describe('a sign-in that did not reach the cache', () => {
   const msalConfig: Configuration = {
     auth: { clientId: CLIENT_ID, authority: 'https://login.microsoftonline.com/common' },
@@ -407,11 +710,25 @@ describe('a sign-in that did not reach the cache', () => {
     homeAccountId: HOME_ID,
   } as AccountInfo;
 
-  function createAuth(storage: TokenCacheStorage, kvStore: Record<string, unknown>) {
+  const otherAccount = {
+    username: 'b@contoso.com',
+    name: 'Account B',
+    homeAccountId: 'uid-b.utid-b',
+  } as AccountInfo;
+
+  function createAuth(
+    storage: TokenCacheStorage,
+    kvStore: Record<string, unknown>,
+    accounts: AccountInfo[] = [account],
+    signedInAs: AccountInfo = account,
+    /** Gives the *other* account a working silent refresh, so a suppressed failure shows up
+     *  as the clean bill of health it would really be. */
+    silentToken?: string
+  ) {
     const tokenCache = {
       serialize: vi.fn().mockReturnValue('serialized-cache'),
       deserialize: vi.fn(),
-      getAllAccounts: vi.fn().mockResolvedValue([account]),
+      getAllAccounts: vi.fn().mockResolvedValue(accounts),
       removeAccount: vi.fn().mockResolvedValue(undefined),
       getKVStore: vi.fn(() => kvStore),
     };
@@ -420,9 +737,18 @@ describe('a sign-in that did not reach the cache', () => {
       acquireTokenByDeviceCode: vi.fn().mockResolvedValue({
         accessToken: 'fresh-access-token',
         expiresOn: new Date(Date.now() + 60_000),
-        account,
+        account: signedInAs,
         scopes: ['User.Read'],
       }),
+      ...(silentToken
+        ? {
+            acquireTokenSilent: vi.fn().mockResolvedValue({
+              accessToken: silentToken,
+              expiresOn: new Date(Date.now() + 60_000),
+              account: accounts[0],
+            }),
+          }
+        : {}),
     };
     const auth = new AuthManager(msalConfig, ['User.Read'], undefined, storage);
     Object.assign(auth as unknown as Record<string, unknown>, { msalApp });
@@ -434,25 +760,46 @@ describe('a sign-in that did not reach the cache', () => {
    * token just issued. Anything that models only the new token hides the case where a
    * stale on-disk token would satisfy the check on its own.
    */
-  function inMemory(secrets: string[]): Record<string, unknown> {
+  function inMemory(secrets: string[], home = HOME_ID): Record<string, unknown> {
     return Object.fromEntries(
       secrets.map((secret, index) => [
         `rt-key-${index}`,
-        { credentialType: 'RefreshToken', homeAccountId: HOME_ID, clientId: CLIENT_ID, secret },
+        { credentialType: 'RefreshToken', homeAccountId: home, clientId: CLIENT_ID, secret },
       ])
     );
   }
 
-  function storageHolding(secrets: string[]): TokenCacheStorage {
-    const cache = JSON.stringify({
+  function serializedCache(secrets: string[], home: string): string {
+    return JSON.stringify({
       RefreshToken: Object.fromEntries(
-        secrets.map((secret, index) => [`rt-key-${index}`, { home_account_id: HOME_ID, secret }])
+        secrets.map((secret, index) => [`rt-key-${index}`, { home_account_id: home, secret }])
       ),
     });
+  }
+
+  function storageHolding(secrets: string[], home = HOME_ID): TokenCacheStorage {
     return {
       description: 'mock-storage',
       failClosed: false,
-      load: vi.fn().mockResolvedValue(wrapCache(cache)),
+      load: vi.fn().mockResolvedValue(wrapCache(serializedCache(secrets, home))),
+      save: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  /**
+   * One entry per load() call, the last repeating. The sign-in path reads the cache before
+   * the acquire and again after, so this is how a sibling writing between the two is
+   * modelled.
+   */
+  function storageReturning(reads: string[][], home = HOME_ID): TokenCacheStorage {
+    let call = 0;
+    return {
+      description: 'mock-storage',
+      failClosed: false,
+      load: vi.fn(async () =>
+        wrapCache(serializedCache(reads[Math.min(call++, reads.length - 1)], home))
+      ),
       save: vi.fn().mockResolvedValue(undefined),
       delete: vi.fn().mockResolvedValue(undefined),
     };
@@ -499,5 +846,154 @@ describe('a sign-in that did not reach the cache', () => {
     const auth = createAuth(storageHolding([]), {});
 
     await expect(auth.acquireTokenByDeviceCode()).resolves.toBe('fresh-access-token');
+  });
+
+  const STALE = /refresh token was not written to the auth cache/;
+
+  it('stops reporting the failure after a logout', async () => {
+    const auth = createAuth(
+      storageHolding(['RT-FROM-MAY']),
+      inMemory(['RT-FROM-MAY', 'RT-JUST-ISSUED'])
+    );
+
+    await expect(auth.acquireTokenByDeviceCode()).rejects.toThrow();
+    expect((await auth.testLogin()).message).toMatch(STALE);
+
+    await auth.logout();
+
+    expect((await auth.testLogin()).message).not.toMatch(STALE);
+  });
+
+  it('stops reporting the failure once another account is selected', async () => {
+    const auth = createAuth(
+      storageHolding(['RT-FROM-MAY']),
+      inMemory(['RT-FROM-MAY', 'RT-JUST-ISSUED']),
+      [account, otherAccount]
+    );
+
+    await expect(auth.acquireTokenByDeviceCode()).rejects.toThrow();
+    expect((await auth.testLogin()).message).toMatch(STALE);
+
+    await auth.selectAccount('b@contoso.com');
+
+    expect((await auth.testLogin()).message).not.toMatch(STALE);
+  });
+
+  it('accepts a sign-in another process overwrote with a live token', async () => {
+    // Last-writer-wins across processes, not locked (issue #545): a sibling mid-refresh
+    // rotates the same credential right after this save. Disk no longer holds our token but
+    // what it does hold is live, so the sign-in is not lost
+    const auth = createAuth(
+      storageReturning([['RT-FROM-MAY'], ['RT-ROTATED-BY-SIBLING']]),
+      inMemory(['RT-FROM-MAY', 'RT-JUST-ISSUED'])
+    );
+
+    await expect(auth.acquireTokenByDeviceCode()).resolves.toBe('fresh-access-token');
+  });
+
+  it('still fails when a sibling only pruned a duplicate', async () => {
+    // The on-disk set changed - one of two tokens is gone - but nothing was written, and
+    // the survivor may be the stale one. Set inequality alone would wave this through.
+    const auth = createAuth(
+      storageReturning([['RT-FROM-MAY', 'RT-FROM-AUGUST'], ['RT-FROM-AUGUST']]),
+      inMemory(['RT-FROM-MAY', 'RT-FROM-AUGUST', 'RT-JUST-ISSUED'])
+    );
+
+    await expect(auth.acquireTokenByDeviceCode()).rejects.toThrow(STALE);
+  });
+
+  it('reports the failure when no account was ever explicitly selected', async () => {
+    // A's write was swallowed so A is not in the cache; B is, from earlier. And
+    // assertLoginPersisted runs before the auto-select, so nothing is selected - resolving
+    // "the current account" lands on B and pronounces it healthy
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Response.json({ displayName: 'Account B', userPrincipalName: 'b@contoso.com' })
+      )
+    );
+    const auth = createAuth(
+      storageHolding(['RT-B'], otherAccount.homeAccountId),
+      inMemory(['RT-A-JUST-ISSUED']),
+      [otherAccount],
+      account,
+      'token-for-b'
+    );
+
+    await expect(auth.acquireTokenByDeviceCode()).rejects.toThrow(STALE);
+    expect(auth.getSelectedAccountId()).toBeNull();
+
+    expect((await auth.testLogin()).message).toMatch(STALE);
+  });
+
+  it('still fails when the cache is byte-for-byte what it was before the sign-in', async () => {
+    // Same shape as above, minus the sibling: nothing wrote, so nothing changed.
+    const auth = createAuth(
+      storageReturning([['RT-FROM-MAY'], ['RT-FROM-MAY']]),
+      inMemory(['RT-FROM-MAY', 'RT-JUST-ISSUED'])
+    );
+
+    await expect(auth.acquireTokenByDeviceCode()).rejects.toThrow(STALE);
+  });
+
+  it('keeps reporting the failure when an unrelated account is removed', async () => {
+    const auth = createAuth(
+      storageHolding(['RT-FROM-MAY']),
+      inMemory(['RT-FROM-MAY', 'RT-JUST-ISSUED']),
+      [account, otherAccount]
+    );
+
+    await expect(auth.acquireTokenByDeviceCode()).rejects.toThrow();
+    await expect(auth.removeAccount('b@contoso.com')).resolves.toBe(true);
+
+    expect((await auth.testLogin()).message).toMatch(STALE);
+  });
+
+  it('keeps reporting the failure when the failing account is the one selected', async () => {
+    const auth = createAuth(
+      storageHolding(['RT-FROM-MAY']),
+      inMemory(['RT-FROM-MAY', 'RT-JUST-ISSUED']),
+      [account, otherAccount]
+    );
+
+    await expect(auth.acquireTokenByDeviceCode()).rejects.toThrow();
+    await auth.selectAccount('a@contoso.com');
+
+    expect((await auth.testLogin()).message).toMatch(STALE);
+  });
+
+  it('does not answer for one account while another is the one being verified', async () => {
+    // Account A is selected and fine; the sign-in that failed was for B. Verifying must
+    // test A rather than short-circuit on B's failure.
+    const auth = createAuth(
+      storageHolding(['RT-B-FROM-MAY'], otherAccount.homeAccountId),
+      inMemory(['RT-B-FROM-MAY', 'RT-B-JUST-ISSUED'], otherAccount.homeAccountId),
+      [account, otherAccount],
+      otherAccount
+    );
+    await auth.selectAccount('a@contoso.com');
+
+    await expect(auth.acquireTokenByDeviceCode()).rejects.toThrow(STALE);
+
+    // Reaches the real token path for A instead, which the stub has no answer for.
+    expect((await auth.testLogin()).message).toMatch(/Silent token acquisition failed/);
+  });
+
+  it('stops reporting the failure once the account is removed', async () => {
+    // A failed sign-in never reached the auto-select, so its account is not the selected
+    // one - the clear cannot be conditional on that
+    const auth = createAuth(
+      storageHolding(['RT-FROM-MAY']),
+      inMemory(['RT-FROM-MAY', 'RT-JUST-ISSUED']),
+      [account, otherAccount]
+    );
+
+    await expect(auth.acquireTokenByDeviceCode()).rejects.toThrow();
+    expect(auth.getSelectedAccountId()).toBeNull();
+    expect((await auth.testLogin()).message).toMatch(STALE);
+
+    await expect(auth.removeAccount('a@contoso.com')).resolves.toBe(true);
+
+    expect((await auth.testLogin()).message).not.toMatch(STALE);
   });
 });

--- a/test/token-cache-roundtrip.test.ts
+++ b/test/token-cache-roundtrip.test.ts
@@ -1,0 +1,503 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AccountInfo, Configuration, TokenCacheContext } from '@azure/msal-node';
+import { PublicClientApplication } from '@azure/msal-node';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AuthManager, {
+  buildDiskCoherencyCachePlugin,
+  resetRefreshTokenWarningsForTests,
+} from '../src/auth.js';
+import { dedupeRefreshTokens } from '../src/lib/cache-dedupe.js';
+import {
+  DefaultTokenCacheStorage,
+  resetCacheKeyForTests,
+  unwrapCache,
+  wrapCache,
+  type TokenCacheStorage,
+} from '../src/token-cache-storage.js';
+
+vi.mock('../src/logger.js', () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+// keytar is a real dependency, so without this the suite would touch the developer's
+// actual login keyring.
+const keychain = new Map<string, string>();
+vi.mock('keytar', () => ({
+  default: {
+    getPassword: vi.fn(async (service: string, account: string) => {
+      return keychain.get(`${service}/${account}`) ?? null;
+    }),
+    setPassword: vi.fn(async (service: string, account: string, value: string) => {
+      keychain.set(`${service}/${account}`, value);
+    }),
+    deletePassword: vi.fn(async (service: string, account: string) => {
+      return keychain.delete(`${service}/${account}`);
+    }),
+  },
+}));
+
+const HOME_ID = 'uid-a.utid-a';
+const CLIENT_ID = '11111111-2222-3333-4444-555555555555';
+const CURRENT_ENV = 'login.windows.net';
+const ALIAS_ENV = 'login.microsoftonline.com';
+const OTHER_CLIENT_ID = '99999999-8888-7777-6666-555555555555';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  keychain.clear();
+  resetCacheKeyForTests();
+  resetRefreshTokenWarningsForTests();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms365-cache-roundtrip-'));
+  vi.stubEnv('MS365_MCP_TOKEN_CACHE_PATH', path.join(tmpDir, 'token-cache.json'));
+  vi.stubEnv('MS365_MCP_SELECTED_ACCOUNT_PATH', path.join(tmpDir, 'selected-account.json'));
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  resetCacheKeyForTests();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function accountEntity(environment: string) {
+  return {
+    home_account_id: HOME_ID,
+    environment,
+    realm: 'utid-a',
+    local_account_id: 'uid-a',
+    username: 'a@contoso.com',
+    authority_type: 'MSSTS',
+    name: 'Account A',
+  };
+}
+
+function accessTokenEntity(environment: string, cachedAt: string, client = CLIENT_ID) {
+  return {
+    home_account_id: HOME_ID,
+    environment,
+    credential_type: 'AccessToken',
+    client_id: client,
+    secret: `AT-${cachedAt}`,
+    realm: 'utid-a',
+    target: 'mail.read',
+    cached_at: cachedAt,
+    expires_on: String(Number(cachedAt) + 3600),
+    token_type: 'Bearer',
+  };
+}
+
+function refreshTokenEntity(environment: string, secret: string, client = CLIENT_ID) {
+  return {
+    home_account_id: HOME_ID,
+    environment,
+    credential_type: 'RefreshToken',
+    client_id: client,
+    secret,
+  };
+}
+
+function refreshTokenKey(environment: string, client = CLIENT_ID) {
+  return `${HOME_ID}-${environment}-refreshtoken-${client}---`;
+}
+
+function accessTokenKey(environment: string, client = CLIENT_ID) {
+  return `${HOME_ID}-${environment}-accesstoken-${client}-utid-a-mail.read`;
+}
+
+/**
+ * The plugin only reads `cacheHasChanged` and `tokenCache` off the context, so a plain
+ * object stands in for MSAL's own - while the token cache underneath stays the real one.
+ */
+function context(tokenCache: unknown, cacheHasChanged: boolean): TokenCacheContext {
+  return { cacheHasChanged, tokenCache } as unknown as TokenCacheContext;
+}
+
+function buildApp(storage: TokenCacheStorage) {
+  const app = new PublicClientApplication({
+    auth: { clientId: CLIENT_ID, authority: 'https://login.microsoftonline.com/common' },
+    cache: { cachePlugin: buildDiskCoherencyCachePlugin(storage) },
+  });
+  const tokenCache = app.getTokenCache();
+  // Reaching past the public surface on purpose: NodeStorage is what actually answers
+  // the refresh flow, and its selection is the thing under test.
+  const nodeStorage = (tokenCache as unknown as { storage: Record<string, never> }).storage;
+  return { app, tokenCache, nodeStorage: nodeStorage as unknown as NodeStorageLike };
+}
+
+interface NodeStorageLike {
+  setRefreshTokenCredential: (credential: object, correlationId: string) => Promise<void>;
+  getRefreshToken: (
+    account: AccountInfo,
+    familyRT: boolean,
+    correlationId: string
+  ) => { secret: string } | null;
+}
+
+async function readRefreshTokens(storage: TokenCacheStorage): Promise<Record<string, string>> {
+  const raw = await storage.load('token-cache');
+  const parsed = JSON.parse(unwrapCache(raw as string).data) as {
+    RefreshToken: Record<string, { secret: string }>;
+  };
+  return Object.fromEntries(
+    Object.entries(parsed.RefreshToken).map(([key, value]) => [key, value.secret])
+  );
+}
+
+describe('token cache round-trip through the real MSAL cache', () => {
+  it('persists a rotated refresh token', async () => {
+    const storage = new DefaultTokenCacheStorage();
+    await storage.save(
+      'token-cache',
+      wrapCache(
+        JSON.stringify({
+          Account: { [`${HOME_ID}-${CURRENT_ENV}-utid-a`]: accountEntity(CURRENT_ENV) },
+          IdToken: {},
+          AccessToken: {},
+          RefreshToken: {
+            [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-OLD'),
+          },
+          AppMetadata: {},
+        })
+      )
+    );
+
+    const { tokenCache, nodeStorage } = buildApp(storage);
+    const plugin = buildDiskCoherencyCachePlugin(storage);
+
+    // The order msal-common's ResponseHandler uses around a token response.
+    const ctx = context(tokenCache, true);
+    await plugin.beforeCacheAccess!(ctx);
+    await nodeStorage.setRefreshTokenCredential(
+      {
+        homeAccountId: HOME_ID,
+        environment: CURRENT_ENV,
+        credentialType: 'RefreshToken',
+        clientId: CLIENT_ID,
+        secret: 'RT-NEW',
+      },
+      'corr-1'
+    );
+    await plugin.afterCacheAccess!(ctx);
+
+    expect(Object.values(await readRefreshTokens(storage))).toContain('RT-NEW');
+  });
+
+  it('collapses alias-environment duplicates so the newest refresh token wins', async () => {
+    const storage = new DefaultTokenCacheStorage();
+    await storage.save(
+      'token-cache',
+      wrapCache(
+        JSON.stringify({
+          Account: { [`${HOME_ID}-${CURRENT_ENV}-utid-a`]: accountEntity(CURRENT_ENV) },
+          IdToken: {},
+          // The newest access token names the environment MSAL last wrote under.
+          AccessToken: {
+            [`${HOME_ID}-${ALIAS_ENV}-accesstoken-${CLIENT_ID}-utid-a-mail.read`]:
+              accessTokenEntity(ALIAS_ENV, '1747814065'),
+            [`${HOME_ID}-${CURRENT_ENV}-accesstoken-${CLIENT_ID}-utid-a-mail.read`]:
+              accessTokenEntity(CURRENT_ENV, '1755000000'),
+          },
+          // Insertion order matters: the stale one is first, which is what MSAL would pick.
+          RefreshToken: {
+            [refreshTokenKey(ALIAS_ENV)]: refreshTokenEntity(ALIAS_ENV, 'RT-FROM-MAY'),
+            [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-FROM-AUGUST'),
+          },
+          AppMetadata: {},
+        })
+      )
+    );
+
+    const { tokenCache, nodeStorage } = buildApp(storage);
+    const accounts = await tokenCache.getAllAccounts();
+    expect(accounts).toHaveLength(1);
+
+    const picked = nodeStorage.getRefreshToken(accounts[0], false, 'corr-1');
+    expect(picked?.secret).toBe('RT-FROM-AUGUST');
+  });
+
+  it('keeps the pruning once something persists the cache', async () => {
+    const storage = new DefaultTokenCacheStorage();
+    await storage.save(
+      'token-cache',
+      wrapCache(
+        JSON.stringify({
+          Account: { [`${HOME_ID}-${CURRENT_ENV}-utid-a`]: accountEntity(CURRENT_ENV) },
+          IdToken: {},
+          AccessToken: {
+            [`${HOME_ID}-${CURRENT_ENV}-accesstoken-${CLIENT_ID}-utid-a-mail.read`]:
+              accessTokenEntity(CURRENT_ENV, '1755000000'),
+          },
+          RefreshToken: {
+            [refreshTokenKey(ALIAS_ENV)]: refreshTokenEntity(ALIAS_ENV, 'RT-FROM-MAY'),
+            [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-FROM-AUGUST'),
+          },
+          AppMetadata: {},
+        })
+      )
+    );
+
+    const { tokenCache } = buildApp(storage);
+    const plugin = buildDiskCoherencyCachePlugin(storage);
+    const ctx = context(tokenCache, true);
+    await plugin.beforeCacheAccess!(ctx);
+    await plugin.afterCacheAccess!(ctx);
+
+    expect(Object.values(await readRefreshTokens(storage))).toEqual(['RT-FROM-AUGUST']);
+  });
+});
+
+describe('dedupeRefreshTokens', () => {
+  it('leaves a blob it cannot parse exactly as it found it', () => {
+    expect(dedupeRefreshTokens('serialized-cache').data).toBe('serialized-cache');
+  });
+
+  it('leaves duplicates alone when nothing says which is current', () => {
+    const cache = JSON.stringify({
+      Account: {},
+      AccessToken: {},
+      RefreshToken: {
+        [refreshTokenKey(ALIAS_ENV)]: refreshTokenEntity(ALIAS_ENV, 'RT-ONE'),
+        [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-TWO'),
+      },
+    });
+
+    const result = dedupeRefreshTokens(cache);
+
+    expect(result.data).toBe(cache);
+    expect(result.dropped).toEqual([]);
+    expect(result.ambiguous).toBe(1);
+  });
+
+  it('does not pit a family token against an app-specific one', () => {
+    const familyKey = `${HOME_ID}-${CURRENT_ENV}-refreshtoken-1---`;
+    const cache = JSON.stringify({
+      Account: { [`${HOME_ID}-${CURRENT_ENV}-utid-a`]: accountEntity(CURRENT_ENV) },
+      AccessToken: {},
+      RefreshToken: {
+        [familyKey]: { ...refreshTokenEntity(CURRENT_ENV, 'RT-FAMILY'), family_id: '1' },
+        [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-APP'),
+      },
+    });
+
+    const result = dedupeRefreshTokens(cache);
+
+    expect(result.data).toBe(cache);
+    expect(result.dropped).toEqual([]);
+    expect(result.ambiguous).toBe(0);
+  });
+
+  it('falls back to the account environment when there is no access token to date', () => {
+    const cache = JSON.stringify({
+      Account: { [`${HOME_ID}-${CURRENT_ENV}-utid-a`]: accountEntity(CURRENT_ENV) },
+      AccessToken: {},
+      RefreshToken: {
+        [refreshTokenKey(ALIAS_ENV)]: refreshTokenEntity(ALIAS_ENV, 'RT-STALE'),
+        [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-CURRENT'),
+      },
+    });
+
+    const result = dedupeRefreshTokens(cache);
+    const kept = JSON.parse(result.data) as { RefreshToken: Record<string, { secret: string }> };
+
+    expect(Object.values(kept.RefreshToken).map((entity) => entity.secret)).toEqual(['RT-CURRENT']);
+    expect(result.dropped).toEqual([{ environment: ALIAS_ENV, keptEnvironment: CURRENT_ENV }]);
+  });
+
+  it('keeps what the newest access token points at, not whatever was written last', () => {
+    // The survivor is deliberately the FIRST entry here: an implementation that just kept
+    // the last key in insertion order would pass every other case in this file and fail
+    // this one, which is the whole point of ranking by cached_at.
+    const cache = JSON.stringify({
+      Account: {},
+      AccessToken: {
+        [accessTokenKey(CURRENT_ENV)]: accessTokenEntity(CURRENT_ENV, '1755000000'),
+        [accessTokenKey(ALIAS_ENV)]: accessTokenEntity(ALIAS_ENV, '1760000000'),
+      },
+      RefreshToken: {
+        [refreshTokenKey(ALIAS_ENV)]: refreshTokenEntity(ALIAS_ENV, 'RT-NEWEST'),
+        [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-OLDER'),
+      },
+    });
+
+    const result = dedupeRefreshTokens(cache);
+    const kept = JSON.parse(result.data) as { RefreshToken: Record<string, { secret: string }> };
+
+    expect(Object.values(kept.RefreshToken).map((entity) => entity.secret)).toEqual(['RT-NEWEST']);
+    expect(result.dropped).toEqual([{ environment: CURRENT_ENV, keptEnvironment: ALIAS_ENV }]);
+  });
+
+  it('treats two environments stamped at the same instant as unrankable', () => {
+    const cache = JSON.stringify({
+      Account: {},
+      AccessToken: {
+        [accessTokenKey(ALIAS_ENV)]: accessTokenEntity(ALIAS_ENV, '1755000000'),
+        [accessTokenKey(CURRENT_ENV)]: accessTokenEntity(CURRENT_ENV, '1755000000'),
+      },
+      RefreshToken: {
+        [refreshTokenKey(ALIAS_ENV)]: refreshTokenEntity(ALIAS_ENV, 'RT-ONE'),
+        [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-TWO'),
+      },
+    });
+
+    const result = dedupeRefreshTokens(cache);
+
+    expect(result.data).toBe(cache);
+    expect(result.dropped).toEqual([]);
+    expect(result.ambiguous).toBe(1);
+  });
+
+  it("does not let one client id decide another client id's survivor", () => {
+    // The other client's access token is newer and sits in the alias environment. Ranking
+    // account-wide would delete this client's live token and keep its stale one.
+    const cache = JSON.stringify({
+      Account: {},
+      AccessToken: {
+        [accessTokenKey(CURRENT_ENV)]: accessTokenEntity(CURRENT_ENV, '1755000000'),
+        [accessTokenKey(ALIAS_ENV, OTHER_CLIENT_ID)]: accessTokenEntity(
+          ALIAS_ENV,
+          '1760000000',
+          OTHER_CLIENT_ID
+        ),
+      },
+      RefreshToken: {
+        [refreshTokenKey(ALIAS_ENV)]: refreshTokenEntity(ALIAS_ENV, 'RT-STALE'),
+        [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-LIVE'),
+      },
+    });
+
+    const result = dedupeRefreshTokens(cache);
+    const kept = JSON.parse(result.data) as { RefreshToken: Record<string, { secret: string }> };
+
+    expect(Object.values(kept.RefreshToken).map((entity) => entity.secret)).toEqual(['RT-LIVE']);
+  });
+
+  it('preserves sections it does not model when it rewrites the cache', () => {
+    const cache = JSON.stringify({
+      Account: { [`${HOME_ID}-${CURRENT_ENV}-utid-a`]: accountEntity(CURRENT_ENV) },
+      IdToken: { 'id-key': { home_account_id: HOME_ID, secret: 'ID-TOKEN' } },
+      AccessToken: {},
+      RefreshToken: {
+        [refreshTokenKey(ALIAS_ENV)]: refreshTokenEntity(ALIAS_ENV, 'RT-STALE'),
+        [refreshTokenKey(CURRENT_ENV)]: refreshTokenEntity(CURRENT_ENV, 'RT-CURRENT'),
+      },
+      AppMetadata: { 'app-key': { client_id: CLIENT_ID, family_id: '1' } },
+      SomethingLaterMsalAdded: { keep: 'me' },
+    });
+
+    const result = dedupeRefreshTokens(cache);
+    const kept = JSON.parse(result.data) as Record<string, unknown>;
+
+    expect(result.dropped).toHaveLength(1);
+    expect(kept.IdToken).toEqual({ 'id-key': { home_account_id: HOME_ID, secret: 'ID-TOKEN' } });
+    expect(kept.AppMetadata).toEqual({ 'app-key': { client_id: CLIENT_ID, family_id: '1' } });
+    expect(kept.SomethingLaterMsalAdded).toEqual({ keep: 'me' });
+  });
+});
+
+describe('a sign-in that did not reach the cache', () => {
+  const msalConfig: Configuration = {
+    auth: { clientId: CLIENT_ID, authority: 'https://login.microsoftonline.com/common' },
+  };
+  const account = {
+    username: 'a@contoso.com',
+    name: 'Account A',
+    homeAccountId: HOME_ID,
+  } as AccountInfo;
+
+  function createAuth(storage: TokenCacheStorage, kvStore: Record<string, unknown>) {
+    const tokenCache = {
+      serialize: vi.fn().mockReturnValue('serialized-cache'),
+      deserialize: vi.fn(),
+      getAllAccounts: vi.fn().mockResolvedValue([account]),
+      removeAccount: vi.fn().mockResolvedValue(undefined),
+      getKVStore: vi.fn(() => kvStore),
+    };
+    const msalApp = {
+      getTokenCache: vi.fn(() => tokenCache),
+      acquireTokenByDeviceCode: vi.fn().mockResolvedValue({
+        accessToken: 'fresh-access-token',
+        expiresOn: new Date(Date.now() + 60_000),
+        account,
+        scopes: ['User.Read'],
+      }),
+    };
+    const auth = new AuthManager(msalConfig, ['User.Read'], undefined, storage);
+    Object.assign(auth as unknown as Record<string, unknown>, { msalApp });
+    return auth;
+  }
+
+  /**
+   * What MSAL actually holds after a sign-in: the cache it reloaded from disk, plus the
+   * token just issued. Anything that models only the new token hides the case where a
+   * stale on-disk token would satisfy the check on its own.
+   */
+  function inMemory(secrets: string[]): Record<string, unknown> {
+    return Object.fromEntries(
+      secrets.map((secret, index) => [
+        `rt-key-${index}`,
+        { credentialType: 'RefreshToken', homeAccountId: HOME_ID, clientId: CLIENT_ID, secret },
+      ])
+    );
+  }
+
+  function storageHolding(secrets: string[]): TokenCacheStorage {
+    const cache = JSON.stringify({
+      RefreshToken: Object.fromEntries(
+        secrets.map((secret, index) => [`rt-key-${index}`, { home_account_id: HOME_ID, secret }])
+      ),
+    });
+    return {
+      description: 'mock-storage',
+      failClosed: false,
+      load: vi.fn().mockResolvedValue(wrapCache(cache)),
+      save: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  it('fails the login instead of reporting success', async () => {
+    // The write was swallowed, so disk still holds only the token from months ago - which
+    // is also still in memory, and must not be what satisfies the check.
+    const auth = createAuth(
+      storageHolding(['RT-FROM-MAY']),
+      inMemory(['RT-FROM-MAY', 'RT-JUST-ISSUED'])
+    );
+
+    await expect(auth.acquireTokenByDeviceCode()).rejects.toThrow(
+      /refresh token was not written to the auth cache/
+    );
+  });
+
+  it('reports the failure through verify login', async () => {
+    // The MCP login tool has already returned by the time the sign-in fails, so this is
+    // where the user finds out (issue #648).
+    const auth = createAuth(
+      storageHolding(['RT-FROM-MAY']),
+      inMemory(['RT-FROM-MAY', 'RT-JUST-ISSUED'])
+    );
+
+    await expect(auth.acquireTokenByDeviceCode()).rejects.toThrow();
+    const result = await auth.testLogin();
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/refresh token was not written to the auth cache/);
+  });
+
+  it('accepts a login whose refresh token did land', async () => {
+    const auth = createAuth(
+      storageHolding(['RT-FROM-MAY', 'RT-JUST-ISSUED']),
+      inMemory(['RT-FROM-MAY', 'RT-JUST-ISSUED'])
+    );
+
+    await expect(auth.acquireTokenByDeviceCode()).resolves.toBe('fresh-access-token');
+  });
+
+  it('stays quiet when MSAL exposes no refresh token to check', async () => {
+    const auth = createAuth(storageHolding([]), {});
+
+    await expect(auth.acquireTokenByDeviceCode()).resolves.toBe('fresh-access-token');
+  });
+});


### PR DESCRIPTION
MSAL matches cached refresh tokens by environment alias and returns the first match with no recency tie-break, so a leftover entry under an aliased environment wins every refresh. Nothing prunes it either: the cache plugin reloads the file before each access, and MSAL's merge only drops keys the in-memory state has lost, which is the same file it just read. A fresh login writes a new token, the old one keeps being spent, and the account dies once that one crosses Entra's 90-day inactivity limit.

Collapse those duplicates on load, ranking the survivor by the newest access token for the same credential owner and leaving anything unrankable alone. Also confirm after a device-code or interactive sign-in that the refresh token reached the cache: persistence is best-effort, and a swallowed write otherwise looks like success for exactly one access token lifetime. The MCP login tool has already returned by then, so that failure surfaces through verify login.

Refs #648