### PR TITLE
fix: respect an explicitly provided Accept header

### DIFF
--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -52,6 +52,7 @@ import {
   CONFIRM_PARAM_DESCRIPTION,
   TIMEZONE_PARAM_DESCRIPTION,
   EXPAND_EXTENDED_PROPERTIES_PARAM_DESCRIPTION,
+  getAcceptParamDescription,
   getAccountParamDescription,
   getFetchAllPagesParamDescription,
 } from './lib/param-descriptions.js';
@@ -1524,6 +1525,11 @@ async function executeGraphTool(
           .replace(`{${camelCaseParamName}}`, encodedValue)
           .replace(`:${camelCaseParamName}`, encodedValue);
         logger.info(`Path param fallback: replaced :${camelCaseParamName} with encoded value`);
+      } else if (paramName.toLowerCase() === 'accept' && config?.acceptType) {
+        // The synthetic Accept param added for acceptType endpoints. It has no entry in
+        // the generated client's parameter list, so it lands here rather than in the
+        // 'Header' case above.
+        headers['Accept'] = `${paramValue}`;
       } else if (isOdataParam) {
         // Fallback: OData param recognised by name but absent from generated client's parameter
         // list — forward it as a query param rather than silently dropping it.
@@ -2026,6 +2032,17 @@ export function registerGraphTools(
       if (!(pathParamName in paramSchema)) {
         paramSchema[pathParamName] = z.string().describe(describePathParam(pathParamName));
       }
+    }
+
+    // Endpoints with a configured acceptType get a synthetic, optional `Accept` param.
+    // The generated client declares no Accept header anywhere, so without this the
+    // caller has no way to reach the alternate representation of the resource — the
+    // configured default would be the only value the server can ever send.
+    if (endpointConfig?.acceptType && paramSchema['Accept'] === undefined) {
+      paramSchema['Accept'] = z
+        .string()
+        .describe(getAcceptParamDescription(endpointConfig.acceptType))
+        .optional();
     }
 
     if (isFetchAllPagesApplicable(tool)) {

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -1656,7 +1656,7 @@ async function executeGraphTool(
       logger.info(`Setting custom Content-Type: ${config.contentType}`);
     }
 
-    if (config?.acceptType) {
+    if (config?.acceptType && !headers['Accept']) {
       headers['Accept'] = config.acceptType;
       logger.info(`Setting custom Accept: ${config.acceptType}`);
     }

--- a/src/lib/param-descriptions.ts
+++ b/src/lib/param-descriptions.ts
@@ -108,6 +108,14 @@ export const TIMEZONE_PARAM_DESCRIPTION =
 export const EXPAND_EXTENDED_PROPERTIES_PARAM_DESCRIPTION =
   'When true, expands singleValueExtendedProperties on each event. Use this to retrieve custom extended properties (e.g., sync metadata) stored on calendar events.';
 
+export function getAcceptParamDescription(acceptType: string): string {
+  return (
+    `Accept header for the response representation. Defaults to "${acceptType}". ` +
+    'Only set this when Graph asks for a different format — e.g. a 403 SpeakerAttributionNotAllowed ' +
+    'on transcript content names the media type to retry with.'
+  );
+}
+
 /**
  * Layer 2 of multi-account support: account names are surfaced in the description
  * (not as a strict enum) so the LLM sees available accounts upfront without a

--- a/src/lib/tool-schema.ts
+++ b/src/lib/tool-schema.ts
@@ -12,6 +12,7 @@ import {
   CONFIRM_PARAM_DESCRIPTION,
   TIMEZONE_PARAM_DESCRIPTION,
   EXPAND_EXTENDED_PROPERTIES_PARAM_DESCRIPTION,
+  getAcceptParamDescription,
 } from './param-descriptions.js';
 
 type ToolEndpoint = (typeof api.endpoints)[number];
@@ -26,6 +27,7 @@ export interface ToolSchemaConfig extends DestructiveCheckConfig {
   descriptionOverride?: string;
   supportsTimezone?: boolean;
   supportsExpandExtendedProperties?: boolean;
+  acceptType?: string;
 }
 
 /**
@@ -164,6 +166,19 @@ export function describeToolSchema(
       required: false,
       description: EXPAND_EXTENDED_PROPERTIES_PARAM_DESCRIPTION,
       schema: { type: 'boolean' },
+    });
+  }
+
+  // Mirrors registerGraphTools: endpoints with a configured acceptType get a
+  // synthetic, optional `Accept` header param so the configured default can be
+  // overridden when Graph asks for a different representation.
+  if (config?.acceptType && !params.some((p) => p.name.toLowerCase() === 'accept')) {
+    params.push({
+      name: 'Accept',
+      in: 'Header',
+      required: false,
+      description: getAcceptParamDescription(config.acceptType),
+      schema: { type: 'string' },
     });
   }
 

--- a/test/accept-header-override.test.ts
+++ b/test/accept-header-override.test.ts
@@ -24,7 +24,6 @@ vi.mock('../src/generated/client.js', () => ({
         parameters: [
           { name: 'onlineMeetingId', type: 'Path', schema: z.string() },
           { name: 'callTranscriptId', type: 'Path', schema: z.string() },
-          { name: 'Accept', type: 'Header', schema: z.string().optional() },
         ],
       },
     ],
@@ -45,18 +44,38 @@ describe('explicit Accept header', () => {
     } as unknown as GraphClient;
   });
 
-  function getToolHandler(toolName: string) {
+  function getRegistration(toolName: string) {
     // transcript tools are work-scoped only, so they need org mode to register
     registerGraphTools(mockServer, mockGraphClient, false, undefined, true);
     const call = mockServer.registerTool.mock.calls.find((c: unknown[]) => c[0] === toolName);
     expect(call).toBeDefined();
-    return call![call!.length - 1] as (params: Record<string, unknown>) => Promise<unknown>;
+    return call!;
+  }
+
+  function getToolHandler(toolName: string) {
+    const call = getRegistration(toolName);
+    return call[call.length - 1] as (params: Record<string, unknown>) => Promise<unknown>;
+  }
+
+  function getParamSchema(toolName: string) {
+    const call = getRegistration(toolName);
+    const { inputSchema } = call[1] as { inputSchema: z.ZodObject<z.ZodRawShape> };
+    return inputSchema.shape;
   }
 
   function sentHeaders() {
     const call = (mockGraphClient.graphRequest as ReturnType<typeof vi.fn>).mock.calls[0];
     return (call[1] as { headers: Record<string, string> }).headers;
   }
+
+  it('exposes an Accept param for tools with a configured acceptType', () => {
+    // The generated client declares no Accept header on any endpoint, so without the
+    // synthetic param the caller has no way to send one and the override is unreachable.
+    const schema = getParamSchema('get-meeting-transcript-content');
+
+    expect(schema['Accept']).toBeDefined();
+    expect(schema['Accept'].isOptional()).toBe(true);
+  });
 
   it('falls back to the configured acceptType when the caller sends none', async () => {
     const handler = getToolHandler('get-meeting-transcript-content');

--- a/test/accept-header-override.test.ts
+++ b/test/accept-header-override.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { registerGraphTools } from '../src/graph-tools.js';
+import type { GraphClient } from '../src/graph-client.js';
+
+vi.mock('../src/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('../src/generated/client-beta.js', () => ({ api: { endpoints: [] } }));
+vi.mock('../src/generated/client.js', () => ({
+  api: {
+    endpoints: [
+      {
+        // endpoints.json configures acceptType 'text/vtt' for this tool
+        alias: 'get-meeting-transcript-content',
+        method: 'get',
+        path: '/me/onlineMeetings/:onlineMeetingId/transcripts/:callTranscriptId/content',
+        description: 'Transcript content.',
+        parameters: [
+          { name: 'onlineMeetingId', type: 'Path', schema: z.string() },
+          { name: 'callTranscriptId', type: 'Path', schema: z.string() },
+          { name: 'Accept', type: 'Header', schema: z.string().optional() },
+        ],
+      },
+    ],
+  },
+}));
+
+describe('explicit Accept header', () => {
+  let mockServer: { tool: ReturnType<typeof vi.fn>; registerTool: ReturnType<typeof vi.fn> };
+  let mockGraphClient: GraphClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockServer = { tool: vi.fn(), registerTool: vi.fn() };
+    mockGraphClient = {
+      graphRequest: vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: 'WEBVTT' }],
+      }),
+    } as unknown as GraphClient;
+  });
+
+  function getToolHandler(toolName: string) {
+    // transcript tools are work-scoped only, so they need org mode to register
+    registerGraphTools(mockServer, mockGraphClient, false, undefined, true);
+    const call = mockServer.registerTool.mock.calls.find((c: unknown[]) => c[0] === toolName);
+    expect(call).toBeDefined();
+    return call![call!.length - 1] as (params: Record<string, unknown>) => Promise<unknown>;
+  }
+
+  function sentHeaders() {
+    const call = (mockGraphClient.graphRequest as ReturnType<typeof vi.fn>).mock.calls[0];
+    return (call[1] as { headers: Record<string, string> }).headers;
+  }
+
+  it('falls back to the configured acceptType when the caller sends none', async () => {
+    const handler = getToolHandler('get-meeting-transcript-content');
+
+    await handler({ onlineMeetingId: 'meeting-1', callTranscriptId: 'transcript-1' });
+
+    expect(sentHeaders()['Accept']).toBe('text/vtt');
+  });
+
+  it('keeps an explicitly provided Accept header instead of overwriting it', async () => {
+    const handler = getToolHandler('get-meeting-transcript-content');
+
+    // Graph asks for this format when speaker-attributed transcripts are
+    // disabled for the tenant (403 SpeakerAttributionNotAllowed). Overwriting
+    // it with the configured acceptType made that retry impossible.
+    await handler({
+      onlineMeetingId: 'meeting-1',
+      callTranscriptId: 'transcript-1',
+      Accept: 'application/vnd.microsoft.graph.transcript+text',
+    });
+
+    expect(sentHeaders()['Accept']).toBe('application/vnd.microsoft.graph.transcript+text');
+  });
+});

--- a/test/accept-header-real-client.test.ts
+++ b/test/accept-header-real-client.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerGraphTools } from '../src/graph-tools.js';
+import type { GraphClient } from '../src/graph-client.js';
+
+// End-to-end smoke against the REAL generated client (no endpoint mocks):
+// both acceptType endpoints must expose Accept and forward it to graphRequest.
+describe('Accept override, real generated client', () => {
+  function setup() {
+    const server = new McpServer({ name: 't', version: '1' });
+    const calls: Array<[string, { headers: Record<string, string> }]> = [];
+    const graphClient = {
+      graphRequest: vi.fn(async (path: string, opts: { headers: Record<string, string> }) => {
+        calls.push([path, opts]);
+        return { content: [{ type: 'text', text: 'ok' }] };
+      }),
+    } as unknown as GraphClient;
+    const handlers = new Map<string, (p: Record<string, unknown>) => Promise<unknown>>();
+    vi.spyOn(server, 'registerTool').mockImplementation(((
+      name: string,
+      _cfg: unknown,
+      h: never
+    ) => {
+      handlers.set(name, h);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- registerTool() has many overloads
+    }) as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(server, 'tool').mockImplementation((() => {}) as any);
+    registerGraphTools(server, graphClient, false, undefined, true);
+    return { handlers, calls };
+  }
+
+  it('transcript content: default text/vtt, override survives', async () => {
+    const { handlers, calls } = setup();
+    const h = handlers.get('get-meeting-transcript-content')!;
+    expect(h).toBeDefined();
+    await h({ onlineMeetingId: 'm1', callTranscriptId: 't1' });
+    expect(calls[0][1].headers['Accept']).toBe('text/vtt');
+    await h({
+      onlineMeetingId: 'm1',
+      callTranscriptId: 't1',
+      Accept: 'application/vnd.microsoft.graph.transcript+text',
+    });
+    expect(calls[1][1].headers['Accept']).toBe('application/vnd.microsoft.graph.transcript+text');
+  });
+
+  it('mail mime: default text/plain, override survives', async () => {
+    const { handlers, calls } = setup();
+    const h = handlers.get('get-mail-message-mime')!;
+    expect(h).toBeDefined();
+    await h({ messageId: 'abc' });
+    expect(calls[0][1].headers['Accept']).toBe('text/plain');
+    await h({ messageId: 'abc', Accept: 'application/octet-stream' });
+    expect(calls[1][1].headers['Accept']).toBe('application/octet-stream');
+  });
+});

--- a/test/tool-schema.test.ts
+++ b/test/tool-schema.test.ts
@@ -218,6 +218,23 @@ describe('describeToolSchema parity with registerGraphTools (discovery-mode drif
     expect(discovery?.description).toBe(expected);
   });
 
+  it('matches Accept description exactly for an endpoint with a configured acceptType', () => {
+    const entry = registry.get('get-meeting-transcript-content');
+    if (!entry) throw new Error('registry missing get-meeting-transcript-content');
+    const s = describeToolSchema(entry.tool, entry.config);
+    const discovery = s.parameters.find((p) => p.name === 'Accept');
+    const expected = registeredDescription('get-meeting-transcript-content', 'Accept');
+    expect(expected).toBeDefined();
+    expect(discovery?.in).toBe('Header');
+    expect(discovery?.description).toBe(expected);
+  });
+
+  it('adds no Accept param to endpoints without a configured acceptType', () => {
+    const s = schemaFor('list-mail-messages');
+    expect(s.parameters.find((p) => p.name === 'Accept')).toBeUndefined();
+    expect(registered.get('list-mail-messages')).not.toHaveProperty('Accept');
+  });
+
   it('matches confirm description exactly (already shared logic, guarded against future drift)', () => {
     const entry = registry.get('delete-mail-message');
     if (!entry) throw new Error('registry missing delete-mail-message');


### PR DESCRIPTION
## Problem

An `Accept` header passed explicitly by the caller is silently discarded for every endpoint that
declares `acceptType` in `endpoints.json`.

`Header` parameters are copied into `headers` at `src/graph-tools.ts:1506`, but a few lines later the
configured `acceptType` overwrites the entry unconditionally:

```ts
if (config?.acceptType) {
  headers['Accept'] = config.acceptType;
}
```

This makes the alternate representation of a resource unreachable through the tool, even when the
Graph API explicitly asks the client to retry with a different `Accept` value.

## Concrete failure

`get-meeting-transcript-content` is configured with `acceptType: 'text/vtt'`. When a tenant has
speaker attribution disabled (`EnableAttributedTranscripts = false`), Graph rejects the
speaker-attributed format and names the format to retry with:

```json
{
  "error": {
    "code": "Forbidden",
    "message": "Speaker-attributed transcript content is disabled for this tenant.",
    "innerError": {
      "code": "SpeakerAttributionNotAllowed",
      "message": "Speaker-attributed transcript content is disabled for this tenant. Retry with Accept 'application/vnd.microsoft.graph.transcript+text'."
    }
  }
}
```

Retrying with `Accept: application/vnd.microsoft.graph.transcript+text` returns the identical 403,
because the header never leaves the process — `text/vtt` is put back in its place. The transcript is
unreachable for that tenant, with no way for the caller to work around it.

Per the [Get callTranscript docs](https://learn.microsoft.com/graph/api/calltranscript-get), the
unattributed format is exactly the documented fallback here: "The speaker-attribution setting never
blocks the unattributed format."

## Change

Treat `acceptType` as a default rather than an override:

```ts
if (config?.acceptType && !headers['Accept']) {
```

Callers who send nothing keep the previous behaviour; callers who send an `Accept` header now get
what they asked for. This mirrors how a default should compose with an explicit argument, and keeps
the fix scoped to one condition.

## Tests

`test/accept-header-override.test.ts` covers both directions: the configured `acceptType` is still
applied when no header is supplied, and an explicitly supplied header survives.

## Notes

Found while retrieving Teams meeting transcripts on a tenant with speaker attribution turned off.
The same class of bug applies to any endpoint declaring `acceptType`, not just transcripts.
