### PR TITLE
feat(teams): add ad hoc call transcript tools

### DIFF
--- a/bin/modules/generate-mcp-tools.mjs
+++ b/bin/modules/generate-mcp-tools.mjs
@@ -2,6 +2,17 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 
+/**
+ * Converts single-quoted `path:` strings that contain function-style OData segments with
+ * quoted parameters (e.g. `range(address=':address')`) into template literals, so the
+ * nested single quotes no longer break the generated TypeScript. A function may take
+ * several parameters, quoted or not, in any order:
+ * `getAllTranscripts(userId=':userId',startDateTime=:startDateTime)`.
+ */
+export function fixFunctionStylePaths(clientCode) {
+  return clientCode.replace(/(path:\s*)'(\/[^']*\([^)]*=':[\w]+'[^)]*\)[^']*)'/g, '$1`$2`');
+}
+
 export function generateMcpTools(openapiTrimmedFile, clientFilePath) {
   try {
     console.log(
@@ -47,7 +58,7 @@ export function generateMcpTools(openapiTrimmedFile, clientFilePath) {
     // to backticks (template literal) so single quotes can remain inside.
     // Match: path: '/...range(param=':value')...',
     // Replace with: path: `/...range(param=':value')...`,
-    clientCode = clientCode.replace(/(path:\s*)'(\/[^']*\([^)]*=':[\w]+'\)[^']*)'/g, '$1`$2`');
+    clientCode = fixFunctionStylePaths(clientCode);
 
     // openapi-zod-client emits z.instanceof(File) for `format: binary` bodies; MCP
     // transports JSON so no caller produces File. Body marshaller decodes the string.

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -2141,6 +2141,24 @@
     "llmTip": "Returns the transcript content in WebVTT format with speaker identification and timestamps."
   },
   {
+    "pathPattern": "/me/adhocCalls/getAllTranscripts(userId='{userId}',startDateTime={startDateTime},endDateTime={endDateTime})",
+    "method": "get",
+    "toolName": "list-adhoc-call-transcripts",
+    "presets": ["teams", "work"],
+    "workScopes": ["CallTranscripts.Read.All"],
+    "skipEncoding": ["startDateTime", "endDateTime"],
+    "llmTip": "Lists transcripts of ad hoc calls (PSTN, 1:1 and group calls) started by the signed-in user. Use this for calls that have no calendar event and no online meeting, e.g. recordings named 'Anruf mit ...'. userId must be the signed-in user's object id (from get-current-user), not an email. startDateTime and endDateTime are required ISO 8601 UTC timestamps such as 2026-08-01T00:00:00Z. Each item carries callId and id (the transcript id) for get-adhoc-call-transcript-content; contentCorrelationId ends with the yyyyMMdd_HHmmss stamp that also appears in the recording file name in OneDrive. Do not use $filter, $orderby or $top."
+  },
+  {
+    "pathPattern": "/me/adhocCalls/{adhocCall-id}/transcripts/{callTranscript-id}/content",
+    "method": "get",
+    "toolName": "get-adhoc-call-transcript-content",
+    "presets": ["teams", "work"],
+    "workScopes": ["CallTranscripts.Read.All"],
+    "acceptType": "text/vtt",
+    "llmTip": "Returns the transcript of an ad hoc call as WebVTT with speaker tags and timestamps. Take adhocCallId (the callId) and callTranscriptId (the id) from list-adhoc-call-transcripts; copy both exactly. On 403 SpeakerAttributionNotAllowed retry with Accept set to application/vnd.microsoft.graph.transcript+text."
+  },
+  {
     "pathPattern": "/me/onlineMeetings/{onlineMeeting-id}/recordings",
     "method": "get",
     "toolName": "list-meeting-recordings",

--- a/test/generator-function-paths.test.ts
+++ b/test/generator-function-paths.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error - generator module is plain JS with no type declarations
+import { fixFunctionStylePaths } from '../bin/modules/generate-mcp-tools.mjs';
+
+// openapi-zod-client emits every path as a single-quoted string. Function-style OData
+// segments with quoted parameters (range(address='{address}')) therefore end up with
+// single quotes nested inside single quotes, which is a TypeScript syntax error. The
+// generator rewrites those paths as template literals.
+
+describe('fixFunctionStylePaths', () => {
+  it('converts a path with one quoted function parameter', () => {
+    const input = `    path: '/drives/:driveId/items/:driveItemId/workbook/worksheets/:workbookWorksheetId/range(address=':address')',`;
+    expect(fixFunctionStylePaths(input)).toBe(
+      `    path: \`/drives/:driveId/items/:driveItemId/workbook/worksheets/:workbookWorksheetId/range(address=':address')\`,`
+    );
+  });
+
+  // Before this was fixed, a quoted parameter followed by further parameters was left
+  // untouched and the generated client failed to compile (TS1005 "',' expected").
+  it('converts a path where further parameters follow the quoted one', () => {
+    const input = `    path: '/me/adhocCalls/getAllTranscripts(userId=':userId',startDateTime=:startDateTime,endDateTime=:endDateTime)',`;
+    expect(fixFunctionStylePaths(input)).toBe(
+      `    path: \`/me/adhocCalls/getAllTranscripts(userId=':userId',startDateTime=:startDateTime,endDateTime=:endDateTime)\`,`
+    );
+  });
+
+  it('converts a quoted parameter in the middle of the path', () => {
+    const input = `    path: '/drives/:driveId/items/:driveItemId/workbook/worksheets/:workbookWorksheetId/range(address=':address')/format/font',`;
+    expect(fixFunctionStylePaths(input)).toBe(
+      `    path: \`/drives/:driveId/items/:driveItemId/workbook/worksheets/:workbookWorksheetId/range(address=':address')/format/font\`,`
+    );
+  });
+
+  it('leaves function paths without quoted parameters alone', () => {
+    const input = `    path: '/drives/:driveId/items/:driveItemId/workbook/tables/:workbookTableId/rows/itemAt(index=:index)',`;
+    expect(fixFunctionStylePaths(input)).toBe(input);
+  });
+
+  it('leaves plain paths alone', () => {
+    const input = `    path: '/me/onlineMeetings/:onlineMeetingId/transcripts/:callTranscriptId/content',`;
+    expect(fixFunctionStylePaths(input)).toBe(input);
+  });
+});


### PR DESCRIPTION
## Summary

Adds two tools for transcripts of **ad hoc calls** (PSTN, 1:1 and group calls). These calls have no calendar event and no `onlineMeeting`, so the existing `list-online-meetings` → `list-meeting-transcripts` → `get-meeting-transcript-content` chain cannot reach them, even though Teams stores their transcripts just like meeting transcripts.

- `list-adhoc-call-transcripts` — `GET /me/adhocCalls/getAllTranscripts(userId='…',startDateTime=…,endDateTime=…)`
- `get-adhoc-call-transcript-content` — `GET /me/adhocCalls/{adhocCallId}/transcripts/{callTranscriptId}/content` with `Accept: text/vtt` (overridable since #656, e.g. for `application/vnd.microsoft.graph.transcript+text` when speaker attribution is disabled)

Both use the delegated scope `CallTranscripts.Read.All` (admin consent required) and are in the `teams` and `work` presets.

## Why the function, and not the collection

Verified against Graph v1.0 on 2026-09-02 with a delegated token (work account, `CallTranscripts.Read.All` consented):

| Request | Result |
|---|---|
| `GET /me/adhocCalls?$top=5` | 404 `NotFound: Requested API is not supported` (also on beta) |
| `GET /me/adhocCalls/{callId}` | 404 |
| `GET /me/adhocCalls/{callId}/transcripts` | 501 `NotImplemented` |
| `GET /me/adhocCalls/getAllTranscripts` (no parameters) | 400 `userId='{userId}' expected as a function parameter` |
| `GET /me/adhocCalls/getAllTranscripts(userId='<own object id>')` | **200**, list with `callId`, transcript `id`, `contentCorrelationId`, `transcriptContentUrl` |
| same with `startDateTime`/`endDateTime` | 200, filtered |
| `GET /me/adhocCalls/{callId}/transcripts/{id}/content`, `Accept: text/vtt` | 200, WebVTT with `<v Speaker>` tags |
| same with `Accept: application/vnd.microsoft.graph.transcript+text` | 200, without speaker tags |

The [docs for `adhocCall: getAllTranscripts`](https://learn.microsoft.com/graph/api/adhoccall-getalltranscripts?view=graph-rest-1.0) list delegated permissions as "Not supported", but the call works with the delegated `CallTranscripts.Read.All` scope as long as `userId` is the signed-in user's object id. Since the collection and per-call listing are not served, the function is the only working entry point, which is why `userId`, `startDateTime` and `endDateTime` are path (function) parameters rather than query options. The `llmTip` tells the model to take `userId` from `get-current-user`.

`contentCorrelationId` ends with the same `yyyyMMdd_HHmmss` stamp as the recording file name Teams writes to OneDrive (`Anruf mit …-20260810_143034-Besprechungstranskript.mp4`), which is how a model can match a transcript to a file the user points at.

## Generator fix

`generate-mcp-tools.mjs` rewrites single-quoted `path:` strings that contain a quoted function parameter (`range(address=':address')`) into template literals. The regex only matched when the quoted parameter sat directly before the closing paren, so a function with further parameters — as above — produced a `client.ts` that failed to compile (`TS1005: ',' expected`). The rewrite now lives in an exported `fixFunctionStylePaths` and also matches when further parameters follow the quoted one. Existing single-parameter paths are unaffected.

## Test plan

- [x] `npm run generate`, `npm run typecheck`, `npm run build`
- [x] New `test/generator-function-paths.test.ts` (5 cases, including the previously failing shape)
- [x] `test/presets.test.ts`, `test/endpoints-validation.test.ts`, `test/generator-description-fallback.test.ts`
- [x] End to end over the MCP HTTP transport against a Docker build of this branch: `tools/list` shows both tools, `list-adhoc-call-transcripts` returns the call, `get-adhoc-call-transcript-content` returns a 21 KB VTT, and the `Accept` override returns the unattributed format
- [x] In production use with Open WebUI as the MCP client

## Tenant prerequisites (same as for meeting transcripts)

Teams admin center → Meetings → Meeting settings → "Transcript API access → Microsoft Graph access" must be on, otherwise all transcript requests return `403 GraphAccessToTranscriptsDisabled`. Call transcription must be allowed for the user by calling policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
