### PR TITLE
fix(tools): tighten skiptoken cursor handling and shorten its description

### DIFF
--- a/src/__tests__/graph-tools.test.ts
+++ b/src/__tests__/graph-tools.test.ts
@@ -1292,14 +1292,20 @@ describe('graph-tools', () => {
       else process.env.MS365_MCP_ALLOW_PAGINATION = prevAllowPagination;
     });
 
-    const callWith = async (args: Record<string, unknown>) => {
+    const callForResult = async (args: Record<string, unknown>) => {
       mockEndpoints.push(makeEndpoint());
       mockEndpointsJson = [makeConfig()];
       const graphClient = createMockGraphClient();
       const server = createMockServer();
       const { registerGraphTools } = await loadModule();
       registerGraphTools(server as any, graphClient as any);
-      await server.tools.get('test-tool')!.handler(args);
+      const result = await server.tools.get('test-tool')!.handler(args);
+      return { result, graphClient };
+    };
+
+    /** The request path the tool sent to Graph. */
+    const callWith = async (args: Record<string, unknown>) => {
+      const { graphClient } = await callForResult(args);
       return graphClient.graphRequest.mock.calls[0][0] as string;
     };
 
@@ -1408,9 +1414,96 @@ describe('graph-tools', () => {
       expect(path).toContain('$skiptoken=abc123');
     });
 
-    it('omits $skiptoken entirely when blank', async () => {
-      const path = await callWith({ skiptoken: '   ' });
+    it.each(['', '   '])('omits $skiptoken entirely when blank (%j)', async (blank) => {
+      const path = await callWith({ skiptoken: blank });
       expect(path).not.toContain('skiptoken');
+    });
+
+    it('sends $skip when the nextLink pages with $skip', async () => {
+      // Outlook mail and calendar nextLinks carry $skip, not $skiptoken
+      const path = await callWith({
+        top: 10,
+        skiptoken: 'https://graph.microsoft.com/v1.0/me/messages?$top=10&$skip=10',
+      });
+      expect(path).toContain('$skip=10');
+      expect(path).not.toContain('skiptoken');
+    });
+
+    it('ignores a cursor-looking value inside another query param', async () => {
+      const path = await callWith({
+        skiptoken:
+          "https://graph.microsoft.com/v1.0/me/messages?$filter=subject eq '%24skip=100'&$skip=10",
+      });
+      expect(path).toContain('$skip=10');
+      expect(path).not.toContain('100');
+    });
+
+    it('refuses a link with no cursor to page with', async () => {
+      const { result, graphClient } = await callForResult({
+        skiptoken:
+          'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta()?$deltatoken=abc',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(JSON.parse(result.content[0].text).error).toBe('invalid_skiptoken');
+      expect(graphClient.graphRequest).not.toHaveBeenCalled();
+    });
+
+    it('refuses a delta token= link without calling it a deltaLink', async () => {
+      // get-drive-delta and get-sharepoint-sites-delta page with token=, so the refusal must
+      // not tell the model to pass the @odata.nextLink it just passed
+      const { result, graphClient } = await callForResult({
+        skiptoken: 'https://graph.microsoft.com/v1.0/me/drive/delta(token=1230919asd190410jlka)',
+      });
+
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toBe('invalid_skiptoken');
+      expect(payload.message).not.toContain('deltaLink');
+      expect(payload.message).toContain('fetchAllPages');
+      expect(graphClient.graphRequest).not.toHaveBeenCalled();
+    });
+
+    it('refuses a link whose $skiptoken carries no value', async () => {
+      const { result } = await callForResult({
+        skiptoken: 'https://graph.microsoft.com/v1.0/me/chats?$skiptoken=&$top=5',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(JSON.parse(result.content[0].text).error).toBe('invalid_skiptoken');
+    });
+
+    it('accepts an encoded %24skiptoken marker', async () => {
+      const path = await callWith({
+        skiptoken: 'https://graph.microsoft.com/v1.0/me/chats?%24top=5&%24skiptoken=tok123',
+      });
+      expect(path).toContain('$skiptoken=tok123');
+    });
+
+    it.each([
+      ['https://graph.microsoft.com/v1.0/me/messages?$top=10&$skip=0', '$skip=0'],
+      ['https://graph.microsoft.com/v1.0/me/messages?%24top=10&%24skip=10', '$skip=10'],
+    ])('reads the $skip cursor out of %s', async (link, expected) => {
+      const path = await callWith({ skiptoken: link });
+      expect(path).toContain(expected);
+    });
+
+    it('refuses a $skip cursor that is not a plain number', async () => {
+      const { result } = await callForResult({
+        skiptoken: 'https://graph.microsoft.com/v1.0/me/messages?$skip=10junk',
+      });
+
+      expect(JSON.parse(result.content[0].text).error).toBe('invalid_skiptoken');
+    });
+
+    it('offers no fetchAllPages in the refusal when pagination is disabled', async () => {
+      process.env.MS365_MCP_ALLOW_PAGINATION = '0';
+      const { result } = await callForResult({
+        skiptoken: 'https://graph.microsoft.com/v1.0/me/drive/delta(token=1230919asd190410jlka)',
+      });
+
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.error).toBe('invalid_skiptoken');
+      expect(payload.message).not.toContain('fetchAllPages');
     });
 
     it('sends the cursor alongside the original query options', async () => {

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -69,7 +69,6 @@ import {
   getFetchAllPagesParamDescription,
   SKIPTOKEN_PARAM_DESCRIPTION,
   isSkiptokenApplicable,
-  normalizeSkiptoken,
 } from './lib/param-descriptions.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -373,6 +372,75 @@ function normalizeSearchQueryParam(
     logger.info(`Auto-corrected parameter '$search': normalized KQL quoting to ${normalized}`);
     queryParams['$search'] = normalized;
   }
+}
+
+/**
+ * `skiptoken` takes what a model copies out of a response: the whole @odata.nextLink, a
+ * `$skiptoken=...` fragment, or the bare token, percent-encoded or not. Outlook mail and
+ * calendar links page with $skip instead, so that value goes out as $skip
+ * (https://learn.microsoft.com/en-us/graph/query-parameters). A link carrying neither is
+ * refused: forwarding it hands Graph a garbage cursor, and dropping it would return the
+ * first page as though it were the next one. The drive and sites delta tools land there,
+ * since their nextLink pages with a token= value this param cannot resend.
+ */
+function normalizeSkiptokenQueryParam(
+  queryParams: Record<string, string>,
+  toolAlias: string
+): CallToolResult | undefined {
+  const raw = queryParams['$skiptoken'];
+  if (raw === undefined) return;
+  delete queryParams['$skiptoken'];
+
+  let token = raw.trim();
+  if (token === '') return;
+
+  const cursorlessLink = (): CallToolResult => {
+    logger.warn(`Refusing ${toolAlias}: 'skiptoken' has no $skiptoken or $skip to page with`);
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            error: 'invalid_skiptoken',
+            tool: toolAlias,
+            message:
+              'The value passed as skiptoken has no $skiptoken or $skip to page with. The drive and sites delta tools page with a token= link, which skiptoken cannot resend.' +
+              (paginationAllowed()
+                ? ' Remove skiptoken and retry with fetchAllPages set to true to follow the link, or remove it for the first page.'
+                : ' Remove skiptoken and retry for the first page.'),
+          }),
+        },
+      ],
+      isError: true,
+    };
+  };
+
+  // Anchored on the start or a query separator, so a cursor-looking value inside another
+  // param (a $filter compared against the text "$skip=100", say) cannot be read as the cursor
+  const marker = token.match(/(?:^|[?&])(?:\$|%24)skiptoken=/i);
+  if (marker?.index !== undefined) {
+    // A nextLink can carry params after the cursor; keep only this one's value
+    token = token.slice(marker.index + marker[0].length).split('&')[0];
+    // A link that names the cursor but carries no value is not a first-page call
+    if (token === '') return cursorlessLink();
+  } else if (/:\/\/|\?|^(?:\$|%24)\w+=/.test(token)) {
+    const skip = token.match(/(?:^|[?&])(?:\$|%24)skip=(\d+)(?=&|$)/i)?.[1];
+    if (skip === undefined) return cursorlessLink();
+    logger.info(
+      `Auto-corrected parameter 'skiptoken': link pages with $skip, sending $skip=${skip}`
+    );
+    queryParams['$skip'] = skip;
+    return;
+  }
+
+  if (token.includes('%')) {
+    try {
+      token = decodeURIComponent(token);
+    } catch {
+      logger.warn('skiptoken looks percent-encoded but could not be decoded; sending as-is');
+    }
+  }
+  queryParams['$skiptoken'] = token;
 }
 
 const DEFAULT_MAX_ITEMS = 10_000;
@@ -2022,12 +2090,8 @@ async function executeGraphTool(
       delete queryParams['$top'];
     }
 
-    // Manual cursor paging, for endpoints where $skip is not allowed
-    if (queryParams['$skiptoken']) {
-      const cursor = normalizeSkiptoken(queryParams['$skiptoken']);
-      if (cursor) queryParams['$skiptoken'] = cursor;
-      else delete queryParams['$skiptoken'];
-    }
+    const skiptokenError = normalizeSkiptokenQueryParam(queryParams, tool.alias);
+    if (skiptokenError) return skiptokenError;
 
     clampTopQueryParam(queryParams);
     const searchError = normalizeSearchQueryParam(queryParams, tool.path, tool.alias);

--- a/src/lib/param-descriptions.ts
+++ b/src/lib/param-descriptions.ts
@@ -97,19 +97,17 @@ export const TOP_PARAM_DESCRIPTION =
 
 export const SKIP_PARAM_DESCRIPTION = 'Items to skip for pagination. Not supported with $search.';
 
+// Reaches ~100 tools, like $search, so it stays short. It asks for the whole link because
+// normalizeSkiptokenQueryParam in graph-tools.ts reads both $skiptoken and $skip out of it.
 export const SKIPTOKEN_PARAM_DESCRIPTION =
-  'Opaque cursor for the next page, taken from the previous response. Copy the ' +
-  '$skiptoken value out of @odata.nextLink (or paste the whole nextLink URL — the ' +
-  'token is extracted from it) and resend it with the SAME $filter/$select/$expand/' +
-  '$top as the first call. Use this to walk pages one at a time instead of ' +
-  'fetchAllPages. Omit it for the first page.';
+  'Next page: the @odata.nextLink from the previous response. Keep the other arguments the same.';
 
 // Query options that only exist on a collection, which are used to determine if
-// if skiptoken pagination is allowed
+// skiptoken pagination is allowed
 const COLLECTION_QUERY_PARAMS = new Set(['top', 'filter', 'orderby', 'count']);
 
 // Guess whether a tool returns a collection and can take a `skiptoken`, given the
-// parameter names in its schema .
+// parameter names in its schema.
 export function isSkiptokenApplicable(
   tool: { method: string },
   paramNames: Iterable<string>
@@ -119,30 +117,6 @@ export function isSkiptokenApplicable(
     if (COLLECTION_QUERY_PARAMS.has(name.replace(/^\$/, '').toLowerCase())) return true;
   }
   return false;
-}
-
-// Accepts every shape a model plausibly sends a cursor in and returns the raw token:
-// a whole nextLink URL, a bare `$skiptoken=...` fragment, an already-percent-encoded
-// token, or the decoded token itself.
-export function normalizeSkiptoken(raw: string): string {
-  let token = raw.trim();
-
-  const marker = token.match(/(?:\$|%24)skiptoken=/i);
-  if (marker?.index !== undefined) {
-    token = token.slice(marker.index + marker[0].length);
-    // A nextLink can carry params after the cursor; keep only this one's value.
-    token = token.split('&')[0];
-  }
-
-  if (token.includes('%')) {
-    try {
-      token = decodeURIComponent(token);
-    } catch {
-      logger.warn('skiptoken looks percent-encoded but could not be decoded; sending as-is');
-    }
-  }
-
-  return token;
 }
 
 export const COUNT_PARAM_DESCRIPTION =


### PR DESCRIPTION
Follow-up to #668.

- A pasted `@odata.nextLink` that pages with `$skip` (Outlook mail and calendar) now sends `$skip`, instead of forwarding the whole URL as a cursor.
- A link carrying no cursor, such as a drive or sites delta `token=` link, is refused with a clear error instead of a garbage request.
- `skiptoken: ""` no longer goes out as an empty `$skiptoken=`.
- The cursor is matched only at the start of the value or after `?` or `&`, so a cursor-looking value inside another query param cannot be read as the cursor.
- The parameter description is one sentence now. It rides on ~101 tools, where the old text cost about 40 KB of tool schema.
