### PR TITLE
feat: Add support for the skiptoken parameter

### DIFF
--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -1089,6 +1089,143 @@ describe('graph-tools', () => {
     });
   });
 
+  // ---- 2a. skiptoken cursor paging ----
+  describe('skiptoken cursor', () => {
+    const prevAllowPagination = process.env.MS365_MCP_ALLOW_PAGINATION;
+    afterEach(() => {
+      if (prevAllowPagination === undefined) delete process.env.MS365_MCP_ALLOW_PAGINATION;
+      else process.env.MS365_MCP_ALLOW_PAGINATION = prevAllowPagination;
+    });
+
+    const callWith = async (args: Record<string, unknown>) => {
+      mockEndpoints.push(makeEndpoint());
+      mockEndpointsJson = [makeConfig()];
+      const graphClient = createMockGraphClient();
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, graphClient as any);
+      await server.tools.get('test-tool')!.handler(args);
+      return graphClient.graphRequest.mock.calls[0][0] as string;
+    };
+
+    /** A single-object GET: $select/$expand and nothing collection-shaped. */
+    const singleObjectEndpoint = () =>
+      makeEndpoint({
+        alias: 'get-thing',
+        path: '/me/thing',
+        parameters: [
+          { name: 'select', type: 'Query', schema: z.string().optional() },
+          { name: 'expand', type: 'Query', schema: z.string().optional() },
+        ],
+      });
+
+    const registerAnd = async (endpoint: any, config: any) => {
+      mockEndpoints.push(endpoint);
+      mockEndpointsJson = [config];
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, createMockGraphClient() as any);
+      return server;
+    };
+
+    it('omits skiptoken on single-object GETs', async () => {
+      const server = await registerAnd(
+        singleObjectEndpoint(),
+        makeConfig({ toolName: 'get-thing', pathPattern: '/me/thing' })
+      );
+
+      expect(server.tools.get('get-thing')!.schema.skiptoken).toBeUndefined();
+    });
+
+    it('keeps skiptoken on delta tools that have $top stripped', async () => {
+      // list-calendar-events-delta pages via cursor but is in TOP_UNSUPPORTED_DELTA_TOOLS,
+      // so a $top-only test would strip the cursor from an endpoint that needs it.
+      const endpoint = makeEndpoint({
+        alias: 'list-calendar-events-delta',
+        path: '/me/calendarView/delta',
+      });
+      const server = await registerAnd(
+        endpoint,
+        makeConfig({
+          toolName: 'list-calendar-events-delta',
+          pathPattern: '/me/calendarView/delta',
+        })
+      );
+
+      const schema = server.tools.get('list-calendar-events-delta')!.schema;
+      expect(schema.top).toBeUndefined();
+      expect(schema.skiptoken).toBeDefined();
+    });
+
+    it('advertises skiptoken on GET list tools', async () => {
+      mockEndpoints.push(makeEndpoint());
+      mockEndpointsJson = [makeConfig()];
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, createMockGraphClient() as any);
+
+      expect(server.tools.get('test-tool')!.schema.skiptoken).toBeDefined();
+    });
+
+    it('still advertises skiptoken when MS365_MCP_ALLOW_PAGINATION is disabled', async () => {
+      // Manual paging returns one page, so the auto-follow kill switch must not
+      // remove the only cursor a stateless client has.
+      process.env.MS365_MCP_ALLOW_PAGINATION = '0';
+      mockEndpoints.push(makeEndpoint());
+      mockEndpointsJson = [makeConfig()];
+      const server = createMockServer();
+      const { registerGraphTools } = await loadModule();
+      registerGraphTools(server as any, createMockGraphClient() as any);
+
+      expect(server.tools.get('test-tool')!.schema.fetchAllPages).toBeUndefined();
+      expect(server.tools.get('test-tool')!.schema.skiptoken).toBeDefined();
+    });
+
+    it('forwards a bare token as $skiptoken', async () => {
+      const path = await callWith({ skiptoken: 'abc123' });
+      expect(path).toContain('$skiptoken=abc123');
+    });
+
+    it('does not double-encode a token copied from @odata.nextLink', async () => {
+      // Tokens arrive percent-encoded straight out of the nextLink URL; encoding
+      // them again yields %253d and Graph rejects the cursor.
+      const path = await callWith({ skiptoken: 'eyJhIjoxfQ%3d%3d' });
+      expect(path).toContain('$skiptoken=eyJhIjoxfQ%3D%3D');
+      expect(path).not.toContain('%253');
+    });
+
+    it('extracts the token when handed a whole nextLink URL', async () => {
+      const path = await callWith({
+        skiptoken: 'https://graph.microsoft.com/v1.0/me/chats?$top=5&$filter=x&$skiptoken=tok123',
+      });
+      expect(path).toContain('$skiptoken=tok123');
+      expect(path).not.toContain('graph.microsoft.com');
+    });
+
+    it('keeps only the cursor when the nextLink has params after it', async () => {
+      const path = await callWith({ skiptoken: '$skiptoken=tok123&$top=5' });
+      expect(path).toContain('$skiptoken=tok123');
+      expect(path).not.toContain('tok123&');
+    });
+
+    it('accepts the $-prefixed param name', async () => {
+      const path = await callWith({ $skiptoken: 'abc123' });
+      expect(path).toContain('$skiptoken=abc123');
+    });
+
+    it('omits $skiptoken entirely when blank', async () => {
+      const path = await callWith({ skiptoken: '   ' });
+      expect(path).not.toContain('skiptoken');
+    });
+
+    it('sends the cursor alongside the original query options', async () => {
+      const path = await callWith({ filter: "chatType eq 'oneOnOne'", top: 5, skiptoken: 'tok' });
+      expect(path).toContain('$filter=');
+      expect(path).toContain('$top=5');
+      expect(path).toContain('$skiptoken=tok');
+    });
+  });
+
   // ---- 2. fetchAllPages pagination ----
   describe('fetchAllPages pagination', () => {
     it('should follow @odata.nextLink and combine results', async () => {

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -67,6 +67,9 @@ import {
   getAcceptParamDescription,
   getAccountParamDescription,
   getFetchAllPagesParamDescription,
+  SKIPTOKEN_PARAM_DESCRIPTION,
+  isSkiptokenApplicable,
+  normalizeSkiptoken,
 } from './lib/param-descriptions.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -1799,6 +1802,7 @@ async function executeGraphTool(
         'expand',
         'orderby',
         'skip',
+        'skiptoken',
         'top',
         'count',
         'search',
@@ -1995,6 +1999,13 @@ async function executeGraphTool(
     // callers) might still try — drop it server-side before clamping or sending.
     if (TOP_UNSUPPORTED_DELTA_TOOLS.has(tool.alias)) {
       delete queryParams['$top'];
+    }
+
+    // Manual cursor paging, for endpoints where $skip is not allowed
+    if (queryParams['$skiptoken']) {
+      const cursor = normalizeSkiptoken(queryParams['$skiptoken']);
+      if (cursor) queryParams['$skiptoken'] = cursor;
+      else delete queryParams['$skiptoken'];
     }
 
     clampTopQueryParam(queryParams);
@@ -2472,6 +2483,10 @@ export function registerGraphTools(
         .boolean()
         .describe(getFetchAllPagesParamDescription(maxPages))
         .optional();
+    }
+
+    if (isSkiptokenApplicable(tool, Object.keys(paramSchema))) {
+      paramSchema['skiptoken'] = z.string().describe(SKIPTOKEN_PARAM_DESCRIPTION).optional();
     }
 
     // Override OData parameter descriptions with spec-gap guidance. Text lives in

--- a/src/lib/param-descriptions.ts
+++ b/src/lib/param-descriptions.ts
@@ -97,6 +97,54 @@ export const TOP_PARAM_DESCRIPTION =
 
 export const SKIP_PARAM_DESCRIPTION = 'Items to skip for pagination. Not supported with $search.';
 
+export const SKIPTOKEN_PARAM_DESCRIPTION =
+  'Opaque cursor for the next page, taken from the previous response. Copy the ' +
+  '$skiptoken value out of @odata.nextLink (or paste the whole nextLink URL — the ' +
+  'token is extracted from it) and resend it with the SAME $filter/$select/$expand/' +
+  '$top as the first call. Use this to walk pages one at a time instead of ' +
+  'fetchAllPages. Omit it for the first page.';
+
+// Query options that only exist on a collection, which are used to determine if
+// if skiptoken pagination is allowed
+const COLLECTION_QUERY_PARAMS = new Set(['top', 'filter', 'orderby', 'count']);
+
+// Guess whether a tool returns a collection and can take a `skiptoken`, given the
+// parameter names in its schema .
+export function isSkiptokenApplicable(
+  tool: { method: string },
+  paramNames: Iterable<string>
+): boolean {
+  if (tool.method.toUpperCase() !== 'GET') return false;
+  for (const name of paramNames) {
+    if (COLLECTION_QUERY_PARAMS.has(name.replace(/^\$/, '').toLowerCase())) return true;
+  }
+  return false;
+}
+
+// Accepts every shape a model plausibly sends a cursor in and returns the raw token:
+// a whole nextLink URL, a bare `$skiptoken=...` fragment, an already-percent-encoded
+// token, or the decoded token itself.
+export function normalizeSkiptoken(raw: string): string {
+  let token = raw.trim();
+
+  const marker = token.match(/(?:\$|%24)skiptoken=/i);
+  if (marker?.index !== undefined) {
+    token = token.slice(marker.index + marker[0].length);
+    // A nextLink can carry params after the cursor; keep only this one's value.
+    token = token.split('&')[0];
+  }
+
+  if (token.includes('%')) {
+    try {
+      token = decodeURIComponent(token);
+    } catch {
+      logger.warn('skiptoken looks percent-encoded but could not be decoded; sending as-is');
+    }
+  }
+
+  return token;
+}
+
 export const COUNT_PARAM_DESCRIPTION =
   'Set true to enable advanced query mode (ConsistencyLevel: eventual). Required for complex $filter on flag/flagStatus or contains().';
 

--- a/src/lib/tool-schema.ts
+++ b/src/lib/tool-schema.ts
@@ -6,6 +6,8 @@ import {
   getODataParamDescription,
   shouldOmitTopParam,
   isFetchAllPagesApplicable,
+  isSkiptokenApplicable,
+  SKIPTOKEN_PARAM_DESCRIPTION,
   getMaxPages,
   getFetchAllPagesParamDescription,
   getAccountParamDescription,
@@ -132,6 +134,22 @@ export function describeToolSchema(
       required: false,
       description: getFetchAllPagesParamDescription(getMaxPages()),
       schema: { type: 'boolean' },
+    });
+  }
+
+  // Mirrors registerGraphTools: GET list endpoints have a skiptoken cursor param.
+  if (
+    isSkiptokenApplicable(
+      { method: tool.method },
+      params.map((p) => p.name)
+    )
+  ) {
+    params.push({
+      name: 'skiptoken',
+      in: 'Query',
+      required: false,
+      description: SKIPTOKEN_PARAM_DESCRIPTION,
+      schema: { type: 'string' },
     });
   }
 


### PR DESCRIPTION
This PR makes it possible for callers to send Graph's skiptoken parameter, which was previously filtered out.

The fetchAllPages parameter can take a long time if there are many pages. This change allows the caller to choose to follow nextLink pagination links on its own. This can be a bit more efficient because it can stop as soon as it finds the desired result - for example when trying to find a oneOnOne chat with a specific person using list-chats.

We make an attempt to only add this parameter to endpoints that probably allow it, rather than every single endpoint.