### PR TITLE
feat(endpoints): let drive item tools run under Sites.Selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ SharePoint supports two enterprise permission models:
 - Broad tenant scopes such as `Sites.Read.All`, `Sites.ReadWrite.All`, and `Sites.Manage.All`.
 - Microsoft Graph `Sites.Selected`, where SharePoint site access is granted to the app on specific site collections and Graph evaluates the signed-in user's own permissions at request time.
 
-The default org-mode behavior continues to request the broad SharePoint scopes used by existing deployments. Enterprises that want selected-site SharePoint access can set an allowlist containing `Sites.Selected` instead of broad `Sites.*.All` scopes. Direct site/list/item tools that target an explicit SharePoint site can run with `Sites.Selected`; tenant-wide SharePoint discovery and search tools still require broad SharePoint scopes.
+The default org-mode behavior continues to request the broad SharePoint scopes used by existing deployments. Enterprises that want selected-site SharePoint access can set an allowlist containing `Sites.Selected` instead of broad `Sites.*.All` scopes. Direct site/list/item tools that target an explicit SharePoint site, and the `/drives/{drive-id}/...` item tools (list, get, upload, folder, move/rename, copy, versions) for drives of a granted site, can run with `Sites.Selected`; tenant-wide SharePoint discovery and search tools still require broad SharePoint scopes.
 
 ```bash
 npx @softeria/ms-365-mcp-server \

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -621,14 +621,14 @@
     "method": "get",
     "toolName": "get-drive-root-item",
     "presets": ["files", "onedrive", "personal"],
-    "scopes": ["Files.Read"]
+    "scopes": [["Files.Read"], ["Sites.Selected"]]
   },
   {
     "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/children",
     "method": "get",
     "toolName": "list-folder-files",
     "presets": ["files", "onedrive", "personal"],
-    "scopes": ["Files.Read"]
+    "scopes": [["Files.Read"], ["Sites.Selected"]]
   },
   {
     "pathPattern": "/drives/{drive-id}/items/{driveItem-id}",
@@ -642,7 +642,7 @@
     "method": "put",
     "toolName": "upload-file-content",
     "presets": ["files", "onedrive", "personal"],
-    "scopes": ["Files.ReadWrite"],
+    "scopes": [["Files.ReadWrite"], ["Sites.Selected"]],
     "llmTip": "Body is a base64-encoded string of the file bytes; the server decodes it before PUT. Graph accepts up to 250MB here, but the whole string travels as a tool argument and a truncated one decodes to a truncated file with no error, so use create-upload-session rather than emitting a large base64 string. For new files use path format: /items/root:/path/to/file.txt:/content. Overwrites existing files without warning."
   },
   {
@@ -650,7 +650,7 @@
     "method": "post",
     "toolName": "create-upload-session",
     "presets": ["files", "onedrive", "personal"],
-    "scopes": ["Files.ReadWrite"],
+    "scopes": [["Files.ReadWrite"], ["Sites.Selected"]],
     "llmTip": "For large file uploads (no size limit, and no minimum unlike the Outlook attachment session). Returns a pre-authenticated uploadUrl; the caller PUTs the bytes there itself. This server does not perform the PUT. For new files use path: /items/{parentId}:/{fileName}:/createUploadSession. Body (optional): { item: { '@microsoft.graph.conflictBehavior': 'rename' } }."
   },
   {
@@ -658,7 +658,7 @@
     "method": "get",
     "toolName": "get-drive-item",
     "presets": ["files", "onedrive", "personal"],
-    "scopes": ["Files.Read"],
+    "scopes": [["Files.Read"], ["Sites.Selected"]],
     "llmTip": "Gets metadata for a file or folder: name, size, lastModifiedDateTime, createdBy, webUrl, file (mimeType, hashes), folder (childCount), parentReference, and @microsoft.graph.downloadUrl. For large drive/SharePoint files, call get-download-url with target=/drives/{drive-id}/items/{driveItem-id}/content to fetch out-of-band with no Authorization header. For small files where base64 in the tool response is acceptable, call download-bytes with the same /content target."
   },
   {
@@ -666,7 +666,7 @@
     "method": "patch",
     "toolName": "move-rename-onedrive-item",
     "presets": ["files", "onedrive", "personal"],
-    "scopes": ["Files.ReadWrite"],
+    "scopes": [["Files.ReadWrite"], ["Sites.Selected"]],
     "llmTip": "Move and/or rename a file or folder. To move, provide parentReference with the target folder's id. To rename, provide a new name. Both can be done in a single request."
   },
   {
@@ -674,7 +674,7 @@
     "method": "post",
     "toolName": "create-onedrive-folder",
     "presets": ["files", "onedrive", "personal"],
-    "scopes": ["Files.ReadWrite"],
+    "scopes": [["Files.ReadWrite"], ["Sites.Selected"]],
     "llmTip": "Creates a new folder inside the specified drive item. Body must include name (string) and folder ({}) fields. Use @microsoft.graph.conflictBehavior to control behavior on name conflict: 'rename' (default), 'replace', or 'fail'."
   },
   {
@@ -698,7 +698,7 @@
     "method": "post",
     "toolName": "copy-drive-item",
     "presets": ["files", "onedrive", "personal"],
-    "scopes": ["Files.ReadWrite"],
+    "scopes": [["Files.ReadWrite"], ["Sites.Selected"]],
     "llmTip": "Asynchronously copy a file or folder to a new location and/or name. Body: { parentReference: { driveId: '...', id: '...' }, name?: 'New Name.xlsx' }. Returns 202 Accepted with a Location header pointing at a monitor URL for the async job. Ideal for duplicating templates (e.g. clone an Armhr Census Template per prospect), bulk file provisioning, or preserving an immutable snapshot of a working file."
   },
   {
@@ -738,7 +738,7 @@
     "method": "get",
     "toolName": "list-drive-item-versions",
     "presets": ["files", "onedrive", "personal"],
-    "scopes": ["Files.Read"],
+    "scopes": [["Files.Read"], ["Sites.Selected"]],
     "llmTip": "Lists version history of a file. Each version has id, lastModifiedDateTime, lastModifiedBy, and size. Use the version id with /versions/{id}/content to download a specific version."
   },
   {

--- a/test/sites-selected-drive-tools.test.ts
+++ b/test/sites-selected-drive-tools.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { buildAllowedScopeDiagnostics } from '../src/auth.js';
+
+/**
+ * The /drives/{drive-id}/... item tools are how a Sites.Selected deployment reads and
+ * writes files in a granted site (Graph serves those paths for any drive of a granted
+ * site collection). Each of them must therefore accept Sites.Selected as an alternative
+ * to Files.Read / Files.ReadWrite, while keeping Files.* as the primary group so login
+ * scopes without an allowlist are unchanged.
+ */
+const DRIVE_ITEM_TOOLS = [
+  'get-drive-root-item',
+  'get-drive-item',
+  'list-folder-files',
+  'upload-file-content',
+  'create-upload-session',
+  'create-onedrive-folder',
+  'move-rename-onedrive-item',
+  'copy-drive-item',
+  'list-drive-item-versions',
+];
+const enabledTools = `^(${DRIVE_ITEM_TOOLS.join('|')})$`;
+
+describe('drive item tools under a Sites.Selected allowlist', () => {
+  it('are all enabled and request only Sites.Selected', () => {
+    const d = buildAllowedScopeDiagnostics({
+      orgMode: true,
+      enabledTools,
+      allowedScopes: 'User.Read Sites.Selected',
+    });
+    expect(d.disabledTools.map((t) => t.toolName)).toEqual([]);
+    expect(d.effectivePermissions).toEqual(['Sites.Selected']);
+  });
+
+  it('are all disabled when the allowlist has neither Files.* nor Sites.Selected', () => {
+    const d = buildAllowedScopeDiagnostics({
+      orgMode: true,
+      enabledTools,
+      allowedScopes: 'User.Read',
+    });
+    expect(d.disabledTools.map((t) => t.toolName).sort()).toEqual([...DRIVE_ITEM_TOOLS].sort());
+  });
+
+  it('still request Files.ReadWrite (primary group) without an allowlist', () => {
+    const d = buildAllowedScopeDiagnostics({ orgMode: true, enabledTools });
+    expect(d.effectivePermissions).toEqual(['Files.ReadWrite']);
+  });
+});


### PR DESCRIPTION
## Problem

The README documents `Sites.Selected` as a supported SharePoint permission model with `--allowed-scopes`, and the `/sites/...` tools already carry `Sites.Selected` as an OR-group alternative. The `/drives/{drive-id}/...` item tools do not: they declare only `Files.Read` / `Files.ReadWrite`, so an allowlist like `--allowed-scopes 'User.Read Sites.Selected'` hides every file operation:

```
disabledTools: list-folder-files, upload-file-content, create-upload-session, get-drive-item,
               move-rename-onedrive-item, create-onedrive-folder, copy-drive-item, list-drive-item-versions
missingAllowedScopesForTools: Files.Read, Files.ReadWrite
```

That leaves a selected-site deployment able to list a site's drives but unable to read or write anything in them — while Graph itself serves `/drives/{id}/items/...` for any drive of a granted site collection.

## Change

Nine drive item tools become OR-groups with `Sites.Selected` as the second alternative, the same shape `get-sharepoint-site` etc. already use:

```json
"scopes": [["Files.ReadWrite"], ["Sites.Selected"]]
```

The primary group is unchanged, so login scopes without an allowlist are identical (`--list-permissions` still reports `Files.ReadWrite`). `scopes` is kept (not `workScopes`) so personal-account behaviour is untouched. No code change.

Also: one README sentence, and `test/sites-selected-drive-tools.test.ts` (fails on the previous `endpoints.json`, passes now; asserts enabled-under-Sites.Selected, disabled-without-either, and unchanged login scopes).

## Verification

- `--list-permissions` with the allowlist: `disabledTools: []`, `effectivePermissions: ['Sites.Selected']`.
- End-to-end against a tenant where the app is granted `write` on one site and `read` on another (delegated `Sites.Selected` only, admin-consented), signed in as a user who has Edit on both in the browser: upload to the read-only site → 403 `accessDenied`; upload to the write site → 201; listing an ungranted site's library → 403; listing the read site's library → 200.
- `npm run typecheck`, `lint`, `format:check` clean. `npm test`: the only failures on my machine are the 5 in `test/attachment-split-listener.test.ts`, which fail identically on `main` here (port binding), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)