### PR TITLE
feat(tools): honour $select server-side where Graph ignores it

### DIFF
--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -3416,6 +3416,237 @@ describe('graph-tools', () => {
     });
   });
 
+  // ---- 13. Server-side $select projection (#660) ----
+  describe('$select projection', () => {
+    // The onlineMeeting shape from #660: the caller asked for three fields and Graph
+    // sent the whole resource back, invite HTML and passcode included.
+    const untrimmed = {
+      value: [
+        {
+          id: 'MSo',
+          subject: 'Standup',
+          joinWebUrl: 'https://teams/x',
+          joinInformation: { content: '<div>invite</div>' },
+          joinMeetingIdSettings: { passcode: '123456' },
+        },
+      ],
+    };
+
+    async function run(
+      args: Record<string, unknown>,
+      responses?: any[],
+      outputFormat: 'json' | 'toon' = 'json'
+    ) {
+      mockEndpoints.push(makeEndpoint());
+      mockEndpointsJson = [makeConfig()];
+      const graphClient = createMockGraphClient(
+        responses ?? [{ content: [{ type: 'text', text: JSON.stringify(untrimmed) }] }],
+        outputFormat
+      );
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+      const result = await server.tools.get('test-tool')!.handler(args);
+      return { result, graphClient };
+    }
+
+    it('narrows the body to the requested fields when Graph ignored $select', async () => {
+      const { result } = await run({ select: 'id,subject,joinWebUrl' });
+      expect(JSON.parse(result.content[0].text).value[0]).toEqual({
+        id: 'MSo',
+        subject: 'Standup',
+        joinWebUrl: 'https://teams/x',
+      });
+    });
+
+    it('leaves the body untouched when no select was passed', async () => {
+      const { result } = await run({});
+      expect(JSON.parse(result.content[0].text)).toEqual(untrimmed);
+    });
+
+    it('forces JSON so a --toon client still gets a trimmed body', async () => {
+      const { result, graphClient } = await run({ select: 'id,subject' }, undefined, 'toon');
+      expect(graphClient.graphRequest).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ forceJsonOutput: true })
+      );
+      expect(result.content[0].text.startsWith('TOON:')).toBe(true);
+      expect(result.content[0].text).not.toContain('joinInformation');
+    });
+
+    // Regression: the merge re-encodes to TOON, so projecting after it would JSON.parse
+    // a TOON string, throw, and silently ship the untrimmed body.
+    it('still projects when --toon and fetchAllPages are combined', async () => {
+      const { result } = await run(
+        { select: 'id,subject', fetchAllPages: true },
+        [
+          {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  value: [{ id: '1', subject: 'a', joinInformation: { content: 'huge' } }],
+                  '@odata.nextLink': 'https://graph.microsoft.com/v1.0/me/messages?$skip=1',
+                }),
+              },
+            ],
+          },
+          {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  value: [{ id: '2', subject: 'b', joinInformation: { content: 'huge' } }],
+                }),
+              },
+            ],
+          },
+        ],
+        'toon'
+      );
+      expect(result.content[0].text.startsWith('TOON:')).toBe(true);
+      expect(result.content[0].text).not.toContain('joinInformation');
+      const merged = JSON.parse(result.content[0].text.slice('TOON:'.length));
+      expect(merged.value).toEqual([
+        { id: '1', subject: 'a' },
+        { id: '2', subject: 'b' },
+      ]);
+    });
+
+    // Binary and raw-text payloads are wrapped in an envelope; projecting one would
+    // strip every key and lose the file or transcript.
+    it('does not project a raw-text transport envelope', async () => {
+      const envelope = { message: 'OK!', rawResponse: 'WEBVTT\n\n00:00:01.000 --> 00:00:02.000' };
+      const { result } = await run({ select: 'id' }, [
+        { content: [{ type: 'text', text: JSON.stringify(envelope) }] },
+      ]);
+      expect(JSON.parse(result.content[0].text)).toEqual(envelope);
+    });
+
+    it('does not project a binary transport envelope', async () => {
+      const envelope = {
+        message: 'OK!',
+        contentType: 'video/mp4',
+        encoding: 'base64',
+        contentLength: 3,
+        contentBytes: 'AAA',
+      };
+      const { result } = await run({ select: 'id' }, [
+        { content: [{ type: 'text', text: JSON.stringify(envelope) }] },
+      ]);
+      expect(JSON.parse(result.content[0].text)).toEqual(envelope);
+    });
+
+    // $select and $expand are independent in OData: the expanded property arrives in
+    // addition to the selected fields and has to survive the projection.
+    it('keeps an $expand-ed navigation property that was not selected', async () => {
+      const { result } = await run({ select: 'subject', expand: 'attachments' }, [
+        {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                id: '1',
+                subject: 'a',
+                attachments: [{ id: 'att1' }],
+                bodyPreview: 'huge',
+              }),
+            },
+          ],
+        },
+      ]);
+      const body = JSON.parse(result.content[0].text);
+      expect(body.attachments).toEqual([{ id: 'att1' }]);
+      expect(body).not.toHaveProperty('bodyPreview');
+    });
+
+    // Graph never rejects a bad property name on the endpoints that ignore $select, so
+    // a typo would otherwise silently reduce the response to {id}.
+    it('returns the body untrimmed when no requested field is present', async () => {
+      const body = { id: '1', joinWebUrl: 'u', joinInformation: { content: 'huge' } };
+      const { result } = await run({ select: 'joinUrl' }, [
+        { content: [{ type: 'text', text: JSON.stringify(body) }] },
+      ]);
+      expect(JSON.parse(result.content[0].text)).toEqual(body);
+    });
+
+    it('keeps the _etag that includeHeaders adds to a single resource', async () => {
+      const { result } = await run({ select: 'subject', includeHeaders: true }, [
+        {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ id: '1', subject: 'a', _etag: 'W/"1"', bodyPreview: 'huge' }),
+            },
+          ],
+        },
+      ]);
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        id: '1',
+        subject: 'a',
+        _etag: 'W/"1"',
+      });
+    });
+
+    // Asserting on the body alone passed even with the excludeResponse clause removed,
+    // because { success: true } trips the envelope guard anyway. forceJsonOutput is the
+    // signal that projection was never armed in the first place.
+    it('does not arm projection when excludeResponse was requested', async () => {
+      const { result, graphClient } = await run({ select: 'id', excludeResponse: true }, [
+        { content: [{ type: 'text', text: JSON.stringify({ success: true }) }] },
+      ]);
+      expect(graphClient.graphRequest).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.not.objectContaining({ forceJsonOutput: true })
+      );
+      expect(JSON.parse(result.content[0].text)).toEqual({ success: true });
+    });
+
+    // An error body still reaches the merge block, which parses and re-serializes it, so
+    // shouldProject is the only thing standing between it and the projection. Two keys
+    // with one selected: if the guard goes, `code` disappears.
+    it('does not project an error body on the merge path', async () => {
+      const errorBody = { error: 'Microsoft Graph API error: 403 Forbidden', code: 'accessDenied' };
+      const { result } = await run({ select: 'error', fetchAllPages: true }, [
+        { content: [{ type: 'text', text: JSON.stringify(errorBody) }], isError: true },
+      ]);
+      expect(JSON.parse(result.content[0].text)).toEqual(errorBody);
+    });
+
+    // A page failing mid-merge replaces `response` with the error, which the guard
+    // computed before the request cannot see.
+    it('leaves an error from a later page alone', async () => {
+      const errorBody = { error: 'Microsoft Graph API error: 503 Service Unavailable' };
+      const { result } = await run(
+        { select: 'error', fetchAllPages: true },
+        [
+          {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  value: [{ id: '1', subject: 'a' }],
+                  '@odata.nextLink': 'https://graph.microsoft.com/v1.0/me/messages?$skip=1',
+                }),
+              },
+            ],
+          },
+          { content: [{ type: 'text', text: JSON.stringify(errorBody) }], isError: true },
+        ],
+        'toon'
+      );
+      expect(result.content[0].text.startsWith('TOON:')).toBe(false);
+      expect(JSON.parse(result.content[0].text)).toEqual(errorBody);
+    });
+
+    // The llmTips tell the model to pass select=id,subject,joinWebUrl, so id is in the
+    // list nearly every time; counting it as a match made the typo guard inert.
+    it('returns the body untrimmed when the only real field is a typo alongside id', async () => {
+      const { result } = await run({ select: 'id,joinUrl' });
+      expect(JSON.parse(result.content[0].text)).toEqual(untrimmed);
+    });
+  });
+
   // ---- isDestructiveOperation helper ----
   describe('isDestructiveOperation', () => {
     it('returns true for POST, PATCH, PUT, DELETE', async () => {

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -2081,7 +2081,7 @@
     "toolName": "list-online-meetings",
     "presets": ["teams", "work"],
     "workScopes": ["OnlineMeetings.Read"],
-    "llmTip": "Look up a meeting with $filter=JoinWebUrl eq '{url}', using the joinUrl from an event's onlineMeeting property. This filter is required: the collection cannot be listed or paged, and $search/$orderby are not supported. Without it Graph returns 400 InvalidArgument ('One of the required parameters to lookup meeting by QueryOptions is null or empty'). Returns the meeting ID needed for transcript access."
+    "llmTip": "Look up a meeting with $filter=JoinWebUrl eq '{url}', using the joinUrl from an event's onlineMeeting property. This filter is required: the collection cannot be listed or paged, and $search/$orderby are not supported. Without it Graph returns 400 InvalidArgument ('One of the required parameters to lookup meeting by QueryOptions is null or empty'). Returns the meeting ID needed for transcript access. The full meeting object is large and can include the invite HTML and the meeting passcode, so pass select=id,subject,joinWebUrl unless you need more."
   },
   {
     "pathPattern": "/me/onlineMeetings/{onlineMeeting-id}",
@@ -2089,7 +2089,7 @@
     "toolName": "get-online-meeting",
     "presets": ["teams", "work"],
     "workScopes": ["OnlineMeetings.Read"],
-    "llmTip": "Gets a specific online meeting by ID. Returns full details including subject, startDateTime, endDateTime, joinWebUrl, chatInfo (threadId for meeting chat), participants (organizer, attendees), lobbyBypassSettings, and videoTeleconferenceId. Use list-online-meetings first to find the meeting ID."
+    "llmTip": "Gets a specific online meeting by ID. Returns full details including subject, startDateTime, endDateTime, joinWebUrl, chatInfo (threadId for meeting chat), participants (organizer, attendees), lobbyBypassSettings, and videoTeleconferenceId. Use list-online-meetings first to find the meeting ID. The full meeting object is large and can include the invite HTML and the meeting passcode, so pass select=id,subject,joinWebUrl unless you need more."
   },
   {
     "pathPattern": "/me/onlineMeetings",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -2089,7 +2089,7 @@
     "toolName": "get-online-meeting",
     "presets": ["teams", "work"],
     "workScopes": ["OnlineMeetings.Read"],
-    "llmTip": "Gets a specific online meeting by ID. Returns full details including subject, startDateTime, endDateTime, joinWebUrl, chatInfo (threadId for meeting chat), participants (organizer, attendees), lobbyBypassSettings, and videoTeleconferenceId. Use list-online-meetings first to find the meeting ID. The full meeting object is large and can include the invite HTML and the meeting passcode, so pass select=id,subject,joinWebUrl unless you need more."
+    "llmTip": "Gets a specific online meeting by ID. Returns full details including subject, startDateTime, endDateTime, joinWebUrl, chatInfo (threadId for meeting chat), participants (organizer, attendees), lobbyBypassSettings, and videoTeleconferenceId. Use list-online-meetings first to find the meeting ID. The full meeting object is large and can include the invite HTML and the meeting passcode, so pass select with the fields you came here for, e.g. select=id,chatInfo,participants."
   },
   {
     "pathPattern": "/me/onlineMeetings",

--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -10,6 +10,7 @@ import {
   loadResilienceConfig,
 } from './lib/graph-resilience.js';
 import { applyMessageSignoffToRequest } from './lib/message-signoff.js';
+import { TRANSPORT_OK_MESSAGE } from './lib/select-projection.js';
 import { open, stat, unlink } from 'fs/promises';
 import { pipeline } from 'stream/promises';
 
@@ -231,7 +232,7 @@ class GraphClient {
         // raw bytes and return them as base64 so callers can reconstruct them.
         const buffer = Buffer.from(await response.arrayBuffer());
         result = {
-          message: 'OK!',
+          message: TRANSPORT_OK_MESSAGE,
           contentType: contentTypeHeader,
           encoding: 'base64',
           contentLength: buffer.byteLength,
@@ -241,18 +242,18 @@ class GraphClient {
         const text = await response.text();
 
         if (text === '') {
-          result = { message: 'OK!' };
+          result = { message: TRANSPORT_OK_MESSAGE };
         } else if (options.rawResponse) {
           // download-bytes on /content wants the body verbatim. A JSON body
           // would otherwise round-trip through JSON.parse -> JSON.stringify,
           // which is lossy (whitespace, trailing newline, key order, number
           // formatting). Return the raw text instead. (issue #546)
-          result = { message: 'OK!', rawResponse: text };
+          result = { message: TRANSPORT_OK_MESSAGE, rawResponse: text };
         } else {
           try {
             result = JSON.parse(text);
           } catch {
-            result = { message: 'OK!', rawResponse: text };
+            result = { message: TRANSPORT_OK_MESSAGE, rawResponse: text };
           }
         }
       }

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -6,6 +6,12 @@ import { auditLog, getUserIdentityForAudit, type AuditEvent } from './audit-log.
 import GraphClient from './graph-client.js';
 import { isDestructiveOperation } from './lib/destructive-ops.js';
 import { describePathParam } from './lib/path-params.js';
+import {
+  anyFieldPresent,
+  isTransportEnvelope,
+  parseSelectFields,
+  projectSelectedFields,
+} from './lib/select-projection.js';
 import AuthManager, {
   getEndpointScopeGroups,
   getMissingAllowedScopesForGroups,
@@ -1667,6 +1673,16 @@ async function executeGraphTool(
       logger.info(`Setting custom Accept: ${config.acceptType}`);
     }
 
+    // Captured before the query string is built so the same value can be reapplied to
+    // the response for the operations where Graph ignores it (#660). $select is what
+    // triggers projection; $expand only widens what survives it, since in OData an
+    // expanded navigation property comes back in addition to the selected fields
+    // (supportsExpandExtendedProperties adds one of its own just above).
+    const requestedSelect = parseSelectFields(queryParams['$select']);
+    const keepFields = [
+      ...new Set([...requestedSelect, ...parseSelectFields(queryParams['$expand'])]),
+    ];
+
     if (Object.keys(queryParams).length > 0) {
       const queryString = Object.entries(queryParams)
         .map(([key, value]) => `${key}=${encodeURIComponent(value).replace(/%2C/gi, ',')}`)
@@ -1764,11 +1780,35 @@ async function executeGraphTool(
     // be TOON and JSON.parse would throw, silently returning only page one (#560).
     // The merged result gets re-encoded once at the end.
     const mergePages = fetchAllPages && paginationEnabled;
-    if (mergePages) {
+    // Projecting means parsing the body, and under --toon JSON.parse would throw and
+    // leave the response untrimmed. Same reason the merge below forces JSON (#560).
+    const willProject = requestedSelect.length > 0 && params.excludeResponse !== true;
+    if (mergePages || willProject) {
       options.forceJsonOutput = true;
     }
 
     let response = await graphClient.graphRequest(path, options);
+
+    const shouldProject = willProject && !response?.isError;
+    let projectionHandled = false;
+    const applyProjection = (body: unknown): unknown => {
+      // Binary, raw-text and ack payloads are wrapped in an envelope of this server's
+      // own making. Projecting one strips every key and hands back {}, losing the
+      // transcript or file outright.
+      if (isTransportEnvelope(body)) {
+        logger.info('Skipping $select projection: body is a transport envelope, not a resource');
+        return body;
+      }
+      // Graph never rejects a misspelled property on the endpoints that ignore $select,
+      // so without this a typo would silently empty the response instead of erroring.
+      if (!anyFieldPresent(body, requestedSelect)) {
+        logger.warn(
+          `None of the requested $select fields (${requestedSelect.join(',')}) appear in the response; returning it untrimmed`
+        );
+        return body;
+      }
+      return projectSelectedFields(body, keepFields);
+    };
 
     if (mergePages && response?.content?.[0]?.text) {
       type ODataPage = {
@@ -1864,7 +1904,22 @@ async function executeGraphTool(
       // (non-collection skip and mid-loop abort included), so a --toon client
       // never gets handed the forced-JSON body.
       if (combinedResponse !== undefined) {
-        response.content[0].text = graphClient.serialize(combinedResponse);
+        // Project before serialize(), not after: under --toon serialize() emits TOON and
+        // parsing that back as JSON would throw, silently skipping the projection.
+        const merged = shouldProject ? applyProjection(combinedResponse) : combinedResponse;
+        projectionHandled = shouldProject;
+        response.content[0].text = graphClient.serialize(merged);
+      }
+    }
+
+    // isError is re-tested: a failing page inside the merge loop replaces `response`
+    // with the error result, which shouldProject (computed before the request) misses.
+    if (shouldProject && !projectionHandled && !response?.isError && response?.content?.[0]?.text) {
+      try {
+        const parsed = JSON.parse(response.content[0].text);
+        response.content[0].text = graphClient.serialize(applyProjection(parsed));
+      } catch {
+        // Body was not JSON after all; nothing to project.
       }
     }
 

--- a/src/lib/select-projection.ts
+++ b/src/lib/select-projection.ts
@@ -1,0 +1,135 @@
+/**
+ * Graph honours $select on most operations, but not all: the onlineMeeting endpoints
+ * return the entire resource no matter what is asked for (#660), costing several
+ * thousand tokens per lookup and dragging joinInformation and the meeting passcode
+ * through the model's context. Projection is therefore applied here as well, after the
+ * response comes back. Where Graph already trimmed there is normally nothing left to
+ * remove, though OData does allow a service to return supporting properties it was not
+ * asked for, and those do get dropped.
+ *
+ * Projection is deny-by-default over a whole response body, so everything that is NOT a
+ * selected entity property has to be accounted for: the collection envelope, the keys
+ * this server adds itself, whatever $expand asked for, and the envelopes that carry
+ * non-JSON payloads. Those are handled by isAlwaysKept and isTransportEnvelope below.
+ */
+
+/**
+ * Splits a `$select` or `$expand` value into the top-level property names to keep.
+ *
+ * Nested paths (`onlineMeeting/joinUrl`) and $expand's nested options
+ * (`attachments($select=id)`) are reduced to the property at their root, since trimming
+ * inside a complex type is Graph's job and it either honoured the path already or
+ * ignored the whole parameter.
+ */
+export function parseSelectFields(value: string | undefined): string[] {
+  if (!value) return [];
+  return [
+    ...new Set(
+      value
+        .split(',')
+        .map((field) => field.trim().split(/[/(]/)[0].trim())
+        .filter(Boolean)
+    ),
+  ];
+}
+
+// Graph returns id and the @odata.* annotations regardless of $select, so stripping them
+// here would take away fields the caller gets today. nextLink in particular is what
+// fetchAllPages and manual paging resume from, and delta tombstones carry @removed.
+// Underscore keys are this server's own additions rather than Graph properties: _etag is
+// what --includeHeaders surfaces the ETag as, and dropping it would break read-then-PATCH
+// for any caller that also passed select.
+function isAlwaysKept(key: string): boolean {
+  return key === 'id' || key.startsWith('@') || key.startsWith('_');
+}
+
+/**
+ * True for the wrappers GraphClient puts around payloads that are not Graph entities:
+ * binary content, a verbatim non-JSON body, an empty 200, or an excludeResponse ack.
+ * Projecting one of these would strip every key and hand the caller `{}`, losing a
+ * transcript or a downloaded file outright.
+ */
+export function isTransportEnvelope(data: unknown): boolean {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+  const body = data as Record<string, unknown>;
+  // Every wrapper GraphClient builds stamps message: 'OK!' - the binary one, the verbatim
+  // text one and the empty-200 ack alike. Keying on that value rather than on property
+  // names keeps real resources out of the guard: a fileAttachment carries contentBytes,
+  // and plenty of resources carry a message.
+  if (body.message === 'OK!') return true;
+  // excludeResponse and the delete path return exactly { success: true }.
+  return body.success === true && Object.keys(body).length === 1;
+}
+
+function candidateObjects(data: unknown): Record<string, unknown>[] {
+  if (Array.isArray(data)) return data.filter(isPlainObject);
+  if (!isPlainObject(data)) return [];
+  if (Array.isArray(data.value)) return data.value.filter(isPlainObject);
+  return [data];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Whether the payload actually carries at least one of the requested fields.
+ *
+ * On the endpoints this exists for, Graph ignores $select and therefore never rejects a
+ * misspelled property name. Without this check `select=joinUrl` (the property is
+ * joinWebUrl) would silently reduce a full meeting to `{id}` instead of erroring.
+ * Always-kept names are excluded from the test, so `select=id,joinUrl` is judged on
+ * joinUrl alone. An empty collection counts as a match: nothing to lose by projecting it.
+ */
+export function anyFieldPresent(data: unknown, fields: string[]): boolean {
+  // id and the annotation keys survive projection whether or not they were asked for, so
+  // finding one proves nothing about whether Graph honoured the select. Counting them
+  // made this guard inert for the select=id,subject,... shape the llmTips recommend.
+  // With none left to check the caller only asked for always-kept fields, which projection
+  // returns faithfully, so there is nothing to protect.
+  const checkable = fields.filter((field) => !isAlwaysKept(field));
+  if (checkable.length === 0) return true;
+
+  const wanted = new Set(checkable.map((field) => field.toLowerCase()));
+  const objects = candidateObjects(data);
+  if (objects.length === 0) return true;
+  return objects.some((item) => Object.keys(item).some((key) => wanted.has(key.toLowerCase())));
+}
+
+function projectObject(item: unknown, wanted: Set<string>): unknown {
+  if (!isPlainObject(item)) return item;
+  const projected: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(item)) {
+    if (isAlwaysKept(key) || wanted.has(key.toLowerCase())) {
+      projected[key] = value;
+    }
+  }
+  return projected;
+}
+
+/**
+ * Narrows a Graph response body to the requested fields. Handles both a single resource
+ * and a collection, leaving the collection's own envelope (@odata.count, @odata.nextLink)
+ * intact and projecting only the items inside `value`.
+ *
+ * Matching is case-insensitive because the tool schema takes `select` as free text and
+ * models are inconsistent about casing. That only ever makes this more lenient than
+ * Graph: where Graph honours $select a mis-cased name fails before a body exists.
+ */
+export function projectSelectedFields(data: unknown, fields: string[]): unknown {
+  if (fields.length === 0) return data;
+  if (!data || typeof data !== 'object') return data;
+
+  const wanted = new Set(fields.map((field) => field.toLowerCase()));
+
+  if (Array.isArray(data)) {
+    return data.map((item) => projectObject(item, wanted));
+  }
+
+  const body = data as Record<string, unknown>;
+  if (Array.isArray(body.value)) {
+    return { ...body, value: body.value.map((item) => projectObject(item, wanted)) };
+  }
+
+  return projectObject(body, wanted);
+}

--- a/src/lib/select-projection.ts
+++ b/src/lib/select-projection.ts
@@ -38,9 +38,11 @@ export function parseSelectFields(value: string | undefined): string[] {
 // fetchAllPages and manual paging resume from, and delta tombstones carry @removed.
 // Underscore keys are this server's own additions rather than Graph properties: _etag is
 // what --includeHeaders surfaces the ETag as, and dropping it would break read-then-PATCH
-// for any caller that also passed select.
+// for any caller that also passed select. Matched case-insensitively because this also
+// runs over the names the model asked for, and a capitalised Id would otherwise slip past
+// and make the anyFieldPresent guard inert.
 function isAlwaysKept(key: string): boolean {
-  return key === 'id' || key.startsWith('@') || key.startsWith('_');
+  return key.toLowerCase() === 'id' || key.startsWith('@') || key.startsWith('_');
 }
 
 /**

--- a/src/lib/select-projection.ts
+++ b/src/lib/select-projection.ts
@@ -14,6 +14,35 @@
  */
 
 /**
+ * Splits a comma-separated list on the commas that separate its entries, ignoring the
+ * ones inside an $expand option group. `attachments($select=id,name)` is one entry, not
+ * two: splitting it naively yields a stray `name` that would then keep a top-level `name`
+ * on the parent entity nobody asked for.
+ */
+function splitTopLevel(value: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+
+  for (const char of value) {
+    if (char === '(') depth++;
+    // Clamped so an unbalanced ')' cannot drive depth negative and swallow every
+    // remaining comma.
+    else if (char === ')') depth = Math.max(0, depth - 1);
+
+    if (char === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  parts.push(current);
+
+  return parts;
+}
+
+/**
  * Splits a `$select` or `$expand` value into the top-level property names to keep.
  *
  * Nested paths (`onlineMeeting/joinUrl`) and $expand's nested options
@@ -25,9 +54,8 @@ export function parseSelectFields(value: string | undefined): string[] {
   if (!value) return [];
   return [
     ...new Set(
-      value
-        .split(',')
-        .map((field) => field.trim().split(/[/(]/)[0].trim())
+      splitTopLevel(value)
+        .map((field) => field.trim().split(/[/()]/)[0].trim())
         .filter(Boolean)
     ),
   ];

--- a/src/lib/select-projection.ts
+++ b/src/lib/select-projection.ts
@@ -74,6 +74,14 @@ function isAlwaysKept(key: string): boolean {
 }
 
 /**
+ * The sentinel GraphClient stamps on every wrapper it builds around a payload that is not
+ * a Graph entity. Shared with the producer rather than repeated here: isTransportEnvelope
+ * is the only thing keeping a transcript or a downloaded file from being projected down to
+ * `{}`, so the two drifting apart would cost the payload with no error to show for it.
+ */
+export const TRANSPORT_OK_MESSAGE = 'OK!';
+
+/**
  * True for the wrappers GraphClient puts around payloads that are not Graph entities:
  * binary content, a verbatim non-JSON body, an empty 200, or an excludeResponse ack.
  * Projecting one of these would strip every key and hand the caller `{}`, losing a
@@ -82,11 +90,11 @@ function isAlwaysKept(key: string): boolean {
 export function isTransportEnvelope(data: unknown): boolean {
   if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
   const body = data as Record<string, unknown>;
-  // Every wrapper GraphClient builds stamps message: 'OK!' - the binary one, the verbatim
+  // Every wrapper GraphClient builds stamps this message - the binary one, the verbatim
   // text one and the empty-200 ack alike. Keying on that value rather than on property
   // names keeps real resources out of the guard: a fileAttachment carries contentBytes,
   // and plenty of resources carry a message.
-  if (body.message === 'OK!') return true;
+  if (body.message === TRANSPORT_OK_MESSAGE) return true;
   // excludeResponse and the delete path return exactly { success: true }.
   return body.success === true && Object.keys(body).length === 1;
 }

--- a/test/select-projection.test.ts
+++ b/test/select-projection.test.ts
@@ -20,7 +20,30 @@ describe('parseSelectFields', () => {
 
   // $expand carries nested options; only the navigation property itself matters here.
   it('reduces an $expand with nested options to the property name', () => {
-    expect(parseSelectFields('attachments($select=id)')).toContain('attachments');
+    expect(parseSelectFields('attachments($select=id)')).toEqual(['attachments']);
+  });
+
+  // A comma inside the option group separates the nested select, not two expands.
+  // Splitting on it would yield a stray `name` that keeps the parent's own top-level
+  // name field, which nobody selected.
+  it('does not split on a comma inside an $expand option group', () => {
+    expect(parseSelectFields('attachments($select=id,name),subject')).toEqual([
+      'attachments',
+      'subject',
+    ]);
+  });
+
+  it('handles nested option groups', () => {
+    expect(parseSelectFields('members($expand=user($select=id,displayName)),subject')).toEqual([
+      'members',
+      'subject',
+    ]);
+  });
+
+  // Graph would reject these, but they must not cost us the fields that follow.
+  it('recovers from unbalanced parentheses', () => {
+    expect(parseSelectFields('attachments($select=id')).toEqual(['attachments']);
+    expect(parseSelectFields('a),subject')).toEqual(['a', 'subject']);
   });
 
   it('de-duplicates', () => {

--- a/test/select-projection.test.ts
+++ b/test/select-projection.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+import {
+  anyFieldPresent,
+  isTransportEnvelope,
+  parseSelectFields,
+  projectSelectedFields,
+} from '../src/lib/select-projection.js';
+
+describe('parseSelectFields', () => {
+  it('splits and trims a comma-separated list', () => {
+    expect(parseSelectFields('id, subject ,joinWebUrl')).toEqual(['id', 'subject', 'joinWebUrl']);
+  });
+
+  it('keeps only the top-level segment of a nested path', () => {
+    expect(parseSelectFields('onlineMeeting/joinUrl,subject')).toEqual([
+      'onlineMeeting',
+      'subject',
+    ]);
+  });
+
+  // $expand carries nested options; only the navigation property itself matters here.
+  it('reduces an $expand with nested options to the property name', () => {
+    expect(parseSelectFields('attachments($select=id)')).toContain('attachments');
+  });
+
+  it('de-duplicates', () => {
+    expect(parseSelectFields('id,id,subject')).toEqual(['id', 'subject']);
+  });
+
+  it('returns nothing for an absent or empty value', () => {
+    expect(parseSelectFields(undefined)).toEqual([]);
+    expect(parseSelectFields('')).toEqual([]);
+    expect(parseSelectFields(' , ,')).toEqual([]);
+  });
+});
+
+describe('isTransportEnvelope', () => {
+  it('recognises the binary wrapper', () => {
+    expect(
+      isTransportEnvelope({ message: 'OK!', contentType: 'video/mp4', contentBytes: 'AAA' })
+    ).toBe(true);
+  });
+
+  it('recognises the raw-text wrapper used for VTT and downloads', () => {
+    expect(isTransportEnvelope({ message: 'OK!', rawResponse: 'WEBVTT...' })).toBe(true);
+  });
+
+  it('recognises the empty-body and excludeResponse acks', () => {
+    expect(isTransportEnvelope({ message: 'OK!' })).toBe(true);
+    expect(isTransportEnvelope({ success: true })).toBe(true);
+  });
+
+  it('does not mistake a real resource or collection for an envelope', () => {
+    expect(isTransportEnvelope({ id: '1', subject: 'a' })).toBe(false);
+    expect(isTransportEnvelope({ value: [{ id: '1' }] })).toBe(false);
+  });
+
+  // Keying on property names rather than on message: 'OK!' caught all three of these.
+  it('does not mistake a resource that happens to carry an envelope-ish key', () => {
+    expect(
+      isTransportEnvelope({
+        id: '1',
+        name: 'a.pdf',
+        contentType: 'application/pdf',
+        contentBytes: 'AAA',
+      })
+    ).toBe(false);
+    expect(isTransportEnvelope({ message: 'hello', createdDateTime: 'x' })).toBe(false);
+    expect(isTransportEnvelope({ success: false, diagnosticData: 'x' })).toBe(false);
+  });
+});
+
+describe('anyFieldPresent', () => {
+  it('is true when a requested field is on the resource', () => {
+    expect(anyFieldPresent({ id: '1', subject: 'a' }, ['subject'])).toBe(true);
+  });
+
+  it('is true when a requested field is on any collection item', () => {
+    expect(anyFieldPresent({ value: [{ id: '1' }, { id: '2', subject: 'a' }] }, ['subject'])).toBe(
+      true
+    );
+  });
+
+  // joinUrl is the event facet's name; the meeting property is joinWebUrl. Without this
+  // the typo would silently reduce the response to {id}.
+  it('is false when nothing matches, so the caller keeps the full body', () => {
+    expect(anyFieldPresent({ id: '1', joinWebUrl: 'u' }, ['joinUrl'])).toBe(false);
+  });
+
+  it('treats an empty collection as nothing to lose', () => {
+    expect(anyFieldPresent({ value: [] }, ['subject'])).toBe(true);
+  });
+
+  // id survives projection regardless, so counting it as a match made this guard inert
+  // for exactly the select=id,subject,... shape the llmTips recommend.
+  it('ignores always-kept names, so a typo alongside id is still caught', () => {
+    expect(anyFieldPresent({ id: '1', joinWebUrl: 'u' }, ['id', 'joinUrl'])).toBe(false);
+    expect(anyFieldPresent({ id: '1', joinWebUrl: 'u' }, ['id', 'joinWebUrl'])).toBe(true);
+  });
+
+  it('allows a select that asks only for always-kept fields', () => {
+    expect(anyFieldPresent({ id: '1', subject: 'a' }, ['id'])).toBe(true);
+  });
+});
+
+describe('projectSelectedFields', () => {
+  it('narrows a single resource to the requested fields', () => {
+    expect(projectSelectedFields({ id: '1', subject: 'a', body: 'huge' }, ['subject'])).toEqual({
+      id: '1',
+      subject: 'a',
+    });
+  });
+
+  // Graph returns id whether or not it was selected, so dropping it here would take away
+  // a field callers get today.
+  it('keeps id even when it was not selected', () => {
+    expect(projectSelectedFields({ id: '1', subject: 'a' }, ['subject'])).toHaveProperty('id', '1');
+  });
+
+  // GraphClient strips every @odata.* except nextLink and deltaLink before this runs, so
+  // those two and the underscore keys are the annotations that actually reach projection.
+  it('keeps @odata.nextLink and @odata.deltaLink', () => {
+    const out = projectSelectedFields(
+      { '@odata.nextLink': 'n', '@odata.deltaLink': 'd', value: [{ id: '1', subject: 'a' }] },
+      ['subject']
+    );
+    expect(out).toMatchObject({ '@odata.nextLink': 'n', '@odata.deltaLink': 'd' });
+  });
+
+  it('keeps the _etag that includeHeaders adds to a single resource', () => {
+    expect(
+      projectSelectedFields({ id: '1', subject: 'a', _etag: 'W/"1"', body: 'x' }, ['subject'])
+    ).toEqual({ id: '1', subject: 'a', _etag: 'W/"1"' });
+  });
+
+  it('keeps delta tombstones intact', () => {
+    const out = projectSelectedFields({ value: [{ id: '1', '@removed': { reason: 'deleted' } }] }, [
+      'subject',
+    ]);
+    expect((out as { value: any[] }).value[0]).toEqual({
+      id: '1',
+      '@removed': { reason: 'deleted' },
+    });
+  });
+
+  it('projects collection items and leaves the envelope intact', () => {
+    const out = projectSelectedFields(
+      {
+        '@odata.count': 2,
+        '@odata.nextLink': 'https://graph/next',
+        value: [
+          { id: '1', subject: 'a', body: 'huge' },
+          { id: '2', subject: 'b', body: 'huge' },
+        ],
+      },
+      ['subject']
+    );
+    expect(out).toEqual({
+      '@odata.count': 2,
+      '@odata.nextLink': 'https://graph/next',
+      value: [
+        { id: '1', subject: 'a' },
+        { id: '2', subject: 'b' },
+      ],
+    });
+  });
+
+  it('matches property names case-insensitively', () => {
+    expect(projectSelectedFields({ id: '1', joinWebUrl: 'u', body: 'x' }, ['joinweburl'])).toEqual({
+      id: '1',
+      joinWebUrl: 'u',
+    });
+  });
+
+  it('projects a bare array', () => {
+    expect(projectSelectedFields([{ id: '1', a: 1, b: 2 }], ['a'])).toEqual([{ id: '1', a: 1 }]);
+  });
+
+  it('is a no-op when nothing was selected', () => {
+    const body = { id: '1', subject: 'a', body: 'huge' };
+    expect(projectSelectedFields(body, [])).toBe(body);
+  });
+
+  it('passes through values that are not objects', () => {
+    expect(projectSelectedFields('plain text', ['id'])).toBe('plain text');
+    expect(projectSelectedFields(null, ['id'])).toBe(null);
+    expect(projectSelectedFields(42, ['id'])).toBe(42);
+  });
+
+  // The shape from #660: the caller asked for three fields and Graph sent the whole
+  // onlineMeeting, invite HTML and passcode included.
+  it('drops joinInformation and the passcode from an onlineMeeting lookup', () => {
+    const out = projectSelectedFields(
+      {
+        value: [
+          {
+            id: 'MSo',
+            subject: 'Standup',
+            joinWebUrl: 'https://teams/x',
+            joinInformation: { contentType: 'html', content: '<div>...</div>' },
+            joinMeetingIdSettings: { isPasscodeRequired: true, passcode: '123456' },
+          },
+        ],
+      },
+      ['id', 'subject', 'joinWebUrl']
+    );
+    const item = (out as { value: Record<string, unknown>[] }).value[0];
+    expect(item).toEqual({ id: 'MSo', subject: 'Standup', joinWebUrl: 'https://teams/x' });
+  });
+});

--- a/test/select-projection.test.ts
+++ b/test/select-projection.test.ts
@@ -98,6 +98,13 @@ describe('anyFieldPresent', () => {
     expect(anyFieldPresent({ id: '1', joinWebUrl: 'u' }, ['id', 'joinWebUrl'])).toBe(true);
   });
 
+  // select is free text, so the casing is the model's. A capitalised Id used to miss the
+  // always-kept filter, match the response's own id, and leave the guard inert.
+  it('ignores always-kept names whatever their case', () => {
+    expect(anyFieldPresent({ id: '1', joinWebUrl: 'u' }, ['Id', 'joinUrl'])).toBe(false);
+    expect(anyFieldPresent({ id: '1', joinWebUrl: 'u' }, ['ID', 'joinWebUrl'])).toBe(true);
+  });
+
   it('allows a select that asks only for always-kept fields', () => {
     expect(anyFieldPresent({ id: '1', subject: 'a' }, ['id'])).toBe(true);
   });


### PR DESCRIPTION
Graph ignores $select on the onlineMeeting endpoints: a lookup by joinWebUrl and a get by id both return the whole resource whatever is asked for. That is ~7.4KB per lookup, and it carries the invite HTML and the meeting passcode through the model's context for a step whose usual purpose is to fetch an id. Measured against v1.0: identical byte count and identical 38 keys with and without $select.

Apply the projection after the response instead. Passing select on a meeting lookup now returns 480 bytes rather than 7355, with joinInformation and joinMeetingIdSettings gone.

The projection is generic rather than per-endpoint, so it also has to leave alone everything in a body that is not a selected entity property:

  - id and the @odata annotations, which Graph returns regardless, plus the underscore keys this server adds itself such as _etag
  - whatever $expand asked for, since in OData an expanded navigation property arrives in addition to the selected fields
  - the wrappers around non-JSON payloads, recognised by the message 'OK!' that GraphClient stamps on each of them, so a transcript or a download is not reduced to {}
  - error bodies, excludeResponse acks, and responses where none of the requested fields are present at all, which is how a misspelled property name would otherwise silently empty the response

It runs on the parsed body before the fetchAllPages merge re-encodes, because serialize() emits TOON under --toon and parsing that back would throw and skip the projection.

Add a nudge to the two meeting llmTips to pass select.

Closes #660
