### PR TITLE
fix(auth): don't send client_secret on public-client token exchanges

### DIFF
--- a/src/lib/microsoft-auth.ts
+++ b/src/lib/microsoft-auth.ts
@@ -211,6 +211,103 @@ export function toOAuthErrorResponse(error: unknown): {
   };
 }
 
+// AADSTS700025 — "Client is public so neither 'client_assertion' nor
+// 'client_secret' should be presented". One app registration can hold both a
+// Web redirect URI, which requires the secret, and a Mobile and desktop one,
+// which forbids it, so whether to send the secret is a property of the exchange
+// rather than of our configuration. A loopback URI is legal under either
+// platform, so we can't tell them apart from the redirect_uri alone — send the
+// secret, and let Entra tell us when this particular exchange didn't want one.
+const PUBLIC_CLIENT_SECRET_REJECTED = 700025;
+
+function isPublicClientRejection(body: UpstreamOAuthErrorBody | null): boolean {
+  // parseUpstreamOAuthError only guarantees `error` is a string, so error_codes
+  // is whatever the upstream sent. Anything but an array of numbers isn't Entra
+  // answering us, and must not turn into a TypeError that costs the caller the
+  // OAuth passthrough and hands it a bare 500 instead.
+  return (
+    Array.isArray(body?.error_codes) && body.error_codes.includes(PUBLIC_CLIENT_SECRET_REJECTED)
+  );
+}
+
+type TokenResponse =
+  | { ok: true; json: unknown }
+  | { ok: false; status: number; raw: string; parsed: UpstreamOAuthErrorBody | null };
+
+async function postTokenRequest(tokenUrl: string, params: URLSearchParams): Promise<TokenResponse> {
+  const response = await fetch(tokenUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params,
+  });
+
+  if (response.ok) {
+    return { ok: true, json: await response.json() };
+  }
+
+  const raw = await response.text();
+  return { ok: false, status: response.status, raw, parsed: parseUpstreamOAuthError(raw) };
+}
+
+/**
+ * POST to the token endpoint, retrying once without client_secret if Entra
+ * rejects it as a public client. See PUBLIC_CLIENT_SECRET_REJECTED.
+ */
+async function requestToken<T>(
+  tokenUrl: string,
+  params: URLSearchParams,
+  clientSecret: string | undefined,
+  failureMessage: string
+): Promise<T> {
+  if (!clientSecret) {
+    return unwrapToken(await postTokenRequest(tokenUrl, params), failureMessage);
+  }
+
+  const withSecret = new URLSearchParams(params);
+  withSecret.append('client_secret', clientSecret);
+
+  let result = await postTokenRequest(tokenUrl, withSecret);
+
+  if (!result.ok && isPublicClientRejection(result.parsed)) {
+    // Carry the first attempt's correlation_id: if the retry then fails for an
+    // unrelated reason, this is the only record that a 700025 came before it.
+    logger.info(
+      'Upstream rejected client_secret as a public client (AADSTS700025) — retrying without it',
+      {
+        status: result.status,
+        error_codes: result.parsed?.error_codes,
+        correlation_id: result.parsed?.correlation_id,
+      }
+    );
+    // params is the untouched copy, so the retry is the same request minus the secret.
+    result = await postTokenRequest(tokenUrl, params);
+  }
+
+  return unwrapToken(result, failureMessage);
+}
+
+function unwrapToken<T>(result: TokenResponse, failureMessage: string): T {
+  if (result.ok) {
+    return result.json as T;
+  }
+
+  if (result.parsed) {
+    logger.warn(`Token endpoint upstream OAuth error: ${result.parsed.error}`, {
+      status: result.status,
+      error: result.parsed.error,
+      suberror: result.parsed.suberror,
+      error_codes: result.parsed.error_codes,
+      correlation_id: result.parsed.correlation_id,
+    });
+    throw new OAuthUpstreamError(result.status, result.raw, result.parsed);
+  }
+
+  logger.error(`${failureMessage}: ${result.raw}`);
+  throw new Error(`${failureMessage}: ${result.raw}`);
+}
+
 /**
  * Exchange authorization code for access token
  */
@@ -237,42 +334,17 @@ export async function exchangeCodeForToken(
     client_id: clientId,
   });
 
-  // Add client_secret for confidential clients
-  if (clientSecret) {
-    params.append('client_secret', clientSecret);
-  }
-
   // Add code_verifier for PKCE flow
   if (codeVerifier) {
     params.append('code_verifier', codeVerifier);
   }
 
-  const response = await fetch(`${cloudEndpoints.authority}/${tenantId}/oauth2/v2.0/token`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: params,
-  });
-
-  if (!response.ok) {
-    const raw = await response.text();
-    const parsed = parseUpstreamOAuthError(raw);
-    if (parsed) {
-      logger.warn(`Token endpoint upstream OAuth error: ${parsed.error}`, {
-        status: response.status,
-        error: parsed.error,
-        suberror: parsed.suberror,
-        error_codes: parsed.error_codes,
-        correlation_id: parsed.correlation_id,
-      });
-      throw new OAuthUpstreamError(response.status, raw, parsed);
-    }
-    logger.error(`Failed to exchange code for token: ${raw}`);
-    throw new Error(`Failed to exchange code for token: ${raw}`);
-  }
-
-  return response.json();
+  return requestToken(
+    `${cloudEndpoints.authority}/${tenantId}/oauth2/v2.0/token`,
+    params,
+    clientSecret,
+    'Failed to exchange code for token'
+  );
 }
 
 /**
@@ -298,34 +370,10 @@ export async function refreshAccessToken(
     client_id: clientId,
   });
 
-  if (clientSecret) {
-    params.append('client_secret', clientSecret);
-  }
-
-  const response = await fetch(`${cloudEndpoints.authority}/${tenantId}/oauth2/v2.0/token`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: params,
-  });
-
-  if (!response.ok) {
-    const raw = await response.text();
-    const parsed = parseUpstreamOAuthError(raw);
-    if (parsed) {
-      logger.warn(`Token endpoint upstream OAuth error: ${parsed.error}`, {
-        status: response.status,
-        error: parsed.error,
-        suberror: parsed.suberror,
-        error_codes: parsed.error_codes,
-        correlation_id: parsed.correlation_id,
-      });
-      throw new OAuthUpstreamError(response.status, raw, parsed);
-    }
-    logger.error(`Failed to refresh token: ${raw}`);
-    throw new Error(`Failed to refresh token: ${raw}`);
-  }
-
-  return response.json();
+  return requestToken(
+    `${cloudEndpoints.authority}/${tenantId}/oauth2/v2.0/token`,
+    params,
+    clientSecret,
+    'Failed to refresh token'
+  );
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -59,6 +59,22 @@ function parseHttpOption(httpOption: string | boolean): { host: string | undefin
   return { host: undefined, port };
 }
 
+// How long an unclaimed two-leg PKCE mapping is kept. This is memory cleanup,
+// not PKCE validity: createdAt is stamped at /authorize, so it measures how long
+// the user has been on the Microsoft login page, not the age of the code they
+// come back with. A sign-in behind MFA enrollment, admin consent or a password
+// reset can outlast any window worth calling short, and sweeping such an entry
+// costs that user their mapping and hands them AADSTS501481. Entra decides
+// whether the code is still good; the 1000-entry cap below is what actually
+// bounds the store.
+const PKCE_MAX_AGE_MS = 60 * 60 * 1000;
+
+type PkceEntry = {
+  clientCodeChallenge: string;
+  serverCodeVerifier: string;
+  createdAt: number;
+};
+
 class MicrosoftGraphServer {
   private authManager: AuthManager;
   private options: CommandOptions;
@@ -71,15 +87,7 @@ class MicrosoftGraphServer {
   private accountNames: string[] = [];
 
   // Two-leg PKCE: stores client's code_challenge and server's code_verifier, keyed by OAuth state
-  private pkceStore: Map<
-    string,
-    {
-      clientCodeChallenge: string;
-      clientCodeChallengeMethod: string;
-      serverCodeVerifier: string;
-      createdAt: number;
-    }
-  > = new Map();
+  private pkceStore: Map<string, PkceEntry> = new Map();
 
   constructor(authManager: AuthManager, options: CommandOptions = {}) {
     this.authManager = authManager;
@@ -473,6 +481,26 @@ class MicrosoftGraphServer {
           }
         });
 
+        // Drop what this authorization makes obsolete, whichever leg follows:
+        // entries past their retention window, and any earlier mapping for this
+        // same challenge. /token sees the code but never the state, so it cannot
+        // tell two flows sharing a verifier apart; keeping only the newest is a
+        // bet, and it loses if two are genuinely in flight and the user finishes
+        // the older one. The stateless path below needs this too, since it sends
+        // the client's own challenge upstream and a leftover mapping would answer
+        // that with our server verifier.
+        if (clientCodeChallenge) {
+          const now = Date.now();
+          for (const [key, value] of this.pkceStore) {
+            if (
+              now - value.createdAt > PKCE_MAX_AGE_MS ||
+              value.clientCodeChallenge === clientCodeChallenge
+            ) {
+              this.pkceStore.delete(key);
+            }
+          }
+        }
+
         // Two-leg PKCE: if the client sent a code_challenge, store it and generate
         // a separate PKCE pair for the server↔Microsoft leg
         if (clientCodeChallenge && state) {
@@ -482,15 +510,7 @@ class MicrosoftGraphServer {
             .update(serverCodeVerifier)
             .digest('base64url');
 
-          // Clean up expired entries before adding new ones
-          const now = Date.now();
-          const maxAge = 10 * 60 * 1000; // 10 minutes
           const maxEntries = 1000;
-          for (const [key, value] of this.pkceStore) {
-            if (now - value.createdAt > maxAge) {
-              this.pkceStore.delete(key);
-            }
-          }
 
           // Reject if store is still at capacity after cleanup (prevents memory exhaustion)
           if (this.pkceStore.size >= maxEntries) {
@@ -506,7 +526,6 @@ class MicrosoftGraphServer {
 
           this.pkceStore.set(state, {
             clientCodeChallenge,
-            clientCodeChallengeMethod: clientCodeChallengeMethod || 'S256',
             serverCodeVerifier,
             createdAt: Date.now(),
           });
@@ -611,7 +630,8 @@ class MicrosoftGraphServer {
             // We need to find the matching state — it's not sent in the token request,
             // but the code is unique per authorization, so we verify the client's
             // code_verifier against all stored challenges and use the server's verifier
-            let serverCodeVerifier: string | undefined;
+            let matchedPkceState: string | undefined;
+            let matchedPkceEntry: PkceEntry | undefined;
 
             if (body.code_verifier) {
               // Look through pkceStore for a matching client code_challenge
@@ -621,11 +641,16 @@ class MicrosoftGraphServer {
                 .update(clientVerifier)
                 .digest('base64url');
 
+              // Age deliberately plays no part here. If a mapping really is
+              // stale so is the code arriving with it, and Entra answers that
+              // with AADSTS70008, which is the authority giving the right
+              // answer. Evicting on age instead would take the mapping away
+              // from a slow but perfectly valid sign-in.
               for (const [state, pkceData] of this.pkceStore) {
                 if (pkceData.clientCodeChallenge === clientChallengeComputed) {
                   // Client's code_verifier matches stored code_challenge — two-leg PKCE
-                  serverCodeVerifier = pkceData.serverCodeVerifier;
-                  this.pkceStore.delete(state);
+                  matchedPkceState = state;
+                  matchedPkceEntry = pkceData;
                   logger.info('Two-leg PKCE: matched client verifier, using server verifier', {
                     state: state.substring(0, 8) + '...',
                   });
@@ -640,9 +665,21 @@ class MicrosoftGraphServer {
               clientId,
               clientSecret,
               tenantId,
-              serverCodeVerifier || (body.code_verifier as string | undefined),
+              matchedPkceEntry?.serverCodeVerifier || (body.code_verifier as string | undefined),
               this.secrets!.cloudType
             );
+
+            // Hold the mapping until the exchange succeeds. Dropping it on a
+            // failed attempt leaves a retry sending the client's verifier
+            // upstream, where we registered the server's challenge — a PKCE
+            // mismatch (AADSTS501481) that buries whatever actually failed.
+            // Match on identity rather than the key alone: an /authorize that
+            // reused this state while we were awaiting has already replaced the
+            // entry, and that newer mapping is still needed.
+            if (matchedPkceState && this.pkceStore.get(matchedPkceState) === matchedPkceEntry) {
+              this.pkceStore.delete(matchedPkceState);
+            }
+
             res.json(result);
           } else if (body.grant_type === 'refresh_token') {
             const tenantId = this.secrets?.tenantId || 'common';

--- a/test/public-client-token-exchange.test.ts
+++ b/test/public-client-token-exchange.test.ts
@@ -1,0 +1,525 @@
+/**
+ * Regression tests for GitHub issue #664:
+ * "/token unconditionally sends client_secret even when redirect_uri is
+ *  registered as a public client"
+ *
+ * One Entra app registration can hold both a Web redirect URI (confidential,
+ * client_secret required) and a Mobile and desktop one (public, client_secret
+ * forbidden). We can't tell which platform a redirect_uri was registered under,
+ * so we send the secret and retry without it when Entra answers AADSTS700025.
+ *
+ * The reporter's retry then failed with AADSTS501481, which looks like a PKCE
+ * mismatch. It was: /token consumed the two-leg PKCE mapping before the
+ * exchange succeeded, so the retry sent the client's verifier upstream where
+ * the server's challenge was registered.
+ */
+import crypto from 'crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import MicrosoftGraphServer from '../src/server.js';
+import type AuthManager from '../src/auth.js';
+import { clearSecretsCache } from '../src/secrets.js';
+import { exchangeCodeForToken, refreshAccessToken } from '../src/lib/microsoft-auth.js';
+import logger from '../src/logger.js';
+
+const expressMocks = vi.hoisted(() => {
+  type Handler = (req: Record<string, unknown>, res: Record<string, unknown>) => unknown;
+  const routes = new Map<string, Handler>();
+  const app: Record<string, ReturnType<typeof vi.fn>> = {};
+  app.set = vi.fn(() => app);
+  app.use = vi.fn(() => app);
+  app.get = vi.fn((path: string, handler: Handler) => {
+    routes.set(`GET ${path}`, handler);
+    return app;
+  });
+  app.post = vi.fn((path: string, handler: Handler) => {
+    routes.set(`POST ${path}`, handler);
+    return app;
+  });
+  app.listen = vi.fn((...args: unknown[]) => {
+    const callback = args.find((arg): arg is () => void => typeof arg === 'function');
+    callback?.();
+    return { close: vi.fn() };
+  });
+
+  const express = Object.assign(
+    vi.fn(() => app),
+    {
+      json: vi.fn(() => (_req: unknown, _res: unknown, next: () => void) => next()),
+      urlencoded: vi.fn(() => (_req: unknown, _res: unknown, next: () => void) => next()),
+    }
+  );
+
+  return { app, express, routes };
+});
+
+vi.mock('express', () => ({
+  default: expressMocks.express,
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/auth/router.js', () => ({
+  mcpAuthRouter: vi.fn(() => (_req: unknown, _res: unknown, next?: () => void) => next?.()),
+}));
+
+vi.mock('../src/graph-tools.js', () => ({
+  registerDiscoveryTools: vi.fn(),
+  registerGraphTools: vi.fn(),
+}));
+
+vi.mock('../src/oauth-provider.js', () => ({
+  MicrosoftOAuthProvider: vi.fn(),
+}));
+
+vi.mock('../src/logger.js', () => ({
+  default: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  enableConsoleLogging: vi.fn(),
+}));
+
+const TOKEN_RESPONSE = {
+  access_token: 'at',
+  token_type: 'Bearer',
+  scope: 'User.Read',
+  expires_in: 3600,
+  refresh_token: 'rt',
+};
+
+const PUBLIC_CLIENT_REJECTION = JSON.stringify({
+  error: 'invalid_client',
+  error_description:
+    "AADSTS700025: Client is public so neither 'client_assertion' nor 'client_secret' should be presented.",
+  error_codes: [700025],
+  correlation_id: 'corr-700025',
+});
+
+function jsonResponse(status: number, body: string): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => body,
+    json: async () => JSON.parse(body),
+  } as Response;
+}
+
+/** Form bodies of every upstream token call, in order. */
+function sentParams(fetchMock: ReturnType<typeof vi.fn>): URLSearchParams[] {
+  return fetchMock.mock.calls.map((call) => call[1].body as URLSearchParams);
+}
+
+function challengeFor(verifier: string): string {
+  return crypto.createHash('sha256').update(verifier).digest('base64url');
+}
+
+describe('Issue #664: client_secret on a public-client redirect_uri', () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    vi.mocked(logger.info).mockClear();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('retries the code exchange without client_secret on AADSTS700025', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(401, PUBLIC_CLIENT_REJECTION))
+      .mockResolvedValueOnce(jsonResponse(200, JSON.stringify(TOKEN_RESPONSE)));
+    global.fetch = fetchMock;
+
+    const result = await exchangeCodeForToken(
+      'code',
+      'http://localhost:3118/callback',
+      'client-id',
+      'the-secret',
+      'tenant-id',
+      'verifier'
+    );
+
+    expect(result).toEqual(TOKEN_RESPONSE);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [first, second] = sentParams(fetchMock);
+    expect(first.get('client_secret')).toBe('the-secret');
+    expect(second.get('client_secret')).toBeNull();
+    // The retry must still carry everything else, or it trades AADSTS700025 for
+    // an equally opaque PKCE failure.
+    expect(second.get('code')).toBe('code');
+    expect(second.get('code_verifier')).toBe('verifier');
+    expect(second.get('redirect_uri')).toBe('http://localhost:3118/callback');
+    // The first attempt's correlation_id is the only handle on it once the
+    // retry answers, so it has to reach the log.
+    expect(vi.mocked(logger.info)).toHaveBeenCalledWith(
+      expect.stringContaining('AADSTS700025'),
+      expect.objectContaining({ correlation_id: 'corr-700025', status: 401 })
+    );
+  });
+
+  it('retries the refresh without client_secret on AADSTS700025', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(401, PUBLIC_CLIENT_REJECTION))
+      .mockResolvedValueOnce(jsonResponse(200, JSON.stringify(TOKEN_RESPONSE)));
+    global.fetch = fetchMock;
+
+    const result = await refreshAccessToken('rt', 'client-id', 'the-secret', 'tenant-id');
+
+    expect(result).toEqual(TOKEN_RESPONSE);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [first, second] = sentParams(fetchMock);
+    expect(first.get('client_secret')).toBe('the-secret');
+    expect(second.get('client_secret')).toBeNull();
+    expect(second.get('refresh_token')).toBe('rt');
+  });
+
+  it('does not retry other upstream errors', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(
+        400,
+        JSON.stringify({
+          error: 'invalid_grant',
+          error_description: 'AADSTS70008: The provided authorization code has expired.',
+          error_codes: [70008],
+        })
+      )
+    );
+    global.fetch = fetchMock;
+
+    await expect(
+      exchangeCodeForToken('code', 'http://localhost/cb', 'client-id', 'the-secret')
+    ).rejects.toMatchObject({ name: 'OAuthUpstreamError', body: { error_codes: [70008] } });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries only once when the retry is also rejected', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(401, PUBLIC_CLIENT_REJECTION));
+    global.fetch = fetchMock;
+
+    await expect(
+      exchangeCodeForToken('code', 'http://localhost/cb', 'client-id', 'the-secret')
+    ).rejects.toMatchObject({ name: 'OAuthUpstreamError', status: 401 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces a malformed error_codes as an OAuth error, not a 500', async () => {
+    // parseUpstreamOAuthError only vouches for `error`, so error_codes can be
+    // anything. A TypeError here would escape as a bare server_error.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(401, JSON.stringify({ error: 'invalid_client', error_codes: 700025 }))
+      );
+    global.fetch = fetchMock;
+
+    await expect(
+      exchangeCodeForToken('code', 'http://localhost/cb', 'client-id', 'the-secret')
+    ).rejects.toMatchObject({ name: 'OAuthUpstreamError', status: 401 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces AADSTS700025 when there is no secret to drop', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(401, PUBLIC_CLIENT_REJECTION));
+    global.fetch = fetchMock;
+
+    await expect(
+      exchangeCodeForToken('code', 'http://localhost/cb', 'client-id', undefined)
+    ).rejects.toMatchObject({ name: 'OAuthUpstreamError', status: 401 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+function mockAuthManager(): AuthManager {
+  return {
+    isMultiAccount: vi.fn().mockResolvedValue(false),
+    listAccounts: vi.fn().mockResolvedValue([]),
+  } as unknown as AuthManager;
+}
+
+function mockRequest(path: string, body?: Record<string, unknown>) {
+  return {
+    secure: false,
+    protocol: 'http',
+    url: path,
+    method: body ? 'POST' : 'GET',
+    body,
+    get: vi.fn((header: string) =>
+      header.toLowerCase() === 'host' ? 'localhost:3000' : undefined
+    ),
+  };
+}
+
+function mockResponse() {
+  const res = {
+    json: vi.fn(),
+    redirect: vi.fn(),
+    status: vi.fn(),
+  };
+  res.status.mockReturnValue(res);
+  return res;
+}
+
+describe('Issue #664: two-leg PKCE mapping survives a failed exchange', () => {
+  const clientVerifier = 'client-side-code-verifier-for-the-mcp-client';
+  const redirectUri = 'http://localhost:3118/callback';
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    expressMocks.routes.clear();
+    process.env.MS365_MCP_CLIENT_ID = 'test-client-id';
+    process.env.MS365_MCP_TENANT_ID = 'test-tenant';
+    delete process.env.MS365_MCP_CLIENT_SECRET;
+    delete process.env.MS365_MCP_KEYVAULT_URL;
+    clearSecretsCache();
+  });
+
+  async function startServer(clientSecret?: string): Promise<void> {
+    if (clientSecret) {
+      process.env.MS365_MCP_CLIENT_SECRET = clientSecret;
+      clearSecretsCache();
+    }
+    const server = new MicrosoftGraphServer(mockAuthManager(), { http: true });
+    await server.initialize('test');
+    await server.start();
+  }
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    delete process.env.MS365_MCP_CLIENT_ID;
+    delete process.env.MS365_MCP_TENANT_ID;
+    delete process.env.MS365_MCP_CLIENT_SECRET;
+    clearSecretsCache();
+    vi.restoreAllMocks();
+  });
+
+  /** Runs the /authorize leg and returns the challenge we gave Microsoft. */
+  async function authorize(state: string, verifier = clientVerifier): Promise<string> {
+    return callAuthorize(
+      `&state=${state}&code_challenge=${challengeFor(verifier)}&code_challenge_method=S256`
+    );
+  }
+
+  /** The stateless variant: no state to key a mapping on (the Claude Code path). */
+  async function authorizeWithoutState(verifier = clientVerifier): Promise<string> {
+    return callAuthorize(`&code_challenge=${challengeFor(verifier)}&code_challenge_method=S256`);
+  }
+
+  async function callAuthorize(query: string): Promise<string> {
+    const handler = expressMocks.routes.get('GET /authorize')!;
+    const res = mockResponse();
+    await handler(
+      mockRequest(
+        `/authorize?response_type=code&redirect_uri=${encodeURIComponent(redirectUri)}${query}`
+      ),
+      res
+    );
+    return new URL(res.redirect.mock.calls[0][0] as string).searchParams.get('code_challenge')!;
+  }
+
+  function postToken(verifier = clientVerifier) {
+    const handler = expressMocks.routes.get('POST /token')!;
+    const res = mockResponse();
+    const done = handler(
+      mockRequest('/token', {
+        grant_type: 'authorization_code',
+        code: 'the-code',
+        redirect_uri: redirectUri,
+        code_verifier: verifier,
+      }),
+      res
+    );
+    return Promise.resolve(done).then(() => res);
+  }
+
+  it('still sends the server verifier when a first exchange failed', async () => {
+    await startServer();
+    const serverChallenge = await authorize('state-one');
+    expect(serverChallenge).not.toBe(challengeFor(clientVerifier));
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(401, PUBLIC_CLIENT_REJECTION))
+      .mockResolvedValueOnce(jsonResponse(200, JSON.stringify(TOKEN_RESPONSE)));
+    global.fetch = fetchMock;
+
+    const failed = await postToken();
+    expect(failed.status).toHaveBeenCalledWith(400);
+
+    const succeeded = await postToken();
+    expect(succeeded.json).toHaveBeenCalledWith(TOKEN_RESPONSE);
+
+    const [first, second] = sentParams(fetchMock);
+    expect(challengeFor(first.get('code_verifier')!)).toBe(serverChallenge);
+    expect(challengeFor(second.get('code_verifier')!)).toBe(serverChallenge);
+  });
+
+  it('keeps the server verifier across the secret-dropping retry', async () => {
+    // The reporter's configuration: a secret is set for the confidential leg,
+    // two-leg PKCE is active, and Entra answers 700025 on the public one. Both
+    // upstream attempts have to carry the server verifier, not just the first.
+    await startServer('the-secret');
+    const serverChallenge = await authorize('state-mixed');
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(401, PUBLIC_CLIENT_REJECTION))
+      .mockResolvedValueOnce(jsonResponse(200, JSON.stringify(TOKEN_RESPONSE)));
+    global.fetch = fetchMock;
+
+    const res = await postToken();
+
+    expect(res.json).toHaveBeenCalledWith(TOKEN_RESPONSE);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [first, second] = sentParams(fetchMock);
+    expect(first.get('client_secret')).toBe('the-secret');
+    expect(second.get('client_secret')).toBeNull();
+    expect(challengeFor(first.get('code_verifier')!)).toBe(serverChallenge);
+    expect(challengeFor(second.get('code_verifier')!)).toBe(serverChallenge);
+  });
+
+  it('uses the newest mapping when a client reuses one code_verifier', async () => {
+    await startServer();
+    await authorize('state-abandoned');
+    const serverChallenge = await authorize('state-retried');
+
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, JSON.stringify(TOKEN_RESPONSE)));
+    global.fetch = fetchMock;
+
+    await postToken();
+
+    const [sent] = sentParams(fetchMock);
+    expect(challengeFor(sent.get('code_verifier')!)).toBe(serverChallenge);
+  });
+
+  it('still uses its mapping after a sign-in slower than the window', async () => {
+    vi.useFakeTimers();
+    try {
+      await startServer();
+      const serverChallenge = await authorize('state-slow');
+      // Past the retention window on purpose: /token must not consult age at
+      // all. createdAt is stamped at /authorize, so it measures the user's time
+      // on the Microsoft login page, and a long MFA enrollment or consent prompt
+      // still ends in a perfectly fresh authorization code.
+      vi.advanceTimersByTime(61 * 60 * 1000);
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(jsonResponse(200, JSON.stringify(TOKEN_RESPONSE)));
+      global.fetch = fetchMock;
+
+      await postToken();
+
+      const [sent] = sentParams(fetchMock);
+      expect(challengeFor(sent.get('code_verifier')!)).toBe(serverChallenge);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('survives another authorization arriving during a slow sign-in', async () => {
+    const otherVerifier = 'a-second-client-verifier-from-another-user';
+    vi.useFakeTimers();
+    try {
+      await startServer();
+      const serverChallenge = await authorize('state-slow-busy');
+      vi.advanceTimersByTime(30 * 60 * 1000);
+      // Someone else signing in is what used to cost the slow user their
+      // mapping: the sweep runs on every authorization, not just their own.
+      await authorize('state-other-user', otherVerifier);
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(jsonResponse(200, JSON.stringify(TOKEN_RESPONSE)));
+      global.fetch = fetchMock;
+      await postToken();
+
+      const [sent] = sentParams(fetchMock);
+      expect(challengeFor(sent.get('code_verifier')!)).toBe(serverChallenge);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('still sweeps mappings past the retention window', async () => {
+    const otherVerifier = 'a-second-client-verifier-from-another-user';
+    vi.useFakeTimers();
+    try {
+      await startServer();
+      await authorize('state-forgotten');
+      vi.advanceTimersByTime(61 * 60 * 1000);
+      await authorize('state-other-user', otherVerifier);
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(jsonResponse(200, JSON.stringify(TOKEN_RESPONSE)));
+      global.fetch = fetchMock;
+      await postToken();
+
+      const [sent] = sentParams(fetchMock);
+      expect(sent.get('code_verifier')).toBe(clientVerifier);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps a mapping stored while an earlier exchange was in flight', async () => {
+    await startServer();
+    await authorize('state-reused');
+
+    let release: (() => void) | undefined;
+    global.fetch = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          release = () => resolve(jsonResponse(200, JSON.stringify(TOKEN_RESPONSE)));
+        })
+    );
+
+    const pending = postToken();
+    // Same state, so this replaces the entry under that key while the exchange
+    // above is still awaiting upstream.
+    const newChallenge = await authorize('state-reused');
+    release!();
+    await pending;
+
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, JSON.stringify(TOKEN_RESPONSE)));
+    global.fetch = fetchMock;
+    await postToken();
+
+    const [sent] = sentParams(fetchMock);
+    expect(challengeFor(sent.get('code_verifier')!)).toBe(newChallenge);
+  });
+
+  it('drops the mapping when a later authorization forwards the client challenge', async () => {
+    await startServer();
+    await authorize('state-two-leg');
+    // The stateless path sends the client's own challenge upstream, so the
+    // mapping from the earlier run would answer it with the wrong verifier.
+    await authorizeWithoutState();
+
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, JSON.stringify(TOKEN_RESPONSE)));
+    global.fetch = fetchMock;
+    await postToken();
+
+    const [sent] = sentParams(fetchMock);
+    expect(sent.get('code_verifier')).toBe(clientVerifier);
+  });
+
+  it('drops the mapping once the exchange succeeds', async () => {
+    await startServer();
+    await authorize('state-two');
+
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, JSON.stringify(TOKEN_RESPONSE)));
+    global.fetch = fetchMock;
+
+    await postToken();
+    await postToken();
+
+    const [first, second] = sentParams(fetchMock);
+    expect(first.get('code_verifier')).not.toBe(clientVerifier);
+    expect(second.get('code_verifier')).toBe(clientVerifier);
+  });
+});


### PR DESCRIPTION
One Entra app registration can hold both a Web redirect URI, which requires client_secret, and a Mobile and desktop one, which forbids it. /token attached the secret to every exchange, so the public leg failed with AADSTS700025. A loopback URI is legal under either platform, so the redirect_uri cannot tell us which applies: send the secret, and retry once without it when Entra says this exchange did not want one. The same retry covers refresh.

The retry is safe because 700025 is a client-authentication failure, raised before the code is redeemed. Issue #664 reports the code as burned by the first attempt, but its own log shows otherwise: the second request failed with AADSTS501481, the verifier/challenge mismatch code, so Entra reached PKCE validation and had accepted the code as live. A reused code answers 54005 and an expired one 70008.

That 501481 was a second bug. /token consumed the two-leg PKCE mapping the moment it matched, before the exchange ran, so any retry sent the client's verifier upstream where the server's challenge was registered. The mapping is now held until the exchange succeeds, and released by object identity so a concurrent /authorize reusing the same state keeps its replacement.

Retention is no longer treated as PKCE validity. createdAt is stamped at /authorize, so it measures the user's time on the Microsoft login page rather than the age of the code they return with; at ten minutes, any other user's authorization swept away the mapping of a sign-in sitting behind an MFA enrollment or consent prompt, producing that same AADSTS501481. It is now an hour of memory cleanup, bounded by the existing 1000-entry cap, and /token never consults it.

The redirect_uri classification #664 suggests is deliberately not used: Entra permits http://localhost under the Web platform, so treating loopback as public would break deployments that register it there and answer with AADSTS7000218.