### PR TITLE
feat: add createReply, createReplyAll, createForward, and send draft tools for shared mailboxes

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -166,6 +166,38 @@
     "llmTip": "Forward a message from a shared mailbox preserving full HTML formatting and attachments. The 'user-id' is the shared mailbox email address. 'toRecipients' is required. The 'comment' field adds text above the forwarded content. Requires Send As permission on the shared mailbox in Exchange."
   },
   {
+    "pathPattern": "/users/{user-id}/messages/{message-id}/createReply",
+    "method": "post",
+    "toolName": "create-shared-mailbox-reply-draft",
+    "presets": ["work"],
+    "workScopes": ["Mail.ReadWrite.Shared"],
+    "llmTip": "Create a reply draft in a shared mailbox preserving thread metadata (conversationId, In-Reply-To, References). The 'user-id' is the shared mailbox email address (e.g. support@contoso.com). Does not send — use send-shared-mailbox-draft to send afterwards. For HTML replies pass Message.body.contentType: 'html' with Message.body.content as HTML. Specifying both 'comment' and Message.body returns 400. Requires delegated access to the shared mailbox."
+  },
+  {
+    "pathPattern": "/users/{user-id}/messages/{message-id}/createReplyAll",
+    "method": "post",
+    "toolName": "create-shared-mailbox-reply-all-draft",
+    "presets": ["work"],
+    "workScopes": ["Mail.ReadWrite.Shared"],
+    "llmTip": "Create a reply-all draft in a shared mailbox preserving thread metadata (conversationId, In-Reply-To, References). The 'user-id' is the shared mailbox email address. Does not send — use send-shared-mailbox-draft to send afterwards. For HTML replies pass Message.body.contentType: 'html' with Message.body.content as HTML. Specifying both 'comment' and Message.body returns 400. Requires delegated access to the shared mailbox."
+  },
+  {
+    "pathPattern": "/users/{user-id}/messages/{message-id}/createForward",
+    "method": "post",
+    "toolName": "create-shared-mailbox-forward-draft",
+    "presets": ["work"],
+    "workScopes": ["Mail.ReadWrite.Shared"],
+    "llmTip": "Create a forward draft in a shared mailbox without sending. The 'user-id' is the shared mailbox email address. Does not send — use send-shared-mailbox-draft to send afterwards. Useful when the user wants to review before the forward goes out. Requires delegated access to the shared mailbox."
+  },
+  {
+    "pathPattern": "/users/{user-id}/messages/{message-id}/send",
+    "method": "post",
+    "toolName": "send-shared-mailbox-draft",
+    "presets": ["work"],
+    "workScopes": ["Mail.Send.Shared"],
+    "llmTip": "Send an existing draft from a shared mailbox. No request body needed — just call with the message ID and the shared mailbox user-id. Draft must exist in the shared mailbox's Drafts folder. Requires Send As permission on the shared mailbox in Exchange."
+  },
+  {
     "pathPattern": "/users",
     "method": "get",
     "toolName": "list-users",


### PR DESCRIPTION
## Summary

Adds four missing shared-mailbox endpoints, requested in #652. These tools allow drafting and sending replies, reply-alls, and forwards from a shared mailbox without immediately sending — a workflow currently impossible with the existing send-only tools.

| Tool | Endpoint | Scope |
|---|---|---|
| `create-shared-mailbox-reply-draft` | `POST /users/{user-id}/messages/{id}/createReply` | `Mail.ReadWrite.Shared` |
| `create-shared-mailbox-reply-all-draft` | `POST /users/{user-id}/messages/{id}/createReplyAll` | `Mail.ReadWrite.Shared` |
| `create-shared-mailbox-forward-draft` | `POST /users/{user-id}/messages/{id}/createForward` | `Mail.ReadWrite.Shared` |
| `send-shared-mailbox-draft` | `POST /users/{user-id}/messages/{id}/send` | `Mail.Send.Shared` |

## Motivation

The existing shared-mailbox tools (`reply-shared-mailbox-mail`, `reply-all-shared-mailbox-mail`, `forward-shared-mailbox-mail`) send immediately, with no way to create a draft first for review. The `/me/` equivalents (`create-reply-draft`, `create-reply-all-draft`, `create-forward-draft`, `send-draft-message`) only work for the signed-in user's personal mailbox. This PR closes that gap.

## OAuth scopes

`Mail.ReadWrite.Shared` is already required by `create-shared-mailbox-draft`. `Mail.Send.Shared` is already required by `reply-shared-mailbox-mail`, `reply-all-shared-mailbox-mail`, and `forward-shared-mailbox-mail`. No new OAuth consent is needed for users who already have the shared-mailbox preset enabled.

## Changes

- `src/endpoints.json` — four new entries inserted after `forward-shared-mailbox-mail` to keep the shared-mailbox block contiguous.

The code-generation pipeline (`npm run generate`) handles the rest automatically, as it does in CI.

## Testing

`npm run verify` passes locally (68 test files, 1007 tests).