### PR TITLE
feat(http): stateless two-leg PKCE for multi-instance hosts (MS365_MCP_PKCE_SECRET), plus noListen

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -206,6 +206,7 @@ The client automatically discovers OAuth endpoints and opens a browser for authe
 ## Security Considerations
 
 - **Stateless**: the server does not store tokens — each request carries the user's Bearer token
+- **More than one instance? Set `MS365_MCP_PKCE_SECRET`** (32+ random characters). The two-leg PKCE flow otherwise keeps a mapping in process memory between `/authorize` and `/token`, so a second replica, a serverless function or a restart between the two legs fails the exchange with `AADSTS501481`. With the secret set, the server-side verifier is derived from the client's code_challenge and the secret and nothing is stored, so any instance can complete the exchange. Single-process deployments can leave it unset. Embedding hosts can also build the app without binding a port via `options.noListen` + `getHttpApp()`.
 - **Account pinning**: `MS365_MCP_EXPECTED_USERNAME` and `MS365_MCP_EXPECTED_HOME_ACCOUNT_ID` protect local MSAL cache flows for headless stdio deployments. In `--http`, `--obo`, or `MS365_MCP_OAUTH_TOKEN` deployments they are warning-only because Graph calls use request-provided tokens.
 - **Admin consent**: grant tenant-wide consent to avoid per-user consent prompts
 - **Managed identity**: use managed identity for Key Vault access (no secrets in environment variables)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -174,6 +174,11 @@ export interface CommandOptions {
   publicUrl?: string;
   /** @deprecated use publicUrl */
   baseUrl?: string;
+  /**
+   * Build the HTTP app in `start()` without binding a port; read it back with
+   * `getHttpApp()`. For serverless or embedding hosts. Not a CLI flag.
+   */
+  noListen?: boolean;
 
   [key: string]: unknown;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -218,6 +218,40 @@ type PkceEntry = {
   serverCodeVerifier: string;
   createdAt: number;
 };
+
+/**
+ * Stateless two-leg PKCE.
+ *
+ * The in-memory `pkceStore` ties `/authorize` and `/token` to one process: a
+ * second replica, a serverless function, or a restart between the two legs
+ * answers `/token` with no mapping, the client's verifier goes upstream against
+ * the server's challenge, and Entra fails the exchange (AADSTS501481). With
+ * `MS365_MCP_PKCE_SECRET` set, the server-side code_verifier is instead derived
+ * from the client's public code_challenge and the secret, so any process that
+ * holds the secret recomputes it at `/token` and nothing is stored. An attacker
+ * who sees the challenge in the redirect cannot reproduce the verifier without
+ * the secret, which is the guarantee the store gave.
+ */
+export const PKCE_SECRET_MIN_LENGTH = 32;
+
+export function deriveServerCodeVerifier(secret: string, clientCodeChallenge: string): string {
+  return crypto.createHmac('sha256', secret).update(clientCodeChallenge).digest('base64url');
+}
+
+export function statelessPkceSecret(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const secret = env.MS365_MCP_PKCE_SECRET;
+  if (secret === undefined || secret === '') {
+    return undefined;
+  }
+  if (secret.length < PKCE_SECRET_MIN_LENGTH) {
+    throw new Error(
+      `MS365_MCP_PKCE_SECRET must be at least ${PKCE_SECRET_MIN_LENGTH} characters; ` +
+        'a short secret makes the derived PKCE verifier guessable.'
+    );
+  }
+  return secret;
+}
+
 class MicrosoftGraphServer {
   private authManager: AuthManager;
   private options: CommandOptions;
@@ -241,6 +275,17 @@ class MicrosoftGraphServer {
 
   // Two-leg PKCE: stores client's code_challenge and server's code_verifier, keyed by OAuth state
   private pkceStore: Map<string, PkceEntry> = new Map();
+
+  /**
+   * The Express app `start()` built when `options.noListen` is set: the caller
+   * (a serverless function, an embedding host) mounts it instead of this
+   * process binding a port. `null` until `start()` has run in that mode.
+   */
+  private httpApp: express.Express | null = null;
+
+  getHttpApp(): express.Express | null {
+    return this.httpApp;
+  }
 
   constructor(authManager: AuthManager, options: CommandOptions = {}) {
     this.authManager = authManager;
@@ -710,7 +755,18 @@ class MicrosoftGraphServer {
 
         // Two-leg PKCE: if the client sent a code_challenge, store it and generate
         // a separate PKCE pair for the server↔Microsoft leg
-        if (clientCodeChallenge && state) {
+        const pkceSecret = statelessPkceSecret();
+        if (clientCodeChallenge && pkceSecret) {
+          // Stateless variant: nothing is stored; /token re-derives the verifier.
+          const serverCodeVerifier = deriveServerCodeVerifier(pkceSecret, clientCodeChallenge);
+          const serverCodeChallenge = crypto
+            .createHash('sha256')
+            .update(serverCodeVerifier)
+            .digest('base64url');
+          microsoftAuthUrl.searchParams.set('code_challenge', serverCodeChallenge);
+          microsoftAuthUrl.searchParams.set('code_challenge_method', 'S256');
+          logger.info('Two-leg PKCE (stateless): derived server challenge from client challenge');
+        } else if (clientCodeChallenge && state) {
           const serverCodeVerifier = crypto.randomBytes(32).toString('base64url');
           const serverCodeChallenge = crypto
             .createHash('sha256')
@@ -839,6 +895,7 @@ class MicrosoftGraphServer {
             // code_verifier against all stored challenges and use the server's verifier
             let matchedPkceState: string | undefined;
             let matchedPkceEntry: PkceEntry | undefined;
+            let derivedServerVerifier: string | undefined;
 
             if (body.code_verifier) {
               // Look through pkceStore for a matching client code_challenge
@@ -848,12 +905,24 @@ class MicrosoftGraphServer {
                 .update(clientVerifier)
                 .digest('base64url');
 
+              const pkceSecret = statelessPkceSecret();
+              if (pkceSecret) {
+                // Stateless two-leg PKCE: /authorize stored nothing; recompute.
+                derivedServerVerifier = deriveServerCodeVerifier(
+                  pkceSecret,
+                  clientChallengeComputed
+                );
+                logger.info(
+                  'Two-leg PKCE (stateless): derived server verifier from client verifier'
+                );
+              }
+
               // Age deliberately plays no part here. If a mapping really is
               // stale so is the code arriving with it, and Entra answers that
               // with AADSTS70008, which is the authority giving the right
               // answer. Evicting on age instead would take the mapping away
               // from a slow but perfectly valid sign-in.
-              for (const [state, pkceData] of this.pkceStore) {
+              for (const [state, pkceData] of derivedServerVerifier ? [] : this.pkceStore) {
                 if (pkceData.clientCodeChallenge === clientChallengeComputed) {
                   // Client's code_verifier matches stored code_challenge — two-leg PKCE
                   matchedPkceState = state;
@@ -872,7 +941,9 @@ class MicrosoftGraphServer {
               clientId,
               clientSecret,
               tenantId,
-              matchedPkceEntry?.serverCodeVerifier || (body.code_verifier as string | undefined),
+              derivedServerVerifier ||
+                matchedPkceEntry?.serverCodeVerifier ||
+                (body.code_verifier as string | undefined),
               this.secrets!.cloudType
             );
 
@@ -1129,6 +1200,18 @@ class MicrosoftGraphServer {
       app.get('/', (req, res) => {
         res.send('Microsoft 365 MCP Server is running');
       });
+
+      if (this.options.noListen) {
+        // Serverless / embedded host: hand the finished app back instead of
+        // binding. Everything above -- auth routes, /mcp, CORS, limiters -- is
+        // wired; only the listener is skipped. The attachment listener is not
+        // supported in this mode (there is no second port to bind).
+        this.httpApp = app;
+        logger.info(
+          `HTTP app built without a listener (noListen); public URL: ${publicBase ?? 'unset'}`
+        );
+        return;
+      }
 
       // Every line below is written from the address the kernel actually
       // handed back, not from the option that asked for it. On this pair of

--- a/test/stateless-pkce.test.ts
+++ b/test/stateless-pkce.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Stateless two-leg PKCE (MS365_MCP_PKCE_SECRET).
+ *
+ * The in-memory pkceStore ties /authorize and /token to one process. A second
+ * replica or a serverless function answering /token has no mapping, forwards
+ * the client's verifier upstream against the server's challenge, and Entra
+ * rejects the exchange. With the secret set the server verifier is derived
+ * from the client's challenge, so ANY instance can complete the exchange.
+ *
+ * The first test drives /authorize on one server instance and /token on a
+ * fresh one, which is exactly the multi-instance case.
+ */
+import crypto from 'crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import MicrosoftGraphServer, {
+  PKCE_SECRET_MIN_LENGTH,
+  deriveServerCodeVerifier,
+  statelessPkceSecret,
+} from '../src/server.js';
+import type AuthManager from '../src/auth.js';
+import { clearSecretsCache } from '../src/secrets.js';
+
+const expressMocks = vi.hoisted(() => {
+  type Handler = (req: Record<string, unknown>, res: Record<string, unknown>) => unknown;
+  const routes = new Map<string, Handler>();
+  const app: Record<string, ReturnType<typeof vi.fn>> = {};
+  app.set = vi.fn(() => app);
+  app.use = vi.fn(() => app);
+  app.get = vi.fn((path: string, handler: Handler) => {
+    routes.set(`GET ${path}`, handler);
+    return app;
+  });
+  app.post = vi.fn((path: string, handler: Handler) => {
+    routes.set(`POST ${path}`, handler);
+    return app;
+  });
+  app.listen = vi.fn((...args: unknown[]) => {
+    const callback = args.find((arg): arg is () => void => typeof arg === 'function');
+    const port = typeof args[0] === 'number' ? args[0] : 0;
+    const address = typeof args[1] === 'string' ? args[1] : '::';
+    callback?.();
+    return {
+      close: vi.fn(),
+      closeIdleConnections: vi.fn(),
+      once: vi.fn(),
+      address: vi.fn(() => ({ address, family: address.includes(':') ? 'IPv6' : 'IPv4', port })),
+    };
+  });
+  const express = Object.assign(
+    vi.fn(() => app),
+    {
+      json: vi.fn(() => (_req: unknown, _res: unknown, next: () => void) => next()),
+      urlencoded: vi.fn(() => (_req: unknown, _res: unknown, next: () => void) => next()),
+    }
+  );
+  return { app, express, routes };
+});
+
+vi.mock('express', () => ({ default: expressMocks.express }));
+vi.mock('@modelcontextprotocol/sdk/server/auth/router.js', () => ({
+  mcpAuthRouter: vi.fn(() => (_req: unknown, _res: unknown, next?: () => void) => next?.()),
+}));
+vi.mock('../src/graph-tools.js', () => ({
+  registerDiscoveryTools: vi.fn(),
+  registerGraphTools: vi.fn(),
+}));
+vi.mock('../src/oauth-provider.js', () => ({ MicrosoftOAuthProvider: vi.fn() }));
+vi.mock('../src/logger.js', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  enableConsoleLogging: vi.fn(),
+}));
+
+const SECRET = 'stateless-pkce-test-secret-with-at-least-32-characters';
+const TOKEN_RESPONSE = { access_token: 'at', token_type: 'Bearer', expires_in: 3600 };
+
+function mockAuthManager(): AuthManager {
+  return {
+    isOAuthModeEnabled: () => false,
+    isMultiAccount: vi.fn().mockResolvedValue(false),
+    listAccounts: vi.fn().mockResolvedValue([]),
+  } as unknown as AuthManager;
+}
+
+function mockRequest(path: string, body?: Record<string, unknown>) {
+  return {
+    secure: false,
+    protocol: 'http',
+    url: path,
+    body,
+    method: body ? 'POST' : 'GET',
+    get: vi.fn((header: string) =>
+      header.toLowerCase() === 'host' ? 'localhost:3000' : undefined
+    ),
+  };
+}
+
+function mockResponse() {
+  const res = { json: vi.fn(), redirect: vi.fn(), status: vi.fn() };
+  res.status.mockReturnValue(res);
+  return res;
+}
+
+function challengeFor(verifier: string): string {
+  return crypto.createHash('sha256').update(verifier).digest('base64url');
+}
+
+describe('deriveServerCodeVerifier / statelessPkceSecret', () => {
+  it('is deterministic, secret-dependent and a valid PKCE verifier', () => {
+    const a = deriveServerCodeVerifier(SECRET, 'challenge-1');
+    expect(deriveServerCodeVerifier(SECRET, 'challenge-1')).toBe(a);
+    expect(deriveServerCodeVerifier(SECRET + 'x', 'challenge-1')).not.toBe(a);
+    expect(deriveServerCodeVerifier(SECRET, 'challenge-2')).not.toBe(a);
+    // RFC 7636: 43..128 chars of [A-Za-z0-9-._~]; base64url of a 32-byte HMAC is 43.
+    expect(a).toMatch(/^[A-Za-z0-9\-._~]{43,128}$/);
+  });
+
+  it('is off when unset or empty, and refuses a short secret', () => {
+    expect(statelessPkceSecret({})).toBeUndefined();
+    expect(statelessPkceSecret({ MS365_MCP_PKCE_SECRET: '' })).toBeUndefined();
+    expect(() => statelessPkceSecret({ MS365_MCP_PKCE_SECRET: 'short' })).toThrow(
+      new RegExp(`${PKCE_SECRET_MIN_LENGTH}`)
+    );
+    expect(statelessPkceSecret({ MS365_MCP_PKCE_SECRET: SECRET })).toBe(SECRET);
+  });
+});
+
+describe('two-leg PKCE across two server instances', () => {
+  const clientVerifier = 'client-side-code-verifier-for-the-mcp-client';
+  const redirectUri = 'http://localhost:3118/callback';
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    expressMocks.routes.clear();
+    process.env.MS365_MCP_CLIENT_ID = 'test-client-id';
+    process.env.MS365_MCP_TENANT_ID = 'test-tenant';
+    delete process.env.MS365_MCP_CLIENT_SECRET;
+    delete process.env.MS365_MCP_KEYVAULT_URL;
+    delete process.env.MS365_MCP_PKCE_SECRET;
+    clearSecretsCache();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    delete process.env.MS365_MCP_CLIENT_ID;
+    delete process.env.MS365_MCP_TENANT_ID;
+    delete process.env.MS365_MCP_PKCE_SECRET;
+    clearSecretsCache();
+    vi.restoreAllMocks();
+  });
+
+  /** Each call is a fresh process as far as the pkceStore is concerned. */
+  async function freshInstance(): Promise<void> {
+    expressMocks.routes.clear();
+    const server = new MicrosoftGraphServer(mockAuthManager(), { http: true });
+    await server.initialize('test');
+    await server.start();
+  }
+
+  async function authorize(state: string): Promise<string> {
+    const handler = expressMocks.routes.get('GET /authorize')!;
+    const res = mockResponse();
+    await handler(
+      mockRequest(
+        `/authorize?response_type=code&redirect_uri=${encodeURIComponent(redirectUri)}` +
+          `&state=${state}&code_challenge=${challengeFor(clientVerifier)}&code_challenge_method=S256`
+      ),
+      res
+    );
+    return new URL(res.redirect.mock.calls[0][0] as string).searchParams.get('code_challenge')!;
+  }
+
+  async function postToken(): Promise<URLSearchParams> {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(TOKEN_RESPONSE),
+      json: async () => TOKEN_RESPONSE,
+    } as Response);
+    global.fetch = fetchMock;
+    const handler = expressMocks.routes.get('POST /token')!;
+    const res = mockResponse();
+    await handler(
+      mockRequest('/token', {
+        grant_type: 'authorization_code',
+        code: 'the-code',
+        redirect_uri: redirectUri,
+        code_verifier: clientVerifier,
+      }),
+      res
+    );
+    expect(res.json).toHaveBeenCalledWith(TOKEN_RESPONSE);
+    return fetchMock.mock.calls[0][1].body as URLSearchParams;
+  }
+
+  it('with MS365_MCP_PKCE_SECRET, /token on a fresh instance sends the server verifier', async () => {
+    process.env.MS365_MCP_PKCE_SECRET = SECRET;
+
+    await freshInstance();
+    const serverChallenge = await authorize('state-a');
+    expect(serverChallenge).not.toBe(challengeFor(clientVerifier));
+    expect(serverChallenge).toBe(
+      challengeFor(deriveServerCodeVerifier(SECRET, challengeFor(clientVerifier)))
+    );
+
+    await freshInstance(); // a different replica / cold function answers /token
+    const sent = await postToken();
+    expect(challengeFor(sent.get('code_verifier')!)).toBe(serverChallenge);
+  });
+
+  it('without the secret, a fresh instance has no mapping and forwards the client verifier', async () => {
+    // Documents the failure the secret fixes: Entra would reject this exchange
+    // because the server registered its own challenge at /authorize.
+    await freshInstance();
+    const serverChallenge = await authorize('state-b');
+    expect(serverChallenge).not.toBe(challengeFor(clientVerifier));
+
+    await freshInstance();
+    const sent = await postToken();
+    expect(sent.get('code_verifier')).toBe(clientVerifier);
+    expect(challengeFor(sent.get('code_verifier')!)).not.toBe(serverChallenge);
+  });
+});


### PR DESCRIPTION
## Problem

The two-leg PKCE mapping (`pkceStore`) is process memory keyed by OAuth `state`, so `/authorize` and `/token` must hit the same process. `docs/deployment.md` recommends `--max-replicas 3` on Container Apps, and any serverless host has the same shape: when `/token` lands on another instance there is no mapping, the client's verifier is forwarded upstream against the server's challenge, and Entra answers `AADSTS501481`. Sign-in then fails intermittently, which is the worst kind of failure to debug.

## Change

Opt-in, no behaviour change without it. With `MS365_MCP_PKCE_SECRET` (32+ chars) set:

- `/authorize` derives the server-side verifier as `HMAC-SHA256(secret, client code_challenge)`, sends `sha256(verifier)` upstream, stores nothing.
- `/token` recomputes it from `sha256(client code_verifier)` and uses it for the upstream exchange.

An attacker who sees the challenge in the redirect cannot reproduce the verifier without the secret — the same guarantee the store gave. A secret shorter than 32 chars is refused at startup rather than silently weakening the derivation. Without the env var the existing store path is untouched.

Also `options.noListen` (not a CLI flag): `start()` builds the Express app and exposes it via `getHttpApp()` instead of binding a port, so an embedding host can mount it. One paragraph in `docs/deployment.md` for both.

## Verification

- `test/stateless-pkce.test.ts`: derivation is deterministic/secret-dependent/RFC 7636-shaped; secret length enforced; and the multi-instance case — `/authorize` on one `MicrosoftGraphServer`, `/token` on a *fresh* one — sends the server verifier with the secret and the client verifier without it (the documented failure).
- In production on Vercel (one function, many instances): dynamic client registration → `/authorize` → real Microsoft sign-in → `/token` → bearer → Graph tool calls, all succeeding. The same deployment without the secret cannot complete sign-in reliably.
- `npm run typecheck`, `lint`, `format:check` clean; OAuth-related suites pass. `test/attachment-split-listener.test.ts` fails identically on `main` here (port binding on this machine), unrelated.

Independent of #671 (Sites.Selected on drive tools); either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)